### PR TITLE
fix: externalize `jiti` to prevent hardcoded paths in build

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -1,5 +1,5 @@
 import { defineBuildConfig } from 'unbuild'
 
 export default defineBuildConfig({
-  externals: ['consola'],
+  externals: ['consola', 'jiti'],
 })


### PR DESCRIPTION
## Problem

Module installation fails because the build includes hardcoded absolute paths from the build machine:

```
[1:40:55 PM]  ERROR  Error while importing module @onmax/nuxt-better-auth: Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/maxi/nuxt/better-auth/node_modules/.pnpm/jiti@2.6.1/node_modules/jiti/lib/jiti.mjs' imported from /Users/username/Projects/nuxt-app/node_modules/.pnpm/jiti@2.6.1/node_modules/jiti/lib/jiti.mjs

    at loadNuxtModuleInstance (node_modules/.pnpm/@nuxt+kit@4.2.2_magicast@0.5.1/node_modules/@nuxt/kit/dist/index.mjs:761:15)
    at async installModules (node_modules/.pnpm/@nuxt+kit@4.2.2_magicast@0.5.1/node_modules/@nuxt/kit/dist/index.mjs:580:17)
    at async initNuxt (node_modules/.pnpm/nuxt@4.2.2_@electric-sql+pglite@0.3.14_@parcel+watcher@2.5.1_@types+node@25.0.3_@vercel_692e7f05af8731f155b06eb4efd8df5f/node_modules/nuxt/dist/index.mjs:5387:3)
    at async loadNuxt (node_modules/.pnpm/nuxt@4.2.2_@electric-sql+pglite@0.3.14_@parcel+watcher@2.5.1_@types+node@25.0.3_@vercel_692e7f05af8731f155b06eb4efd8df5f/node_modules/nuxt/dist/index.mjs:5589:5)
    at async loadNuxt (node_modules/.pnpm/@nuxt+kit@4.2.2_magicast@0.5.1/node_modules/@nuxt/kit/dist/index.mjs:1012:16)
    at async Object.run (node_modules/.pnpm/@nuxt+cli@3.31.3_cac@6.7.14_magicast@0.5.1/node_modules/@nuxt/cli/dist/prepare-CUaf6Joj.mjs:28:16)
    at async runCommand (node_modules/.pnpm/citty@0.1.6/node_modules/citty/dist/index.mjs:316:16)
    at async runCommand (node_modules/.pnpm/citty@0.1.6/node_modules/citty/dist/index.mjs:307:11)
    at async runMain (node_modules/.pnpm/citty@0.1.6/node_modules/citty/dist/index.mjs:445:7) 

```

## Solution

Add `jiti` to build externals so it's not bundled and uses the version from user's `node_modules`, preventing hardcoded paths in the distributed package.

## Changes

- `build.config.ts`: Added `jiti` to `externals` array