### PR TITLE
fix: add missing useUserSession import

### DIFF
--- a/src/runtime/app/middleware/auth.global.ts
+++ b/src/runtime/app/middleware/auth.global.ts
@@ -1,5 +1,5 @@
 import type { AuthMeta, AuthMode, AuthRouteRules } from '../../types'
-import { createError, defineNuxtRouteMiddleware, getRouteRules, navigateTo, useNuxtApp, useRequestHeaders, useRuntimeConfig } from '#imports'
+import { createError, defineNuxtRouteMiddleware, getRouteRules, navigateTo, useNuxtApp, useRequestHeaders, useRuntimeConfig, useUserSession } from '#imports'
 import { matchesUser } from '../../utils/match-user'
 
 declare module '#app' {


### PR DESCRIPTION
Fixes #18

## Problem
`useUserSession()` called in middleware without explicit import. Auto-import works in dev but fails on Cloudflare Workers.

## Fix
Add `useUserSession` to `#imports` in `auth.global.ts:2`.