### PR TITLE
fix: extend NitroRouteConfig type augmentation

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -206,13 +206,25 @@ declare module '#nuxt-better-auth' {
     addTypeTemplate({
       filename: 'types/nuxt-better-auth-nitro.d.ts',
       getContents: () => `
+declare module 'nitropack' {
+  interface NitroRouteRules {
+    auth?: import('${resolver.resolve('./runtime/types')}').AuthMeta
+  }
+  interface NitroRouteConfig {
+    auth?: import('${resolver.resolve('./runtime/types')}').AuthMeta
+  }
+}
 declare module 'nitropack/types' {
   interface NitroRouteRules {
     auth?: import('${resolver.resolve('./runtime/types')}').AuthMeta
   }
+  interface NitroRouteConfig {
+    auth?: import('${resolver.resolve('./runtime/types')}').AuthMeta
+  }
 }
+export {}
 `,
-    })
+    }, { nuxt: true, nitro: true, node: true })
 
     // HMR
     nuxt.hook('builder:watch', async (_event, relativePath) => {


### PR DESCRIPTION
## Summary

Fixes TS error when using `auth` in `routeRules`:
```ts
routeRules: {
  '/': { auth: { only: 'user' } } // was: Object literal may only specify known properties
}
```

## Changes

Combined improvements from #24 and #27:
- Added `NitroRouteConfig` to both `nitropack` and `nitropack/types`
- Added `NitroRouteRules` to `nitropack` (was only in `nitropack/types`)
- Added `{ nuxt: true, nitro: true, node: true }` options (matches Nuxt's pattern)
- Added `export {}` for proper module augmentation

Closes #25

---

Thanks to @amaury-tobias (#24) and @adamkasper (#27) for their contributions! Both credited as co-authors.