### PR TITLE
fix: extend type definitions for NitroRouteConfig

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -205,14 +205,19 @@ declare module '#nuxt-better-auth' {
 
     addTypeTemplate({
       filename: 'types/nuxt-better-auth-nitro.d.ts',
-      getContents: () => `
-declare module 'nitropack/types' {
+      getContents: () => `declare module 'nitropack/types' {
   interface NitroRouteRules {
     auth?: import('${resolver.resolve('./runtime/types')}').AuthMeta
   }
 }
+declare module 'nitropack' {
+  interface NitroRouteConfig {
+    auth?: import('${resolver.resolve('./runtime/types')}').AuthMeta
+  }
+}
+export {}
 `,
-    })
+    }, { nuxt: true, nitro: true, node: true })
 
     // HMR
     nuxt.hook('builder:watch', async (_event, relativePath) => {


### PR DESCRIPTION
Based on Nuxt generation of `types/nitro-middleware.d.ts` I updated the nitro types for better-auth module.

Previous in `nuxt.config.ts`
```ts
{
...
 routeRules: {
    '/': {
      auth: {} // ts error: Object literal may only specify known properties, and 'auth' does not exist in type
    },
  },
...
}
```

after change, no error and autocompletion works