### PR TITLE
fix: load better-auth schema before nuxthub schema

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -305,7 +305,7 @@ async function setupBetterAuthSchema(nuxt: Nuxt, serverConfigPath: string) {
   nuxtWithHubHooks.hook('hub:db:schema:extend', ({ paths, dialect: hookDialect }) => {
     const schemaPath = join(nuxt.options.buildDir, 'better-auth', `schema.${hookDialect}.ts`)
     if (existsSync(schemaPath)) {
-      paths.push(schemaPath)
+      paths.unshift(schemaPath)
     }
   })
 }


### PR DESCRIPTION

## Problem
Better-auth schema was exported after custom schema, causing `user` table to be unavailable when referenced in `server/db/schema.ts`, resulting in "Cannot access 'user' before initialization" error.

```ts
import { pgTable, uuid } from 'drizzle-orm/pg-core'
import { user } from 'hub:db:schema'

export const todos = pgTable('todos', {
  id: uuid().primaryKey().defaultRandom(),
  userId: uuid().notNull().references(() => user.id),
})
```

```ts
export * from '/Users/.../server/db/schema.ts'
export * from '/Users/.../.nuxt/better-auth/schema.postgresql.ts'
```

```console
> pnpm nuxt db generate 
ERROR  ReferenceError: Cannot access 'user' before initialization                                                                 6:33:34 PM
    at Object.<anonymous> (/Users/.../.nuxt/hub/db/schema.mjs:89:34)
    ...
```

## Solution
- Export better-auth schema before custom schema in `.nuxt/hub/db/schema.entry.ts`
