### PR TITLE
fix: secondaryStorage mock value type (string)

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -360,7 +360,7 @@ async function setupBetterAuthSchema(nuxt: Nuxt, serverConfigPath: string, optio
       ...userConfig,
       plugins,
       secondaryStorage: options.secondaryStorage
-        ? { get: async (_key: string) => null, set: async (_key: string, _value: unknown, _ttl?: number) => {}, delete: async (_key: string) => {} }
+        ? { get: async (_key: string) => null, set: async (_key: string, _value: string, _ttl?: number) => {}, delete: async (_key: string) => {} }
         : undefined,
     }
 


### PR DESCRIPTION
Fixes #63

**Before**: `_value: unknown` (imprecise type)
**Expected**: `_value: string` (matches better-auth SecondaryStorage interface)
**Change**: Updated type in secondaryStorage mock at `src/module.ts:363`