### PR TITLE
fix: support usePlural in schema generation

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -213,7 +213,7 @@ declare module 'nitropack/types' {
     })
 
     if (hasHubDb) {
-      await setupBetterAuthSchema(nuxt, serverConfigPath)
+      await setupBetterAuthSchema(nuxt, serverConfigPath, options)
     }
 
     // Only enable devtools in development - explicit production check
@@ -259,7 +259,7 @@ declare module 'nitropack/types' {
   },
 })
 
-async function setupBetterAuthSchema(nuxt: Nuxt, serverConfigPath: string) {
+async function setupBetterAuthSchema(nuxt: Nuxt, serverConfigPath: string, options: BetterAuthModuleOptions) {
   const hub = (nuxt.options as { hub?: NuxtHubOptions }).hub
   const dialect = typeof hub?.db === 'string' ? hub.db : (typeof hub?.db === 'object' ? hub.db.dialect : undefined)
   if (!dialect || !['sqlite', 'postgresql', 'mysql'].includes(dialect)) {
@@ -281,7 +281,7 @@ async function setupBetterAuthSchema(nuxt: Nuxt, serverConfigPath: string) {
     const { getAuthTables } = await import('better-auth/db')
     const tables = getAuthTables({ plugins })
 
-    const schemaCode = generateDrizzleSchema(tables as unknown as Record<string, { fields: Record<string, unknown>, modelName?: string }>, dialect as 'sqlite' | 'postgresql' | 'mysql')
+    const schemaCode = generateDrizzleSchema(tables as unknown as Record<string, { fields: Record<string, unknown>, modelName?: string }>, dialect as 'sqlite' | 'postgresql' | 'mysql', options.schema)
 
     const schemaDir = join(nuxt.options.buildDir, 'better-auth')
     const schemaPath = join(schemaDir, `schema.${dialect}.ts`)

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -27,6 +27,11 @@ export interface BetterAuthModuleOptions {
   }
   /** Enable KV secondary storage for sessions. Requires hub.kv: true */
   secondaryStorage?: boolean
+  /** Schema generation options. Must match drizzleAdapter config. */
+  schema?: {
+    /** Plural table names: user → users. Default: false */
+    usePlural?: boolean
+  }
 }
 
 // Runtime config type for public.auth

--- a/test/schema-generator.test.ts
+++ b/test/schema-generator.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { generateDrizzleSchema } from '../src/schema-generator'
+
+const mockTables = {
+  user: { fields: { name: { type: 'string', required: true } } },
+  session: { fields: { token: { type: 'string', required: true } } },
+}
+
+describe('generateDrizzleSchema', () => {
+  it('singular table names by default', () => {
+    const schema = generateDrizzleSchema(mockTables, 'sqlite')
+    expect(schema).toContain('sqliteTable(\'user\'')
+    expect(schema).toContain('sqliteTable(\'session\'')
+  })
+
+  it('plural table names with usePlural', () => {
+    const schema = generateDrizzleSchema(mockTables, 'sqlite', { usePlural: true })
+    expect(schema).toContain('sqliteTable(\'users\'')
+    expect(schema).toContain('sqliteTable(\'sessions\'')
+  })
+
+  it('custom modelName takes precedence over usePlural', () => {
+    const tables = { user: { modelName: 'custom_user', fields: {} } }
+    const schema = generateDrizzleSchema(tables, 'sqlite', { usePlural: true })
+    expect(schema).toContain('sqliteTable(\'custom_user\'')
+  })
+})


### PR DESCRIPTION
## Summary
- Schema generator now respects `usePlural` option for table names
- Added `schema.usePlural` option to module config

## Usage
```ts
// nuxt.config.ts
export default defineNuxtConfig({
  auth: {
    schema: { usePlural: true }
  }
})
```

Closes #11