### PR TITLE
fix: support BETTER_AUTH_SECRET at runtime

### DIFF
--- a/docs/content/1.getting-started/0.index.md
+++ b/docs/content/1.getting-started/0.index.md
@@ -4,7 +4,7 @@ description: Nuxt Better Auth integrates Better Auth with Nuxt for route protect
 navigation.icon: i-lucide-sparkles
 ---
 
-Nuxt Better Auth integrates **Nuxt** and **Better Auth**, the TypeScript-first authentication library. You get route protection, session management, and schema generation without configuration. The plugin ecosystem adds features like 2FA, organizations, and passkeys.
+Nuxt Better Auth integrates **Nuxt** and **Better Auth**, the TypeScript-first authentication library. You get route protection, session management, and schema generation with minimal setup. The plugin ecosystem adds features like 2FA, organizations, and passkeys.
 
 ::card{to="https://demo-nuxt-better-auth.nuxt.dev" target="_blank" icon="i-lucide-external-link"}
 **Live Demo** – Try the authentication flow in action.
@@ -18,7 +18,7 @@ This module brings Nuxt-specific enhancements on top of Better Auth:
 ---
 features:
   - title: Auto Configuration
-    description: Zero-config setup with sensible defaults
+    description: Auto-wires API routes, middleware, and schema with sensible defaults
   - title: Route Protection
     description: Declarative page and API route guards
   - title: Schema Generation
@@ -47,7 +47,7 @@ Building authentication from scratch is hard. Wiring up Better Auth with Nuxt ma
 - Handling redirects
 - Managing database schemas (if using a database)
 
-This module does all of that for you. It's designed to be **drop-in** and **zero-config** where possible.
+This module does all of that for you. Just configure your auth providers and the module handles the rest.
 
 ## Quick Start
 
