### PR TITLE
docs: use @alpha tag for install commands

### DIFF
--- a/docs/app/components/content/landing/LandingHero.vue
+++ b/docs/app/components/content/landing/LandingHero.vue
@@ -76,7 +76,7 @@ function getCodeBlock(tab: { name: string, code: string }) {
                     <span class="italic text-amber-600">x</span>
                   </p>
                   <p class="relative inline tracking-tight opacity-90 md:text-sm text-xs dark:text-white font-mono text-black select-all">
-                    npx nuxi module add <span class="relative dark:text-fuchsia-300 text-fuchsia-800">@onmax/nuxt-better-auth</span>
+                    npx nuxi module add <span class="relative dark:text-fuchsia-300 text-fuchsia-800">@onmax/nuxt-better-auth@alpha</span>
                   </p>
                 </div>
                 <div class="flex gap-2 items-center">

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -16,18 +16,18 @@ navigation.icon: i-lucide-download
 
 ::code-group{sync="pm"}
 ```bash [pnpm]
-pnpm add @onmax/nuxt-better-auth better-auth
+pnpm add @onmax/nuxt-better-auth@alpha better-auth
 ```
 ```bash [npm]
-npm install @onmax/nuxt-better-auth better-auth
+npm install @onmax/nuxt-better-auth@alpha better-auth
 ```
 ```bash [yarn]
-yarn add @onmax/nuxt-better-auth better-auth
+yarn add @onmax/nuxt-better-auth@alpha better-auth
 ```
 ::
 
 ::tip
-You can also run `npx nuxi module add @onmax/nuxt-better-auth` to auto-inject the module into `nuxt.config.ts`.
+You can also run `npx nuxi module add @onmax/nuxt-better-auth@alpha` to auto-inject the module into `nuxt.config.ts`.
 ::
 
 ::warning


### PR DESCRIPTION
Fixes #60

The `latest` tag points to a broken build. This updates docs to use `@alpha` until stable is fixed.