### PR TITLE
fix(auth): correctly merge user config and allow database override

### DIFF
--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -9,7 +9,7 @@ export interface ClientAuthContext {
   siteUrl: string
 }
 
-type ServerAuthConfig = Omit<BetterAuthOptions, 'database' | 'secret' | 'baseURL'>
+type ServerAuthConfig = Omit<BetterAuthOptions, 'secret' | 'baseURL'>
 type ClientAuthConfig = Omit<ClientOptions, 'baseURL'> & { baseURL?: string }
 
 export type ServerAuthConfigFn = (ctx: ServerAuthContext) => ServerAuthConfig

--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -4,6 +4,7 @@ import { createSecondaryStorage } from '#auth/secondary-storage'
 import createServerAuth from '#auth/server'
 import { betterAuth } from 'better-auth'
 import { consola } from 'consola'
+import { defu } from 'defu'
 import { getRequestURL } from 'h3'
 import { useRuntimeConfig } from 'nitropack/runtime'
 
@@ -36,13 +37,14 @@ export async function serverAuth(event: H3Event): Promise<AuthInstance> {
   const database = createDatabase()
   const userConfig = createServerAuth({ runtimeConfig, db })
 
-  event.context._betterAuth = betterAuth({
-    ...userConfig,
-    ...(database && { database }),
+  const authOptions = defu(userConfig, {
+    database,
     secondaryStorage: createSecondaryStorage(),
     secret: runtimeConfig.betterAuthSecret,
     baseURL: getBaseURL(event, runtimeConfig.public.siteUrl as string | undefined),
   })
+
+  event.context._betterAuth = betterAuth(authOptions)
 
   return event.context._betterAuth
 }


### PR DESCRIPTION
## Description

Fixes an issue where user-defined database configuration was being overridden by module defaults.

## Changes

- **Core Logic:** Switched to `defu` for configuration merging. User settings in `server/auth.config.ts` now correctly take precedence over defaults, allowing custom database adapters and other overrides.
- **Types:** Updated `ServerAuthConfig` to allow the `database` property, resolving TypeScript errors when customizing the adapter.

## Impact

- Users can now properly customize the Better Auth database adapter (e.g., enable `usePlural`) without their settings being ignored.