### PR TITLE
feat(schema): support default function for field attributes

### DIFF
--- a/src/schema-generator.ts
+++ b/src/schema-generator.ts
@@ -1,7 +1,7 @@
 import type { BetterAuthOptions } from 'better-auth'
 import { consola } from 'consola'
 
-interface FieldAttribute { type: string | string[], required?: boolean, unique?: boolean, defaultValue?: unknown, references?: { model: string, field: string, onDelete?: string }, index?: boolean }
+interface FieldAttribute { type: string | string[], required?: boolean, unique?: boolean, defaultValue?: unknown, onUpdate?: (() => unknown), references?: { model: string, field: string, onDelete?: string }, index?: boolean }
 interface TableSchema { fields: Record<string, FieldAttribute>, modelName?: string }
 
 export interface SchemaOptions { usePlural?: boolean, useUuid?: boolean }
@@ -89,6 +89,9 @@ export function generateField(fieldName: string, field: FieldAttribute, dialect:
     if (field.required)
       fieldDef += '.notNull()'
   }
+
+  if (typeof field.onUpdate === 'function' && field.type === 'date')
+    fieldDef += `.$onUpdate(${field.onUpdate})`
 
   if (field.references) {
     const refTable = field.references.model

--- a/test/schema-generator.test.ts
+++ b/test/schema-generator.test.ts
@@ -71,4 +71,14 @@ describe('generateDrizzleSchema', () => {
     expect(result).toContain('.$defaultFn(')
     expect(result).not.toContain('\'() =>') // no quotes around function
   })
+
+  it('generates $onUpdate for date fields with onUpdate function', () => {
+    const field = {
+      type: 'date',
+      required: true,
+      onUpdate: () => new Date(),
+    }
+    const result = generateField('updatedAt', field, 'sqlite', {})
+    expect(result).toContain('.$onUpdate(')
+  })
 })


### PR DESCRIPTION
Modify schema generation to generate
`createdAt: timestamp('createdAt').$defaultFn(() => /* @__PURE__ */ new Date()).notNull(),`
instead of
`createdAt: timestamp('createdAt').default(() => /* @__PURE__ */ new Date()).notNull(),`
since `.default(() => {/*code here*/})` is not supported by drizzle