@@ -76,7 +76,7 @@ export default defineNuxtConfig({
 ```
 
 ```ini [.env]
-NUXT_BETTER_AUTH_SECRET="generate-a-32-char-secret"
+BETTER_AUTH_SECRET="generate-a-32-char-secret"
 ```
 
 ### Create Config Files

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -40,12 +40,11 @@ Add these environment variables to `.env`:
 
 1. **Secret Key**
 
-A secret value used for encryption and hashing. Must be at least 32 characters with high entropy.
+The secret encrypts and hashes sensitive data. Must be at least 32 characters with high entropy.
 
 ```txt [.env]
-NUXT_BETTER_AUTH_SECRET=
+BETTER_AUTH_SECRET=
 ```
-
 
 ::generate-secret
 ::
@@ -56,9 +55,13 @@ Or generate via terminal:
 openssl rand -base64 32
 ```
 
+::tip
+Prefix the variable with `NUXT_` to use Nuxt's runtime config system (recommended for multi-environment deployments): `NUXT_BETTER_AUTH_SECRET=`
+::
+
 2. **Base URL** (Optional)
 
-Auto-detected on Vercel, Cloudflare Pages, and Netlify. Set manually for other platforms.
+The module auto-detects the URL on Vercel, Cloudflare Pages, and Netlify. Set manually for other platforms.
 
 ```txt [.env]
 NUXT_PUBLIC_SITE_URL=https://your-domain.com

--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -25,7 +25,7 @@ export default defineNuxtConfig({
     Enable client-only mode for external auth backends. When `true`:
     - Skips `server/auth.config.ts` requirement
     - Skips server-side setup (API handlers, middleware, schema generation, devtools)
-    - Skips `NUXT_BETTER_AUTH_SECRET` validation
+    - Skips secret validation
 
     Use this when your Better Auth server runs on a separate backend (e.g., standalone h3/Nitro project).
 
@@ -69,7 +69,7 @@ export default defineNuxtConfig({
   ::field{name="schema.casing" type="'camelCase' | 'snake_case'"}
     Default: `camelCase`
 
-    Column/table name casing. Inherits from `hub.db.casing` if not set.
+    Column/table name casing. Falls back to `hub.db.casing` when not specified.
   ::
 ::
 
@@ -95,8 +95,8 @@ export default defineServerAuth(() => {
 
 ::note
 The module automatically injects `secret` and `baseURL`. You don't need to configure these in `defineServerAuth`.
-- **Secret**: Reads from `NUXT_BETTER_AUTH_SECRET` or `BETTER_AUTH_SECRET`
-- **Base URL**: Auto-detected on Vercel/Cloudflare/Netlify, or set `NUXT_PUBLIC_SITE_URL`
+- **Secret**: Priority: `nuxt.config.ts` runtimeConfig > `NUXT_BETTER_AUTH_SECRET` > `BETTER_AUTH_SECRET`
+- **Base URL**: The module auto-detects the base URL on Vercel/Cloudflare/Netlify. For other platforms, set `NUXT_PUBLIC_SITE_URL`
 ::
 
 ### Context Options
@@ -134,17 +134,21 @@ NUXT_PUBLIC_SITE_URL="https://your-domain.com"
 ```
 
 ::note
-For most deployments, the request URL is auto-detected correctly. Only set `NUXT_PUBLIC_SITE_URL` for custom domains or non-request contexts like seed scripts.
+For most deployments, the module auto-detects the request URL correctly. Only set `NUXT_PUBLIC_SITE_URL` for custom domains or non-request contexts like seed scripts.
 ::
 
 ## Runtime Config
 
-Configure secrets via environment variables (see [Installation](/getting-started/installation#set-environment-variables)).
+Configure secrets using environment variables (see [Installation](/getting-started/installation#set-environment-variables)).
 
 ```ini [.env]
-NUXT_BETTER_AUTH_SECRET="your-super-secret-key"
+BETTER_AUTH_SECRET="your-super-secret-key"
 NUXT_PUBLIC_SITE_URL="https://your-domain.com" # Optional on Vercel/Cloudflare/Netlify
 ```
+
+::tip
+Prefix the variable with `NUXT_` to use Nuxt's runtime config system (recommended for multi-environment deployments): `NUXT_BETTER_AUTH_SECRET=`
+::
 
 ## For Module Authors
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -100,7 +100,12 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
 
     // Server-only: secret validation
     if (!clientOnly) {
-      const betterAuthSecret = process.env.BETTER_AUTH_SECRET || process.env.NUXT_BETTER_AUTH_SECRET || (nuxt.options.runtimeConfig.betterAuthSecret as string) || ''
+      // Map BETTER_AUTH_SECRET to runtimeConfig for runtime support
+      // Priority: runtimeConfig (nuxt.config or NUXT_BETTER_AUTH_SECRET) > BETTER_AUTH_SECRET
+      const currentSecret = nuxt.options.runtimeConfig.betterAuthSecret as string | undefined
+      nuxt.options.runtimeConfig.betterAuthSecret = currentSecret || process.env.BETTER_AUTH_SECRET || ''
+
+      const betterAuthSecret = nuxt.options.runtimeConfig.betterAuthSecret as string
 
       if (!nuxt.options.dev && !betterAuthSecret) {
         throw new Error('[nuxt-better-auth] BETTER_AUTH_SECRET is required in production. Set BETTER_AUTH_SECRET or NUXT_BETTER_AUTH_SECRET environment variable.')
@@ -108,8 +113,6 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
       if (betterAuthSecret && betterAuthSecret.length < 32) {
         throw new Error('[nuxt-better-auth] BETTER_AUTH_SECRET must be at least 32 characters for security')
       }
-
-      nuxt.options.runtimeConfig.betterAuthSecret = betterAuthSecret
 
       nuxt.options.runtimeConfig.auth = defu(nuxt.options.runtimeConfig.auth as Record<string, unknown>, {
         secondaryStorage: secondaryStorageEnabled,


### PR DESCRIPTION
Fixes #55

## Problem
`BETTER_AUTH_SECRET` only worked at build time via `process.env`, not runtime.

## Context
- Nuxt auto-maps `NUXT_BETTER_AUTH_SECRET` → `runtimeConfig.betterAuthSecret` ✅
- `BETTER_AUTH_SECRET` was only read from `process.env` at build time ❌

**What we had:** Only build-time support for `BETTER_AUTH_SECRET`
**Current problem:** Runtime deploys can't use `BETTER_AUTH_SECRET`
**How this fix handles both:** Maps `BETTER_AUTH_SECRET` to runtimeConfig manually, preserving Nuxt auto-mapping for `NUXT_BETTER_AUTH_SECRET`

## Solution
Map `BETTER_AUTH_SECRET` to `runtimeConfig.betterAuthSecret` so it works at runtime.

**Precedence:**
1. User's `nuxt.config.ts` runtimeConfig (highest)
2. `NUXT_BETTER_AUTH_SECRET` (Nuxt auto-mapped)
3. `BETTER_AUTH_SECRET` (manually mapped)

## Changes
- `src/module.ts:103-106`: Map `BETTER_AUTH_SECRET` to runtimeConfig
- `src/module.ts:108`: Read secret from runtimeConfig only
- Removed redundant `runtimeConfig.betterAuthSecret` assignment

## Testing
- ✅ Module tests pass
- ✅ Works with `BETTER_AUTH_SECRET` in .env
- ✅ Works with `NUXT_BETTER_AUTH_SECRET` in .env
- ✅ Build succeeds