### PR TITLE
fix: auto-import defineServerAuth in server context

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -5,7 +5,7 @@ import type { AuthRouteRules } from './runtime/types'
 import type { CasingOption } from './schema-generator'
 import { existsSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
-import { addComponentsDir, addImportsDir, addPlugin, addServerHandler, addServerImportsDir, addServerScanDir, addTemplate, addTypeTemplate, createResolver, defineNuxtModule, extendPages, hasNuxtModule, updateTemplates } from '@nuxt/kit'
+import { addComponentsDir, addImportsDir, addPlugin, addServerHandler, addServerImports, addServerImportsDir, addServerScanDir, addTemplate, addTypeTemplate, createResolver, defineNuxtModule, extendPages, hasNuxtModule, updateTemplates } from '@nuxt/kit'
 import { consola as _consola } from 'consola'
 import { defu } from 'defu'
 import { join } from 'pathe'
@@ -246,6 +246,7 @@ export {}
     })
 
     addServerImportsDir(resolver.resolve('./runtime/server/utils'))
+    addServerImports([{ name: 'defineServerAuth', from: resolver.resolve('./runtime/config') }])
     addServerScanDir(resolver.resolve('./runtime/server/middleware'))
     addServerHandler({ route: '/api/auth/**', handler: resolver.resolve('./runtime/server/api/auth/[...all]') })
     addImportsDir(resolver.resolve('./runtime/app/composables'))


### PR DESCRIPTION
Fixes #31

## Problem

`defineServerAuth` was not auto-imported in server context, causing production builds to fail at runtime with `ReferenceError: defineServerAuth is not defined`.

## Solution

1. Add `addServerImports` call to register `defineServerAuth` as a server auto-import
2. Inject `defineServerAuth` into global scope for jiti-loaded configs during schema generation

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxt-better-auth-31](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-better-auth-31/nuxt-better-auth-31?startScript=build) | ❌ Server crashes |
| Fix | [nuxt-better-auth-31-fixed](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-better-auth-31/nuxt-better-auth-31-fixed?startScript=build) | ✅ Server starts |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxt-better-auth-31 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxt-better-auth-31
cd nuxt-better-auth-31 && pnpm i && BETTER_AUTH_SECRET="test-secret-at-least-32-characters-long" pnpm build && node .output/server/index.mjs
```

## Verify fix

```bash
git sparse-checkout add nuxt-better-auth-31-fixed
cd ../nuxt-better-auth-31-fixed && pnpm i && BETTER_AUTH_SECRET="test-secret-at-least-32-characters-long" pnpm build && node .output/server/index.mjs
```