### PR TITLE
fix!: remove event requirement from serverAuth

### DIFF
--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -103,15 +103,16 @@ export default defineServerAuth(({ db, runtimeConfig }) => ({
 }))
 ```
 
-## Base URL Resolution
+## Base URL Configuration
 
-The module determines the authentication base URL in the following order:
+The module requires `siteUrl` to be configured via environment variable:
 
-1. `runtimeConfig.public.siteUrl` (Recommended for production)
-2. The current request origin (Development fallback)
+```ini [.env]
+NUXT_PUBLIC_SITE_URL="http://localhost:3000"
+```
 
-::note
-Always set `NUXT_PUBLIC_SITE_URL` in production to ensure correct redirect URIs for OAuth providers.
+::warning
+`NUXT_PUBLIC_SITE_URL` is **required** in all environments. The module will throw an error if not set.
 ::
 
 ## Runtime Config

--- a/docs/content/1.getting-started/6.how-it-works.md
+++ b/docs/content/1.getting-started/6.how-it-works.md
@@ -23,7 +23,7 @@ On the client side, `useUserSession` initializes the Better Auth client. It esta
 |---------|------------------|------|
 | Server handler | Mounts Better Auth at `/api/auth/*` | Server |
 | Composables | `useUserSession()` for reactive state | Client |
-| Server utils | `serverAuth(event)`, `getUserSession(event)`, etc. | Server |
+| Server utils | `serverAuth()`, `getUserSession(event)`, etc. | Server |
 | Route protection | `routeRules.auth` and `definePageMeta({ auth })` | Both |
 | Type augmentation | Inferred `AuthUser` and `AuthSession` types | Build |
 

--- a/docs/content/2.core-concepts/1.server-auth.md
+++ b/docs/content/2.core-concepts/1.server-auth.md
@@ -1,9 +1,9 @@
 ---
-title: serverAuth(event)
+title: serverAuth()
 description: When to reach for the full Better Auth server instance.
 ---
 
-`serverAuth(event)` returns the memoized Better Auth instance for the current request. Prefer the helper utilities for common checks, and reach for `serverAuth(event)` when you need the full Better Auth API or plugin-specific endpoints.
+`serverAuth()` returns the Better Auth instance (module-level singleton). Prefer the helper utilities for common checks, and reach for `serverAuth()` when you need the full Better Auth API or plugin-specific endpoints.
 
 ## When to Use What
 
@@ -11,7 +11,7 @@ description: When to reach for the full Better Auth server instance.
 |------|-----|---------|
 | Get current session | `getUserSession(event)` | Check if user is logged in |
 | Require authentication | `requireUserSession(event)` | Protect an API route |
-| Access Better Auth API | `serverAuth(event)` | Call `auth.api.listSessions()` |
+| Access Better Auth API | `serverAuth()` | Call `auth.api.listSessions()` |
 | Get session with options | `requireUserSession(event, { role: 'admin' })` | Role-based protection |
 
 :read-more{to="/api/server-utils"}

--- a/docs/content/2.core-concepts/4.auto-imports-aliases.md
+++ b/docs/content/2.core-concepts/4.auto-imports-aliases.md
@@ -11,7 +11,7 @@ description: What the module registers for you.
 
 **Server**
 
-- `serverAuth(event)`
+- `serverAuth()`
 - `getUserSession(event)`
 - `requireUserSession(event, options?)`
 
@@ -27,7 +27,7 @@ description: What the module registers for you.
 export default defineEventHandler(async (event) => {
   // These are auto-imported, no import statement needed
   const session = await getUserSession(event)
-  const auth = await serverAuth(event)
+  const auth = serverAuth()
 })
 ```
 

--- a/docs/content/3.guides/6.two-factor-auth.md
+++ b/docs/content/3.guides/6.two-factor-auth.md
@@ -170,7 +170,7 @@ export default defineEventHandler(async (event) => {
   await requireUserSession(event, { user: { role: 'admin' } })
 
   const { userId } = await readBody(event)
-  const auth = await serverAuth(event)
+  const auth = serverAuth()
 
   // Reset 2FA for user (requires admin plugin)
   await auth.api.admin.disableTwoFactor({ userId })

--- a/docs/content/5.api/2.server-utils.md
+++ b/docs/content/5.api/2.server-utils.md
@@ -5,11 +5,11 @@ description: API reference for server-side helpers available in Nitro event hand
 
 ## serverAuth
 
-Returns the initialized Better Auth instance. This function is memoized and safe to call multiple times per request.
+Returns the initialized Better Auth instance (module-level singleton). This function is safe to call multiple times - subsequent calls return the cached instance.
 
 ```ts [server/api/admin/users.get.ts]
 export default defineEventHandler(async (event) => {
-  const auth = await serverAuth(event)
+  const auth = serverAuth()
   const session = await auth.api.getSession({ headers: event.headers })
 
   if (!session) {

--- a/src/runtime/server/api/_better-auth/config.get.ts
+++ b/src/runtime/server/api/_better-auth/config.get.ts
@@ -2,9 +2,9 @@ import { defineEventHandler } from 'h3'
 import { useRuntimeConfig } from 'nitropack/runtime'
 import { serverAuth } from '../../utils/auth'
 
-export default defineEventHandler(async (event) => {
+export default defineEventHandler(async () => {
   try {
-    const auth = await serverAuth(event)
+    const auth = serverAuth()
     const options = auth.options
     const runtimeConfig = useRuntimeConfig()
     const publicAuth = runtimeConfig.public?.auth as { redirects?: { login?: string, guest?: string }, useDatabase?: boolean } | undefined

--- a/src/runtime/server/api/auth/[...all].ts
+++ b/src/runtime/server/api/auth/[...all].ts
@@ -3,6 +3,6 @@ import { defineEventHandler, toWebRequest } from 'h3'
 import { serverAuth } from '../../utils/auth'
 
 export default defineEventHandler(async (event: H3Event) => {
-  const auth = await serverAuth(event)
+  const auth = serverAuth()
   return auth.handler(toWebRequest(event))
 })

--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -1,49 +1,33 @@
 import type { Auth } from 'better-auth'
-import type { H3Event } from 'h3'
 import { createDatabase, db } from '#auth/database'
 import { createSecondaryStorage } from '#auth/secondary-storage'
 import createServerAuth from '#auth/server'
 import { betterAuth } from 'better-auth'
-import { consola } from 'consola'
-import { getRequestURL } from 'h3'
 import { useRuntimeConfig } from 'nitropack/runtime'
-
-const logger = consola.withTag('nuxt-better-auth')
 
 type AuthInstance = Auth<ReturnType<typeof createServerAuth>>
 
-declare module 'h3' {
-  interface H3EventContext {
-    _betterAuth?: AuthInstance
-  }
-}
+let _auth: AuthInstance | null = null
 
-function getBaseURL(event: H3Event, siteUrl?: string): string {
-  if (siteUrl)
-    return siteUrl
-  const origin = getRequestURL(event).origin
-  if (process.env.NODE_ENV === 'production')
-    throw new Error('siteUrl must be configured in production. Set NUXT_PUBLIC_SITE_URL or configure in nuxt.config.')
-  logger.warn('siteUrl not set, auto-detected:', origin)
-  return origin
-}
-
-export async function serverAuth(event: H3Event): Promise<AuthInstance> {
-  // Request-scoped singleton (like @nuxtjs/supabase pattern)
-  if (event.context._betterAuth)
-    return event.context._betterAuth
+export function serverAuth(): AuthInstance {
+  if (_auth)
+    return _auth
 
   const runtimeConfig = useRuntimeConfig()
+  const siteUrl = runtimeConfig.public.siteUrl as string
+  if (!siteUrl)
+    throw new Error('siteUrl must be configured. Set NUXT_PUBLIC_SITE_URL or configure in nuxt.config.')
+
   const database = createDatabase()
   const userConfig = createServerAuth({ runtimeConfig, db })
 
-  event.context._betterAuth = betterAuth({
+  _auth = betterAuth({
     ...userConfig,
     ...(database && { database }),
     secondaryStorage: createSecondaryStorage(),
     secret: runtimeConfig.betterAuthSecret,
-    baseURL: getBaseURL(event, runtimeConfig.public.siteUrl as string | undefined),
+    baseURL: siteUrl,
   })
 
-  return event.context._betterAuth
+  return _auth
 }

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -7,7 +7,7 @@ import { serverAuth } from './auth'
 interface FullSession { user: AuthUser, session: AuthSession }
 
 export async function getUserSession(event: H3Event): Promise<FullSession | null> {
-  const auth = await serverAuth(event)
+  const auth = serverAuth()
   const session = await auth.api.getSession({ headers: event.headers })
   return session as FullSession | null
 }


### PR DESCRIPTION
Closes #35

## Summary

`serverAuth(event)` required H3Event making it unusable in Nitro tasks, plugins, and seeding scripts. Removed the event param - now uses a module-level singleton.

**Breaking:**
- `serverAuth(event)` -> `serverAuth()` (no event, sync)
- `siteUrl` required in all environments

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxt-better-auth-35](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-better-auth-35/nuxt-better-auth-35?startScript=dev) | Cannot use serverAuth in tasks |
| Fix | [nuxt-better-auth-35-fixed](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-better-auth-35/nuxt-better-auth-35-fixed?startScript=dev) | serverAuth() works in tasks |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxt-better-auth-35 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxt-better-auth-35
cd nuxt-better-auth-35 && pnpm i && pnpm dev
```

## Verify fix

```bash
git sparse-checkout add nuxt-better-auth-35-fixed
cd ../nuxt-better-auth-35-fixed && pnpm i && pnpm dev
```

The `-fixed` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.