### PR TITLE
fix: proper type augmentation for plugin-injected fields

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -189,7 +189,7 @@ declare module '#auth/database' {
       addTypeTemplate({
         filename: 'types/nuxt-better-auth-infer.d.ts',
         getContents: () => `
-import type { InferUser, InferSession } from 'better-auth'
+import type { InferUser, InferSession, InferPluginTypes } from 'better-auth'
 import type { RuntimeConfig } from 'nuxt/schema'
 import type configFn from '${serverConfigPath}'
 
@@ -197,11 +197,12 @@ type _Config = ReturnType<typeof configFn>
 
 declare module '#nuxt-better-auth' {
   interface AuthUser extends InferUser<_Config> {}
-  interface AuthSession { session: InferSession<_Config>['session'], user: InferUser<_Config> }
+  interface AuthSession extends InferSession<_Config> {}
   interface ServerAuthContext {
     runtimeConfig: RuntimeConfig
     ${hasHubDb ? `db: typeof import('hub:db')['db']` : ''}
   }
+  type PluginTypes = InferPluginTypes<_Config>
 }
 
 // Augment the config module to use the extended ServerAuthContext

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -5,7 +5,7 @@ import type { AuthSession, AuthUser } from './types/augment'
 export type { AuthSession, AuthUser, ServerAuthContext, UserSessionComposable } from './types/augment'
 
 // Re-export better-auth types for $Infer access
-export type { Auth, InferSession, InferUser } from 'better-auth'
+export type { Auth, InferPluginTypes, InferSession, InferUser } from 'better-auth'
 
 export type AuthMode = 'guest' | 'user'
 


### PR DESCRIPTION
Fixes #41

## Problem
Plugin-injected session fields (e.g. `activeOrganizationId` from `organization()`) had no types.

## Root Cause
```ts
// WRONG - InferSession<Config> IS the session object, not { session: ..., user: ... }
interface AuthSession { session: InferSession<_Config>['session'], user: ... }
```

## Fix
```ts
interface AuthSession extends InferSession<_Config> {}
```

Also added `InferPluginTypes` export for accessing plugin-specific types like `$Infer.Organization`.

## Reproduction

| | Link | Expected |
|---|---|---|
| Bug | [nuxt-better-auth-41](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-better-auth-41/nuxt-better-auth-41?startScript=typecheck) | ❌ Type error |
| Fix | [nuxt-better-auth-41-fixed](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-better-auth-41/nuxt-better-auth-41-fixed?startScript=typecheck) | ✅ Types pass |

## CLI Verification
```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxt-better-auth-41 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxt-better-auth-41
cd nuxt-better-auth-41 && pnpm i && BETTER_AUTH_SECRET=test123test123test123test123test123 npx nuxi prepare && pnpm typecheck
# → Property 'activeOrganizationId' does not exist on type 'AuthSession'

git sparse-checkout add nuxt-better-auth-41-fixed
cd ../nuxt-better-auth-41-fixed && pnpm i && BETTER_AUTH_SECRET=test123test123test123test123test123 npx nuxi prepare && pnpm typecheck
# → ✅ Passes
```