### PR TITLE
refactor: use nuxt-site-config's getNitroOrigin logic

### DIFF
--- a/test/get-base-url.test.ts
+++ b/test/get-base-url.test.ts
@@ -1,3 +1,4 @@
+import { withoutProtocol } from 'ufo'
 import { describe, expect, it } from 'vitest'
 
 function validateURL(url: string): string {
@@ -9,14 +10,72 @@ function validateURL(url: string): string {
   }
 }
 
-// Recreate getBaseURL logic for unit testing (not exported from module)
-function getBaseURL(config: { public: { siteUrl?: unknown } }, requestURL: string | undefined, env: NodeJS.ProcessEnv, isDev: boolean): string {
+interface GetNitroOriginOptions {
+  isDev: boolean
+  isPrerender: boolean
+  env: Partial<Record<string, string>>
+  requestHost?: string
+  requestProtocol?: string
+}
+
+/**
+ * Mock of getNitroOrigin for unit testing.
+ * Adapted from nuxt-site-config by @harlan-zw
+ * @see https://github.com/harlan-zw/nuxt-site-config/blob/main/packages/kit/src/util.ts
+ */
+function getNitroOrigin(options: GetNitroOriginOptions): string | undefined {
+  const { isDev, isPrerender, env, requestHost, requestProtocol } = options
+  const cert = env.NITRO_SSL_CERT
+  const key = env.NITRO_SSL_KEY
+  let host: string | undefined = env.NITRO_HOST || env.HOST
+  let port: string | undefined
+  if (isDev)
+    port = env.NITRO_PORT || env.PORT || '3000'
+  let protocol = (cert && key) || !isDev ? 'https' : 'http'
+
+  try {
+    if ((isDev || isPrerender) && env.__NUXT_DEV__) {
+      const origin = JSON.parse(env.__NUXT_DEV__).proxy.url
+      host = withoutProtocol(origin)
+      protocol = origin.includes('https') ? 'https' : 'http'
+    }
+    else if ((isDev || isPrerender) && env.NUXT_VITE_NODE_OPTIONS) {
+      const origin = JSON.parse(env.NUXT_VITE_NODE_OPTIONS).baseURL.replace('/__nuxt_vite_node__', '')
+      host = withoutProtocol(origin)
+      protocol = origin.includes('https') ? 'https' : 'http'
+    }
+    else if (requestHost) {
+      host = requestHost || host
+      protocol = requestProtocol || protocol
+    }
+  }
+  catch {
+    // JSON parse failed, continue with env fallbacks
+  }
+
+  if (!host)
+    return undefined
+
+  if (host.includes(':') && !host.startsWith('[')) {
+    const hostParts = host.split(':')
+    port = hostParts.pop()
+    host = hostParts.join(':')
+  }
+
+  const portSuffix = port ? `:${port}` : ''
+  return `${protocol}://${host}${portSuffix}`
+}
+
+// Mock of getBaseURL logic for unit testing
+function getBaseURL(config: { public: { siteUrl?: unknown } }, nitroOriginOptions: GetNitroOriginOptions): string {
   if (config.public.siteUrl && typeof config.public.siteUrl === 'string')
     return validateURL(config.public.siteUrl)
 
-  if (requestURL)
-    return requestURL
+  const nitroOrigin = getNitroOrigin(nitroOriginOptions)
+  if (nitroOrigin)
+    return validateURL(nitroOrigin)
 
+  const env = nitroOriginOptions.env
   if (env.VERCEL_URL)
     return validateURL(`https://${env.VERCEL_URL}`)
   if (env.CF_PAGES_URL)
@@ -24,7 +83,7 @@ function getBaseURL(config: { public: { siteUrl?: unknown } }, requestURL: strin
   if (env.URL)
     return validateURL(env.URL.startsWith('http') ? env.URL : `https://${env.URL}`)
 
-  if (isDev)
+  if (nitroOriginOptions.isDev)
     return 'http://localhost:3000'
 
   throw new Error('siteUrl required. Set NUXT_PUBLIC_SITE_URL.')
@@ -32,35 +91,63 @@ function getBaseURL(config: { public: { siteUrl?: unknown } }, requestURL: strin
 
 describe('getBaseURL', () => {
   it('explicit config takes priority', () => {
-    expect(getBaseURL({ public: { siteUrl: 'https://explicit.com' } }, 'https://request.com', { VERCEL_URL: 'x.vercel.app' } as NodeJS.ProcessEnv, false)).toBe('https://explicit.com')
+    expect(getBaseURL({ public: { siteUrl: 'https://explicit.com' } }, { isDev: false, isPrerender: false, env: {}, requestHost: 'request.com', requestProtocol: 'https' })).toBe('https://explicit.com')
   })
 
-  it('requestURL takes priority over platform vars', () => {
-    expect(getBaseURL({ public: {} }, 'https://myapp.com', { VERCEL_URL: 'x.vercel.app' } as NodeJS.ProcessEnv, false)).toBe('https://myapp.com')
+  it('requestHost used when no explicit config', () => {
+    expect(getBaseURL({ public: {} }, { isDev: false, isPrerender: false, env: {}, requestHost: 'myapp.com', requestProtocol: 'https' })).toBe('https://myapp.com')
   })
 
-  it('platform env vars used when no requestURL', () => {
-    expect(getBaseURL({ public: {} }, undefined, { VERCEL_URL: 'x.vercel.app' } as NodeJS.ProcessEnv, false)).toBe('https://x.vercel.app')
+  it('uses NITRO_HOST/PORT in dev mode', () => {
+    expect(getBaseURL({ public: {} }, { isDev: true, isPrerender: false, env: { NITRO_HOST: 'localhost', NITRO_PORT: '3000' } })).toBe('http://localhost:3000')
   })
 
-  it('normalizes URL without protocol', () => {
-    expect(getBaseURL({ public: {} }, undefined, { URL: 'my-app.netlify.app' } as NodeJS.ProcessEnv, false)).toBe('https://my-app.netlify.app')
-    expect(getBaseURL({ public: {} }, undefined, { URL: 'http://localhost:8888' } as NodeJS.ProcessEnv, false)).toBe('http://localhost:8888')
+  it('dev mode defaults to port 3000', () => {
+    expect(getBaseURL({ public: {} }, { isDev: true, isPrerender: false, env: { HOST: 'localhost' } })).toBe('http://localhost:3000')
   })
 
-  it('dev fallback to localhost', () => {
-    expect(getBaseURL({ public: {} }, undefined, {} as NodeJS.ProcessEnv, true)).toBe('http://localhost:3000')
+  it('uses https with SSL certs', () => {
+    expect(getBaseURL({ public: {} }, { isDev: true, isPrerender: false, env: { HOST: 'localhost', NITRO_SSL_CERT: 'cert', NITRO_SSL_KEY: 'key' } })).toBe('https://localhost:3000')
+  })
+
+  it('parses __NUXT_DEV__ in dev mode', () => {
+    const nuxtDev = JSON.stringify({ proxy: { url: 'http://localhost:3000' } })
+    expect(getBaseURL({ public: {} }, { isDev: true, isPrerender: false, env: { __NUXT_DEV__: nuxtDev } })).toBe('http://localhost:3000')
+  })
+
+  it('handles malformed __NUXT_DEV__ gracefully', () => {
+    expect(getBaseURL({ public: {} }, { isDev: true, isPrerender: false, env: { __NUXT_DEV__: 'not-json', HOST: 'localhost' } })).toBe('http://localhost:3000')
+  })
+
+  it('falls back to VERCEL_URL when no host detected', () => {
+    expect(getBaseURL({ public: {} }, { isDev: false, isPrerender: false, env: { VERCEL_URL: 'my-app.vercel.app' } })).toBe('https://my-app.vercel.app')
+  })
+
+  it('falls back to CF_PAGES_URL when no host detected', () => {
+    expect(getBaseURL({ public: {} }, { isDev: false, isPrerender: false, env: { CF_PAGES_URL: 'my-app.pages.dev' } })).toBe('https://my-app.pages.dev')
+  })
+
+  it('falls back to URL env var', () => {
+    expect(getBaseURL({ public: {} }, { isDev: false, isPrerender: false, env: { URL: 'https://my-app.netlify.app' } })).toBe('https://my-app.netlify.app')
+  })
+
+  it('dev fallback to localhost when no host', () => {
+    expect(getBaseURL({ public: {} }, { isDev: true, isPrerender: false, env: {} })).toBe('http://localhost:3000')
   })
 
   it('throws in production without config', () => {
-    expect(() => getBaseURL({ public: {} }, undefined, {} as NodeJS.ProcessEnv, false)).toThrow('siteUrl required')
+    expect(() => getBaseURL({ public: {} }, { isDev: false, isPrerender: false, env: {} })).toThrow('siteUrl required')
   })
 
   it('ignores non-string siteUrl', () => {
-    expect(getBaseURL({ public: { siteUrl: 123 } }, undefined, { VERCEL_URL: 'x.vercel.app' } as NodeJS.ProcessEnv, false)).toBe('https://x.vercel.app')
+    expect(getBaseURL({ public: { siteUrl: 123 } }, { isDev: true, isPrerender: false, env: { HOST: 'localhost' } })).toBe('http://localhost:3000')
   })
 
   it('throws on invalid URL format', () => {
-    expect(() => getBaseURL({ public: { siteUrl: 'not-a-url' } }, undefined, {} as NodeJS.ProcessEnv, false)).toThrow('Invalid siteUrl')
+    expect(() => getBaseURL({ public: { siteUrl: 'not-a-url' } }, { isDev: false, isPrerender: false, env: {} })).toThrow('Invalid siteUrl')
+  })
+
+  it('handles IPv6 addresses', () => {
+    expect(getBaseURL({ public: {} }, { isDev: false, isPrerender: false, env: {}, requestHost: '[::1]:3000', requestProtocol: 'http' })).toBe('http://[::1]:3000')
   })
 })


### PR DESCRIPTION
**Before**: Custom URL detection with platform-specific env vars (VERCEL_URL, CF_PAGES_URL, URL)

**After**: Battle-tested `getNitroOrigin` from nuxt-site-config with:
- Dev proxy handling (`__NUXT_DEV__`, `NUXT_VITE_NODE_OPTIONS`)
- Explicit `xForwardedHost`/`xForwardedProto` for reverse proxies
- SSL detection (`NITRO_SSL_CERT/KEY`)

Attribution link included in code.