### PR TITLE
fix: add h3 ^1.0.0 peer dep for Cloudflare builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,12 +51,12 @@
   },
   "peerDependencies": {
     "@nuxthub/core": ">=0.10.0",
-    "better-auth": ">=1.0.0"
+    "better-auth": ">=1.0.0",
+    "h3": "^1.0.0"
   },
   "peerDependenciesMeta": {
-    "@nuxthub/core": {
-      "optional": true
-    }
+    "@nuxthub/core": { "optional": true },
+    "h3": { "optional": true }
   },
   "dependencies": {
     "@nuxt/kit": "^4.2.2",


### PR DESCRIPTION
Fixes #53

## Problem
Cloudflare build fails when h3 v2 is resolved via `@nuxt/test-utils`:
```
"toWebRequest" is not exported by h3@2.0.1-rc.7
```

## Solution
Add h3 ^1.0.0 as optional peer dependency to prevent resolution of h3 v2.

h3 v2 renamed `toWebRequest` → `toRequest` with different signature. Will migrate when Nuxt 5 is stable.