### PR TITLE
feat: auto-detect siteUrl from platform env vars

### DIFF
--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -56,9 +56,9 @@ Or generate via terminal:
 openssl rand -base64 32
 ```
 
-2. **Base URL**
+2. **Base URL** (Optional)
 
-Required for production deployments. In development, the module uses `http://localhost:3000` automatically.
+Auto-detected on Vercel, Cloudflare Pages, and Netlify. Set manually for other platforms.
 
 ```txt [.env]
 NUXT_PUBLIC_SITE_URL=https://your-domain.com

--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -96,7 +96,7 @@ export default defineServerAuth(() => {
 ::note
 The module automatically injects `secret` and `baseURL`. You don't need to configure these in `defineServerAuth`.
 - **Secret**: Reads from `NUXT_BETTER_AUTH_SECRET` or `BETTER_AUTH_SECRET`
-- **Base URL**: Reads from `NUXT_PUBLIC_SITE_URL`
+- **Base URL**: Auto-detected on Vercel/Cloudflare/Netlify, or set `NUXT_PUBLIC_SITE_URL`
 ::
 
 ### Context Options
@@ -118,14 +118,23 @@ export default defineServerAuth(({ db, runtimeConfig }) => ({
 
 ## Base URL Configuration
 
-The module requires `siteUrl` to be configured via environment variable:
+The module resolves `siteUrl` using this priority:
+
+| Priority | Source | When Used |
+|----------|--------|-----------|
+| 1 | `NUXT_PUBLIC_SITE_URL` | Explicit config (always wins) |
+| 2 | Request URL | Auto-detected from HTTP request |
+| 3 | `VERCEL_URL`, `CF_PAGES_URL`, `URL` | Platform env vars (Vercel, Cloudflare, Netlify) |
+| 4 | `http://localhost:3000` | Development only |
+
+**Custom domains or self-hosted**: Always set `NUXT_PUBLIC_SITE_URL` when using custom domains or deploying to your own VPS/server. Platform env vars return auto-generated URLs, not your custom domain.
 
 ```ini [.env]
-NUXT_PUBLIC_SITE_URL="http://localhost:3000"
+NUXT_PUBLIC_SITE_URL="https://your-domain.com"
 ```
 
-::warning
-`NUXT_PUBLIC_SITE_URL` is **required** in all environments. The module will throw an error if not set.
+::note
+For most deployments, the request URL is auto-detected correctly. Only set `NUXT_PUBLIC_SITE_URL` for custom domains or non-request contexts like seed scripts.
 ::
 
 ## Runtime Config
