### PR TITLE
fix: augment defineServerAuth with proper context types

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -190,6 +190,18 @@ declare module '#nuxt-better-auth' {
     ${hasHubDb ? `db: typeof import('hub:db')['db']` : ''}
   }
 }
+
+// Augment the config module to use the extended ServerAuthContext
+interface _AugmentedServerAuthContext {
+  runtimeConfig: RuntimeConfig
+  ${hasHubDb ? `db: typeof import('hub:db')['db']` : 'db: unknown'}
+}
+
+declare module '@onmax/nuxt-better-auth/config' {
+  import type { BetterAuthOptions } from 'better-auth'
+  type ServerAuthConfig = Omit<BetterAuthOptions, 'database' | 'secret' | 'baseURL'>
+  export function defineServerAuth<T extends ServerAuthConfig>(config: (ctx: _AugmentedServerAuthContext) => T): (ctx: _AugmentedServerAuthContext) => T
+}
 `,
     })
 


### PR DESCRIPTION
Fixes #29

## Problem

`ctx.runtimeConfig` and `ctx.db` in `defineServerAuth` have fallback types (`Record<string, unknown>` and `unknown`) instead of the augmented types.

## Context

- `defineServerAuth` in `config.ts` imports `ServerAuthContext` from `./types/augment`
- Generated types in `.nuxt/types/nuxt-better-auth-infer.d.ts` extend `ServerAuthContext` via `declare module '#nuxt-better-auth'`
- But the import path mismatch means declaration merging doesn't apply

**Credits:** Issue discovered by @amaury-tobias in #26

## Solution

Add module augmentation for `@onmax/nuxt-better-auth/config` in the generated types, re-declaring `defineServerAuth` with the proper `RuntimeConfig` and `db` types.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxt-better-auth-26](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-better-auth-26/nuxt-better-auth-26?startScript=typecheck) | ❌ Type error |
| Fix | [nuxt-better-auth-26-fixed](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-better-auth-26/nuxt-better-auth-26-fixed?startScript=typecheck) | ✅ Typecheck passes |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxt-better-auth-26 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxt-better-auth-26
cd nuxt-better-auth-26 && pnpm i
BETTER_AUTH_SECRET="12345678901234567890123456789012" pnpm prepare && pnpm typecheck
```

## Verify fix

```bash
git sparse-checkout add nuxt-better-auth-26-fixed
cd ../nuxt-better-auth-26-fixed && pnpm i
BETTER_AUTH_SECRET="12345678901234567890123456789012" pnpm prepare && pnpm typecheck
```