### PR TITLE
fix: add missing useUserSession import in BetterAuthState component

### DIFF
--- a/src/runtime/app/components/BetterAuthState.vue
+++ b/src/runtime/app/components/BetterAuthState.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+import { useUserSession } from '#imports'
+
 const { loggedIn, user, session, signOut, ready } = useUserSession()
 </script>
 


### PR DESCRIPTION
## Problem
`useUserSession()` called in `BetterAuthState.vue` component without explicit import. Auto-import works in dev but fails in production builds and certain runtime environments.

<img width="985" height="591" alt="Snímek obrazovky 2026-01-05 v 18 37 47" src="https://github.com/user-attachments/assets/d29fb81c-9dfd-4ffc-bc77-0b871631dc9c" />

## Fix
Add `useUserSession` import from `#imports` in `BetterAuthState.vue:2`.

Related to #19 (similar fix for middleware)