### PR TITLE
fix: add nitro/node context to server-side type templates

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -173,7 +173,7 @@ declare module '#auth/secondary-storage' {
   export function createSecondaryStorage(): SecondaryStorage | undefined
 }
 `,
-      })
+      }, { nitro: true, node: true })
 
       addTypeTemplate({
         filename: 'types/auth-database.d.ts',
@@ -184,7 +184,7 @@ declare module '#auth/database' {
   export const db: unknown
 }
 `,
-      })
+      }, { nitro: true, node: true })
 
       addTypeTemplate({
         filename: 'types/nuxt-better-auth-infer.d.ts',


### PR DESCRIPTION
Fixes #45

## Problem
`auth-secondary-storage.d.ts` and `auth-database.d.ts` type templates default to `nuxt: true` only → types unavailable in Nitro/Node contexts.

## Context
- #43 - original type augmentation fix
- #44 - fixed `nuxt-better-auth-infer.d.ts` with `{ nitro: true, node: true }`
- #45 - same fix needed for remaining templates

## Solution
Add `{ nitro: true, node: true }` to both `addTypeTemplate()` calls.