### PR TITLE
fix: add UseUserSessionReturn type for better .d.ts generation

### DIFF
--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -1,8 +1,23 @@
 import type { AppAuthClient, AuthSession, AuthUser } from '#nuxt-better-auth'
+import type { ComputedRef, Ref } from 'vue'
 import { createAppAuthClient } from '#auth/client'
 import { computed, nextTick, useRequestHeaders, useRequestURL, useRuntimeConfig, useState, watch } from '#imports'
 
 export interface SignOutOptions { onSuccess?: () => void | Promise<void> }
+
+export interface UseUserSessionReturn {
+  client: AppAuthClient | null
+  session: Ref<AuthSession | null>
+  user: Ref<AuthUser | null>
+  loggedIn: ComputedRef<boolean>
+  ready: ComputedRef<boolean>
+  signIn: NonNullable<AppAuthClient>['signIn']
+  signUp: NonNullable<AppAuthClient>['signUp']
+  signOut: (options?: SignOutOptions) => Promise<void>
+  waitForSession: () => Promise<void>
+  fetchSession: (options?: { headers?: HeadersInit, force?: boolean }) => Promise<void>
+  updateUser: (updates: Partial<AuthUser>) => void
+}
 
 // Singleton client instance to ensure consistent state across all useUserSession calls
 let _client: AppAuthClient | null = null
@@ -12,7 +27,7 @@ function getClient(baseURL: string): AppAuthClient {
   return _client
 }
 
-export function useUserSession() {
+export function useUserSession(): UseUserSessionReturn {
   const runtimeConfig = useRuntimeConfig()
   const requestURL = useRequestURL()
 
@@ -184,11 +199,10 @@ export function useUserSession() {
   async function signOut(options?: SignOutOptions) {
     if (!client)
       throw new Error('signOut can only be called on client-side')
-    const response = await client.signOut()
+    await client.signOut()
     clearSession()
     if (options?.onSuccess)
       await options.onSuccess()
-    return response
   }
 
   return {

--- a/src/runtime/types/augment.ts
+++ b/src/runtime/types/augment.ts
@@ -43,6 +43,6 @@ export interface UserSessionComposable {
   signUp: unknown
   fetchSession: (options?: { headers?: HeadersInit, force?: boolean }) => Promise<void>
   waitForSession: () => Promise<void>
-  signOut: (options?: { onSuccess?: () => void | Promise<void> }) => Promise<unknown>
+  signOut: (options?: { onSuccess?: () => void | Promise<void> }) => Promise<void>
   updateUser: (updates: Partial<AuthUser>) => void
 }


### PR DESCRIPTION
Fixes #21

## Problem

PR #20 tried to fix TypeScript type inference loss when consuming the package, but used invalid indexed access patterns (`FunctionType['parameterName']`).

## Solution

Add explicit return type interface without changing parameter types.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxt-better-auth-21](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-better-auth-21/nuxt-better-auth-21?startScript=typecheck) | ❌ TS errors |
| Fix | [nuxt-better-auth-21-fixed](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-better-auth-21/nuxt-better-auth-21-fixed?startScript=typecheck) | ✅ Passes |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxt-better-auth-21 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxt-better-auth-21
cd nuxt-better-auth-21 && pnpm i && pnpm typecheck
```

## Verify fix

```bash
git sparse-checkout add nuxt-better-auth-21-fixed
cd ../nuxt-better-auth-21-fixed && pnpm i && pnpm typecheck
```