@@ -134,7 +143,7 @@ Configure secrets via environment variables (see [Installation](/getting-started
 
 ```ini [.env]
 NUXT_BETTER_AUTH_SECRET="your-super-secret-key"
-NUXT_PUBLIC_SITE_URL="http://localhost:3000"
+NUXT_PUBLIC_SITE_URL="https://your-domain.com" # Optional on Vercel/Cloudflare/Netlify
 ```
 
 ## For Module Authors

--- a/docs/content/2.core-concepts/1.server-auth.md
+++ b/docs/content/2.core-concepts/1.server-auth.md
@@ -3,7 +3,7 @@ title: serverAuth()
 description: When to reach for the full Better Auth server instance.
 ---
 
-`serverAuth()` returns the Better Auth instance (module-level singleton). Prefer the helper utilities for common checks, and reach for `serverAuth()` when you need the full Better Auth API or plugin-specific endpoints.
+`serverAuth(event?)` returns the Better Auth instance (module-level singleton). Pass the event for accurate URL detection on first initialization. Prefer the helper utilities for common checks, and reach for `serverAuth()` when you need the full Better Auth API or plugin-specific endpoints.
 
 ## When to Use What
 
@@ -11,7 +11,7 @@ description: When to reach for the full Better Auth server instance.
 |------|-----|---------|
 | Get current session | `getUserSession(event)` | Check if user is logged in |
 | Require authentication | `requireUserSession(event)` | Protect an API route |
-| Access Better Auth API | `serverAuth()` | Call `auth.api.listSessions()` |
+| Access Better Auth API | `serverAuth(event)` | Call `auth.api.listSessions()` |
 | Get session with options | `requireUserSession(event, { role: 'admin' })` | Role-based protection |
 
 :read-more{to="/api/server-utils"}

--- a/docs/content/3.guides/5.external-auth-backend.md
+++ b/docs/content/3.guides/5.external-auth-backend.md
@@ -41,7 +41,9 @@ export function createAppAuthClient(_baseURL: string) {
 The function signature must include `baseURL` for compatibility, but you ignore it and hardcode your external server URL instead.
 ::
 
-### 3. Set Site URL
+### 3. Set Site URL (Optional)
+
+Auto-detected on Vercel/Cloudflare/Netlify. For other platforms:
 
 ```ini [.env]
 NUXT_PUBLIC_SITE_URL="https://your-frontend.com"

--- a/docs/content/3.guides/6.migrate-from-nuxt-auth-utils.md
+++ b/docs/content/3.guides/6.migrate-from-nuxt-auth-utils.md
@@ -293,7 +293,7 @@ See **Schema Generation** to set up database tables.
 Ensure `NUXT_BETTER_AUTH_SECRET` is set and database is configured.
 
 ### OAuth redirect errors
-Set `NUXT_PUBLIC_SITE_URL` to your production URL.
+Auto-detected on Vercel/Cloudflare/Netlify. For other platforms, set `NUXT_PUBLIC_SITE_URL`.
 
 ### Type errors on user fields
 Run type augmentation - see [Type Augmentation](/getting-started/type-augmentation).

--- a/docs/content/3.guides/7.two-factor-auth.md
+++ b/docs/content/3.guides/7.two-factor-auth.md
@@ -170,7 +170,7 @@ export default defineEventHandler(async (event) => {
   await requireUserSession(event, { user: { role: 'admin' } })
 
   const { userId } = await readBody(event)
-  const auth = serverAuth()
+  const auth = serverAuth(event)
 
   // Reset 2FA for user (requires admin plugin)
   await auth.api.admin.disableTwoFactor({ userId })

--- a/docs/content/3.guides/9.production-deployment.md
+++ b/docs/content/3.guides/9.production-deployment.md
@@ -11,7 +11,7 @@ Production requires these environment variables:
 # Required: 32+ character secret for session encryption
 NUXT_BETTER_AUTH_SECRET="your-32-character-secret-here-minimum"
 
-# Required for OAuth: Your production URL
+# Optional: Auto-detected on Vercel/Cloudflare/Netlify
 NUXT_PUBLIC_SITE_URL="https://your-app.com"
 
 # OAuth provider credentials (if using)
@@ -32,7 +32,7 @@ The secret must be at least 32 characters. Shorter secrets will cause the module
 ### Before Deploying
 
 - [ ] `NUXT_BETTER_AUTH_SECRET` is set and 32+ characters
-- [ ] `NUXT_PUBLIC_SITE_URL` matches your production domain
+- [ ] `NUXT_PUBLIC_SITE_URL` set (or using Vercel/Cloudflare/Netlify auto-detection)
 - [ ] OAuth redirect URIs configured for production domain
 - [ ] `NODE_ENV=production` is set (disables devtools)
 
@@ -101,9 +101,9 @@ export default defineNuxtConfig({
 
 Your secret is too short. Generate a new one using the command above.
 
-### "siteUrl must be configured in production"
+### "siteUrl required in production"
 
-Set `NUXT_PUBLIC_SITE_URL` to your production domain. This is required for OAuth callbacks.
+The module auto-detects URLs on Vercel, Cloudflare Pages, and Netlify. For other platforms, set `NUXT_PUBLIC_SITE_URL` to your production domain.
 
 ### OAuth Redirects Fail
 

--- a/docs/content/5.api/2.server-utils.md
+++ b/docs/content/5.api/2.server-utils.md
@@ -9,11 +9,11 @@ These utilities are only available in **full mode**. In [clientOnly mode](/guide
 
 ## serverAuth
 
-Returns the initialized Better Auth instance (module-level singleton). This function is safe to call multiple times - subsequent calls return the cached instance.
+Returns the initialized Better Auth instance (module-level singleton). Pass the event for accurate URL detection on first initialization.
 
 ```ts [server/api/admin/users.get.ts]
 export default defineEventHandler(async (event) => {
-  const auth = serverAuth()
+  const auth = serverAuth(event)
   const session = await auth.api.getSession({ headers: event.headers })
 
   if (!session) {

--- a/src/runtime/server/api/_better-auth/config.get.ts
+++ b/src/runtime/server/api/_better-auth/config.get.ts
@@ -2,9 +2,9 @@ import { defineEventHandler } from 'h3'
 import { useRuntimeConfig } from 'nitropack/runtime'
 import { serverAuth } from '../../utils/auth'
 
-export default defineEventHandler(async () => {
+export default defineEventHandler(async (event) => {
   try {
-    const auth = serverAuth()
+    const auth = serverAuth(event)
     const options = auth.options
     const runtimeConfig = useRuntimeConfig()
     const publicAuth = runtimeConfig.public?.auth as { redirects?: { login?: string, guest?: string }, useDatabase?: boolean } | undefined

--- a/src/runtime/server/api/auth/[...all].ts
+++ b/src/runtime/server/api/auth/[...all].ts
@@ -3,6 +3,6 @@ import { defineEventHandler, toWebRequest } from 'h3'
 import { serverAuth } from '../../utils/auth'
 
 export default defineEventHandler(async (event: H3Event) => {
-  const auth = serverAuth()
+  const auth = serverAuth(event)
   return auth.handler(toWebRequest(event))
 })

--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -1,22 +1,49 @@
 import type { Auth } from 'better-auth'
+import type { H3Event } from 'h3'
 import { createDatabase, db } from '#auth/database'
 import { createSecondaryStorage } from '#auth/secondary-storage'
 import createServerAuth from '#auth/server'
 import { betterAuth } from 'better-auth'
+import { getRequestURL } from 'h3'
 import { useRuntimeConfig } from 'nitropack/runtime'
 
 type AuthInstance = Auth<ReturnType<typeof createServerAuth>>
 
 let _auth: AuthInstance | null = null
 
-export function serverAuth(): AuthInstance {
+function getBaseURL(event?: H3Event): string {
+  const config = useRuntimeConfig()
+
+  // 1. Explicit config (highest priority)
+  if (config.public.siteUrl && typeof config.public.siteUrl === 'string')
+    return config.public.siteUrl
+
+  // 2. Request URL (always correct for current request)
+  if (event)
+    return getRequestURL(event).origin
+
+  // 3. Platform env vars (fallback for non-request contexts like seed scripts)
+  if (process.env.VERCEL_URL)
+    return `https://${process.env.VERCEL_URL}`
+  if (process.env.CF_PAGES_URL)
+    return `https://${process.env.CF_PAGES_URL}`
+  if (process.env.URL)
+    return process.env.URL.startsWith('http') ? process.env.URL : `https://${process.env.URL}`
+
+  // 4. Dev fallback
+  if (import.meta.dev)
+    return 'http://localhost:3000'
+
+  throw new Error('siteUrl required. Set NUXT_PUBLIC_SITE_URL.')
+}
+
+/** Returns Better Auth instance. Pass event for accurate URL detection on first call. */
+export function serverAuth(event?: H3Event): AuthInstance {
   if (_auth)
     return _auth
 
   const runtimeConfig = useRuntimeConfig()
-  const siteUrl = runtimeConfig.public.siteUrl as string
-  if (!siteUrl)
-    throw new Error('siteUrl must be configured. Set NUXT_PUBLIC_SITE_URL or configure in nuxt.config.')
+  const siteUrl = getBaseURL(event)
 
   const database = createDatabase()
   const userConfig = createServerAuth({ runtimeConfig, db })

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -7,7 +7,7 @@ import { serverAuth } from './auth'
 interface FullSession { user: AuthUser, session: AuthSession }
 
 export async function getUserSession(event: H3Event): Promise<FullSession | null> {
-  const auth = serverAuth()
+  const auth = serverAuth(event)
   const session = await auth.api.getSession({ headers: event.headers })
   return session as FullSession | null
 }

--- a/test/get-base-url.test.ts
+++ b/test/get-base-url.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+// Recreate getBaseURL logic for unit testing (not exported from module)
+function getBaseURL(config: { public: { siteUrl?: unknown } }, requestURL: string | undefined, env: NodeJS.ProcessEnv, isDev: boolean): string {
+  if (config.public.siteUrl && typeof config.public.siteUrl === 'string')
+    return config.public.siteUrl
+
+  if (requestURL)
+    return requestURL
+
+  if (env.VERCEL_URL)
+    return `https://${env.VERCEL_URL}`
+  if (env.CF_PAGES_URL)
+    return `https://${env.CF_PAGES_URL}`
+  if (env.URL)
+    return env.URL.startsWith('http') ? env.URL : `https://${env.URL}`
+
+  if (isDev)
+    return 'http://localhost:3000'
+
+  throw new Error('siteUrl required. Set NUXT_PUBLIC_SITE_URL.')
+}
+
+describe('getBaseURL', () => {
+  it('explicit config takes priority', () => {
+    expect(getBaseURL({ public: { siteUrl: 'https://explicit.com' } }, 'https://request.com', { VERCEL_URL: 'x.vercel.app' } as NodeJS.ProcessEnv, false)).toBe('https://explicit.com')
+  })
+
+  it('requestURL takes priority over platform vars', () => {
+    expect(getBaseURL({ public: {} }, 'https://myapp.com', { VERCEL_URL: 'x.vercel.app' } as NodeJS.ProcessEnv, false)).toBe('https://myapp.com')
+  })
+
+  it('platform env vars used when no requestURL', () => {
+    expect(getBaseURL({ public: {} }, undefined, { VERCEL_URL: 'x.vercel.app' } as NodeJS.ProcessEnv, false)).toBe('https://x.vercel.app')
+  })
+
+  it('normalizes URL without protocol', () => {
+    expect(getBaseURL({ public: {} }, undefined, { URL: 'my-app.netlify.app' } as NodeJS.ProcessEnv, false)).toBe('https://my-app.netlify.app')
+    expect(getBaseURL({ public: {} }, undefined, { URL: 'http://localhost:8888' } as NodeJS.ProcessEnv, false)).toBe('http://localhost:8888')
+  })
+
+  it('dev fallback to localhost', () => {
+    expect(getBaseURL({ public: {} }, undefined, {} as NodeJS.ProcessEnv, true)).toBe('http://localhost:3000')
+  })
+
+  it('throws in production without config', () => {
+    expect(() => getBaseURL({ public: {} }, undefined, {} as NodeJS.ProcessEnv, false)).toThrow('siteUrl required')
+  })
+
+  it('ignores non-string siteUrl', () => {
+    expect(getBaseURL({ public: { siteUrl: 123 } }, undefined, { VERCEL_URL: 'x.vercel.app' } as NodeJS.ProcessEnv, false)).toBe('https://x.vercel.app')
+  })
+})


### PR DESCRIPTION
Fixes #37 and #48

## Problem

`siteUrl` was mandatory since PR #36, and client/server URL detection could differ.

## Solution

Unified URL resolution priority:

| Priority | Source | When Used |
|----------|--------|-----------|
| 1 | `NUXT_PUBLIC_SITE_URL` | Explicit config (always wins) |
| 2 | Request URL | Auto-detected from HTTP request |
| 3 | Platform env vars | Fallback for non-request contexts |
| 4 | `http://localhost:3000` | Development only |

## Changes

- `src/runtime/server/utils/auth.ts`: Add `event` param, prioritize `requestURL` over platform vars
- `serverAuth(event)` now accepts optional H3Event
- Updated callers to pass event for accurate URL detection
- Docs: Updated configuration.md with new priority table