### PR TITLE
feat: i18n integration

### DIFF
--- a/docs/app/composables/useSidebarConfig.ts
+++ b/docs/app/composables/useSidebarConfig.ts
@@ -59,6 +59,7 @@ export function useSidebarConfig() {
       items: [
         { title: 'NuxtHub', href: '/integrations/nuxthub', icon: 'i-simple-icons-nuxtdotjs' },
         { title: 'DevTools', href: '/integrations/devtools', icon: 'i-solar-tuning-square-bold' },
+        { title: 'i18n', href: '/integrations/i18n', icon: 'i-lucide-languages' },
       ],
     },
     {

--- a/docs/content/4.integrations/0.index.md
+++ b/docs/content/4.integrations/0.index.md
@@ -14,4 +14,7 @@ This module works standalone, but integrates with other tools for enhanced funct
   ::card{title="DevTools" icon="i-simple-icons-nuxtdotjs" to="/integrations/devtools"}
   Inspect auth config and manage users/sessions during development.
   ::
+  ::card{title="i18n" icon="i-lucide-languages" to="/integrations/i18n"}
+  Translate auth errors with @nuxtjs/i18n integration.
+  ::
 ::

--- a/docs/content/4.integrations/3.i18n.md
+++ b/docs/content/4.integrations/3.i18n.md
@@ -1,0 +1,143 @@
+---
+title: i18n
+description: Translate authentication errors with @nuxtjs/i18n.
+---
+
+Translate auth errors with your existing `@nuxtjs/i18n` setup. Auto-detects the module and reads its cookie config - no additional configuration needed.
+
+## Setup
+
+::steps
+
+### Install @nuxtjs/i18n
+
+```bash
+pnpm add @nuxtjs/i18n
+```
+
+### Configure nuxt.config.ts
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/i18n', '@onmax/nuxt-better-auth'],
+  i18n: {
+    locales: ['en', 'es'],
+    defaultLocale: 'en'
+  }
+})
+```
+
+::
+
+## Translation Files
+
+Add error translations to your locale files using the `auth.errors.*` prefix:
+
+::code-group
+
+```yaml [locales/en.yaml]
+auth:
+  errors:
+    USER_NOT_FOUND: "User not found"
+    INVALID_PASSWORD: "Invalid password"
+    INVALID_EMAIL_OR_PASSWORD: "Invalid email or password"
+    EMAIL_NOT_VERIFIED: "Please verify your email first"
+    SESSION_EXPIRED: "Session expired, please sign in again"
+```
+
+```yaml [locales/es.yaml]
+auth:
+  errors:
+    USER_NOT_FOUND: "Usuario no encontrado"
+    INVALID_PASSWORD: "Contraseña incorrecta"
+    INVALID_EMAIL_OR_PASSWORD: "Email o contraseña incorrectos"
+    EMAIL_NOT_VERIFIED: "Por favor verifica tu email primero"
+    SESSION_EXPIRED: "Sesión expirada, inicia sesión de nuevo"
+```
+
+::
+
+## Client-Side Error Handling
+
+Better Auth errors include a `code` property that you can translate using `useI18n()`:
+
+```vue [pages/login.vue]
+<script setup lang="ts">
+const { signIn } = useUserSession()
+const { t, te } = useI18n()
+const error = ref<{ code?: string, message?: string } | null>(null)
+
+async function handleLogin(email: string, password: string) {
+  await signIn.email(
+    { email, password },
+    {
+      onError: (ctx) => {
+        error.value = ctx.error
+      }
+    }
+  )
+}
+
+function getErrorMessage(err: { code?: string, message?: string }) {
+  const key = `auth.errors.${err.code}`
+  return te(key) ? t(key) : err.message
+}
+</script>
+
+<template>
+  <div v-if="error" class="error">{{ getErrorMessage(error) }}</div>
+</template>
+```
+
+The `getErrorMessage` helper checks if a translation exists for the error code. If not, it falls back to the default English message from Better Auth.
+
+## Server-Side Locale Detection
+
+For auth config callbacks like `sendResetPassword`, parse the `Accept-Language` header to determine the user's locale:
+
+```ts [server/auth.config.ts]
+export default defineServerAuth(() => ({
+  emailAndPassword: {
+    enabled: true,
+    sendResetPassword: async ({ user, url }, request) => {
+      const acceptLang = request.headers.get('accept-language') || 'en'
+      const locale = acceptLang.slice(0, 2)
+
+      // Use locale for email content...
+    }
+  }
+}))
+```
+
+## Configuration
+
+The i18n integration is auto-enabled when `@nuxtjs/i18n` is detected and reads its `detectBrowserLanguage.cookieKey` config. To disable it:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  auth: { i18n: false }
+})
+```
+
+## Error Codes Reference
+
+| Code | Default Message |
+|------|-----------------|
+| `USER_NOT_FOUND` | User not found |
+| `INVALID_PASSWORD` | Invalid password |
+| `INVALID_EMAIL_OR_PASSWORD` | Invalid email or password |
+| `EMAIL_NOT_VERIFIED` | Email not verified |
+| `SESSION_EXPIRED` | Session expired |
+| `INVALID_TOKEN` | Invalid token |
+| `USER_ALREADY_EXISTS` | User already exists |
+| `INVALID_EMAIL` | Invalid email |
+| `PASSWORD_TOO_SHORT` | Password too short |
+| `RATE_LIMIT_EXCEEDED` | Too many requests |
+
+::callout{icon="i-lucide-book" to="https://www.better-auth.com/docs/concepts/error-handling"}
+See [Better Auth Error Handling](https://www.better-auth.com/docs/concepts/error-handling) for the complete list of error codes.
+::
+
+::callout{icon="i-lucide-globe" to="https://github.com/better-auth/better-auth-localization"}
+For comprehensive translations, see [better-auth-localization](https://github.com/better-auth/better-auth-localization) plugin with 30+ languages.
+::

--- a/docs/content/5.api/2.server-utils.md
+++ b/docs/content/5.api/2.server-utils.md
@@ -112,3 +112,28 @@ export default defineEventHandler(async (event) => {
   return getTeamSettings(teamId)
 })
 ```
+
+## getLocale
+
+Returns the user's locale from the `@nuxtjs/i18n` context or locale cookie. Useful for sending localized emails.
+
+```ts [server/api/send-email.ts]
+export default defineEventHandler(async (event) => {
+  const locale = getLocale(event) || 'en'
+
+  await sendEmail({
+    subject: locale === 'es' ? 'Bienvenido' : 'Welcome',
+    // ...
+  })
+})
+```
+
+**Returns:**
+- Detected locale string (e.g., `'en'`, `'es'`, `'fr'`)
+- `undefined` if i18n integration is not enabled
+
+::note
+Requires `@nuxtjs/i18n` to be installed and i18n integration enabled.
+::
+
+:read-more{to="/integrations/i18n" title="i18n Integration"}

--- a/src/module.ts
+++ b/src/module.ts
@@ -72,6 +72,15 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
     const hub = hasNuxtHub ? (nuxt.options as { hub?: NuxtHubOptions }).hub : undefined
     const hasHubDb = !clientOnly && hasNuxtHub && !!hub?.db
 
+    // i18n integration - auto-detect @nuxtjs/i18n and read its cookie config
+    const hasI18n = hasNuxtModule('@nuxtjs/i18n', nuxt)
+    const i18nEnabled = !clientOnly && options.i18n !== false && hasI18n
+    const i18nCookie = (nuxt.options as any).i18n?.detectBrowserLanguage?.cookieKey || 'i18n_redirected'
+
+    if (i18nEnabled) {
+      consola.info('i18n integration enabled with @nuxtjs/i18n')
+    }
+
     let secondaryStorageEnabled = options.secondaryStorage ?? false
     if (secondaryStorageEnabled && clientOnly) {
       consola.warn('secondaryStorage is not available in clientOnly mode. Disabling.')
@@ -116,7 +125,8 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
 
       nuxt.options.runtimeConfig.auth = defu(nuxt.options.runtimeConfig.auth as Record<string, unknown>, {
         secondaryStorage: secondaryStorageEnabled,
-      }) as { secondaryStorage: boolean }
+        ...(i18nEnabled && { i18n: { enabled: true, cookie: i18nCookie } }),
+      }) as { secondaryStorage: boolean, i18n?: { enabled: boolean, cookie: string } }
     }
 
     nuxt.options.alias['#nuxt-better-auth'] = resolver.resolve('./runtime/types/augment')
@@ -165,6 +175,41 @@ export const db = undefined`
 
       const databaseTemplate = addTemplate({ filename: 'better-auth/database.mjs', getContents: () => databaseCode, write: true })
       nuxt.options.alias['#auth/database'] = databaseTemplate.dst
+
+      // i18n locale detection template - uses cookie and Accept-Language header
+      const i18nCode = i18nEnabled
+        ? `import { getCookie, getHeader } from 'h3'
+import { useRuntimeConfig } from 'nitropack/runtime'
+
+export function getLocale(event) {
+  if (!event) return undefined
+  const config = useRuntimeConfig().auth?.i18n
+  if (!config?.enabled) return undefined
+  // 1. Check locale cookie (set by nuxt-i18n)
+  const cookieLocale = getCookie(event, config.cookie)
+  if (cookieLocale) return cookieLocale
+  // 2. Parse Accept-Language header
+  const acceptLang = getHeader(event, 'accept-language')
+  if (acceptLang) {
+    const match = acceptLang.match(/^([a-z]{2})/)
+    if (match) return match[1]
+  }
+  return undefined
+}`
+        : `export function getLocale() { return undefined }`
+
+      const i18nTemplate = addTemplate({ filename: 'better-auth/i18n.mjs', getContents: () => i18nCode, write: true })
+      nuxt.options.alias['#auth/i18n'] = i18nTemplate.dst
+
+      addTypeTemplate({
+        filename: 'types/auth-i18n.d.ts',
+        getContents: () => `
+declare module '#auth/i18n' {
+  import type { H3Event } from 'h3'
+  export function getLocale(event?: H3Event): string | undefined
+}
+`,
+      }, { nitro: true, node: true })
 
       addTypeTemplate({
         filename: 'types/auth-secondary-storage.d.ts',

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -37,6 +37,8 @@ export interface BetterAuthModuleOptions {
     /** Column/table name casing. Explicit value takes precedence over hub.db.casing. */
     casing?: CasingOption
   }
+  /** Disable i18n integration. Auto-enabled when @nuxtjs/i18n is detected. */
+  i18n?: false
 }
 
 // Runtime config type for public.auth
@@ -49,6 +51,7 @@ export interface AuthRuntimeConfig {
 // Private runtime config (server-only)
 export interface AuthPrivateRuntimeConfig {
   secondaryStorage: boolean
+  i18n?: { enabled: boolean, cookie: string }
 }
 
 export function defineServerAuth<T extends ServerAuthConfig>(config: (ctx: ServerAuthContext) => T): (ctx: ServerAuthContext) => T {

--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -1,6 +1,7 @@
 import type { Auth } from 'better-auth'
 import type { H3Event } from 'h3'
 import { createDatabase, db } from '#auth/database'
+import { getLocale } from '#auth/i18n'
 import { createSecondaryStorage } from '#auth/secondary-storage'
 import createServerAuth from '#auth/server'
 import { betterAuth } from 'better-auth'
@@ -116,3 +117,5 @@ export function serverAuth(event?: H3Event): AuthInstance {
 
   return _auth
 }
+
+export { getLocale }


### PR DESCRIPTION
Adds core i18n support with @nuxtjs/i18n auto-detection.

**Changes:**
- Auto-detect i18n module and inject locale into auth context
- Export `getLocale` helper from server utils
- Add i18n integration docs

**Before:** No i18n support
**After:** Better Auth respects @nuxtjs/i18n locale settings