### PR TITLE
docs: add custom tables with FK to auth tables

### DIFF
--- a/docs/content/4.integrations/1.nuxthub.md
+++ b/docs/content/4.integrations/1.nuxthub.md
@@ -134,3 +134,63 @@ export default defineServerAuth(({ db }) => ({
   // db is the Drizzle instance from NuxtHub
 }))
 ```
+
+## Creating Custom Tables with Foreign Keys
+
+Create application tables that reference auth tables by importing `schema` from `hub:db`. NuxtHub automatically merges your custom schemas with Better Auth tables.
+
+```ts [server/db/schema.ts]
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core'
+import { schema } from 'hub:db'
+
+export const posts = sqliteTable('posts', {
+  id: text('id').primaryKey(),
+  title: text('title').notNull(),
+  authorId: text('author_id').notNull()
+    .references(() => schema.user.id),
+  createdAt: integer('created_at', { mode: 'timestamp' })
+    .$defaultFn(() => new Date()),
+})
+```
+
+### Available Auth Tables
+
+Reference these tables via the `schema` object:
+
+- `schema.user` - User accounts
+- `schema.session` - Active sessions
+- `schema.account` - OAuth provider accounts
+- `schema.verification` - Email verification tokens
+- Plugin tables: `schema.passkey`, `schema.twoFactor`, etc. (based on enabled plugins)
+
+### ID Type Matching
+
+Match your auth table ID types in foreign keys:
+
+- **SQLite/MySQL**: Use `text()` or `varchar()`
+- **PostgreSQL with UUID**: Use `uuid()` when `advanced.database.generateId = 'uuid'`
+
+::callout{icon="i-lucide-book" to="https://orm.drizzle.team/docs/schemas"}
+See [Drizzle schemas](https://orm.drizzle.team/docs/schemas) for full schema definition guide.
+::
+
+### Migrations
+
+Generate and apply migrations after schema changes:
+
+```bash
+npx nuxt db generate  # Generate migrations
+npx nuxt db migrate   # Apply (automatic in dev)
+```
+
+::warning
+Restart dev server after adding schemas in `server/db/` for NuxtHub to discover them.
+::
+
+### Adding Columns to Auth Tables
+
+To add fields to existing auth tables (e.g., `role` on `user`), use Better Auth's `additionalFields` instead of custom schemas.
+
+::callout{icon="i-lucide-plus" to="https://better-auth.com/docs/concepts/database#additional-fields"}
+See [Better Auth Additional Fields](https://better-auth.com/docs/concepts/database#additional-fields).
+::


### PR DESCRIPTION
## Before
NuxtHub docs lacked guidance on creating custom tables that reference auth tables via foreign keys.

## Expected
Users need to know how to create app-specific tables (e.g., posts) with foreign keys to auth tables (e.g., user.id).

## Changes
- Add "Creating Custom Tables with Foreign Keys" section to NuxtHub integration docs
- Show `import { schema } from 'hub:db'` pattern for referencing auth tables
- List available auth tables (user, session, account, verification, plugins)
- Link to Drizzle docs for schema syntax details
- Add migration instructions
- Cross-reference Better Auth docs for adding columns to existing tables