### PR TITLE
fix: proper type augmentation for server-side plugin-injected fields

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -217,7 +217,7 @@ declare module '@onmax/nuxt-better-auth/config' {
   export function defineServerAuth<T extends ServerAuthConfig>(config: (ctx: _AugmentedServerAuthContext) => T): (ctx: _AugmentedServerAuthContext) => T
 }
 `,
-      })
+      }, { nuxt: true, nitro: true, node: true })
 
       addTypeTemplate({
         filename: 'types/nuxt-better-auth-nitro.d.ts',


### PR DESCRIPTION
Fixes #41
Related #43

## Problem

The `server/` directory was still ignoring your changes from #43.

e.g.:

```ts
export default defineEventHandler(async (event) => {
  const { session } = await requireUserSession(event)
  return session.activeOrganizationId // ❌ Property 'activeOrganizationId' does not exist on type 'AuthSession'.ts
                 ^^^^^^^^^^^^^^^^^^^^
})
```


## Fix

Added `{ nuxt: true, nitro: true, node: true }` options 

```ts
export default defineEventHandler(async (event) => {
  const { session } = await requireUserSession(event)
  return session.activeOrganizationId // ✅ string | null | undefined
})
```