### PR TITLE
refactor: remove redundant getLocale util

### DIFF
--- a/docs/content/4.integrations/3.i18n.md
+++ b/docs/content/4.integrations/3.i18n.md
@@ -3,7 +3,7 @@ title: i18n
 description: Translate authentication errors with @nuxtjs/i18n.
 ---
 
-Translate auth errors with your existing `@nuxtjs/i18n` setup. Auto-detects the module and reads its cookie config - no additional configuration needed.
+This integration enables translated authentication error messages using your existing `@nuxtjs/i18n` setup.
 
 ## Setup
 
@@ -93,30 +93,27 @@ The `getErrorMessage` helper checks if a translation exists for the error code. 
 
 ## Server-Side Locale Detection
 
-For auth config callbacks like `sendResetPassword`, parse the `Accept-Language` header to determine the user's locale:
+For auth config callbacks like `sendResetPassword`, use `@intlify/utils/h3` to detect the user's locale:
+
+::note
+`@intlify/utils` is installed as a dependency of `@nuxtjs/i18n`, but you need to import it explicitly in server code.
+::
 
 ```ts [server/auth.config.ts]
+import { tryCookieLocale, tryHeaderLocale } from '@intlify/utils/h3'
+
 export default defineServerAuth(() => ({
   emailAndPassword: {
     enabled: true,
     sendResetPassword: async ({ user, url }, request) => {
-      const acceptLang = request.headers.get('accept-language') || 'en'
-      const locale = acceptLang.slice(0, 2)
+      const locale = tryCookieLocale(request)?.toString()
+        ?? tryHeaderLocale(request)?.toString()
+        ?? 'en'
 
       // Use locale for email content...
     }
   }
 }))
-```
-
-## Configuration
-
-The i18n integration is auto-enabled when `@nuxtjs/i18n` is detected and reads its `detectBrowserLanguage.cookieKey` config. To disable it:
-
-```ts [nuxt.config.ts]
-export default defineNuxtConfig({
-  auth: { i18n: false }
-})
 ```
 
 ## Error Codes Reference

--- a/docs/content/5.api/2.server-utils.md
+++ b/docs/content/5.api/2.server-utils.md
@@ -113,27 +113,3 @@ export default defineEventHandler(async (event) => {
 })
 ```
 
-## getLocale
-
-Returns the user's locale from the `@nuxtjs/i18n` context or locale cookie. Useful for sending localized emails.
-
-```ts [server/api/send-email.ts]
-export default defineEventHandler(async (event) => {
-  const locale = getLocale(event) || 'en'
-
-  await sendEmail({
-    subject: locale === 'es' ? 'Bienvenido' : 'Welcome',
-    // ...
-  })
-})
-```
-
-**Returns:**
-- Detected locale string (e.g., `'en'`, `'es'`, `'fr'`)
-- `undefined` if i18n integration is not enabled
-
-::note
-Requires `@nuxtjs/i18n` to be installed and i18n integration enabled.
-::
-
-:read-more{to="/integrations/i18n" title="i18n Integration"}

--- a/src/module.ts
+++ b/src/module.ts
@@ -72,15 +72,6 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
     const hub = hasNuxtHub ? (nuxt.options as { hub?: NuxtHubOptions }).hub : undefined
     const hasHubDb = !clientOnly && hasNuxtHub && !!hub?.db
 
-    // i18n integration - auto-detect @nuxtjs/i18n and read its cookie config
-    const hasI18n = hasNuxtModule('@nuxtjs/i18n', nuxt)
-    const i18nEnabled = !clientOnly && options.i18n !== false && hasI18n
-    const i18nCookie = (nuxt.options as any).i18n?.detectBrowserLanguage?.cookieKey || 'i18n_redirected'
-
-    if (i18nEnabled) {
-      consola.info('i18n integration enabled with @nuxtjs/i18n')
-    }
-
     let secondaryStorageEnabled = options.secondaryStorage ?? false
     if (secondaryStorageEnabled && clientOnly) {
       consola.warn('secondaryStorage is not available in clientOnly mode. Disabling.')
@@ -125,8 +116,7 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
 
       nuxt.options.runtimeConfig.auth = defu(nuxt.options.runtimeConfig.auth as Record<string, unknown>, {
         secondaryStorage: secondaryStorageEnabled,
-        ...(i18nEnabled && { i18n: { enabled: true, cookie: i18nCookie } }),
-      }) as { secondaryStorage: boolean, i18n?: { enabled: boolean, cookie: string } }
+      }) as { secondaryStorage: boolean }
     }
 
     nuxt.options.alias['#nuxt-better-auth'] = resolver.resolve('./runtime/types/augment')
@@ -175,41 +165,6 @@ export const db = undefined`
 
       const databaseTemplate = addTemplate({ filename: 'better-auth/database.mjs', getContents: () => databaseCode, write: true })
       nuxt.options.alias['#auth/database'] = databaseTemplate.dst
-
-      // i18n locale detection template - uses cookie and Accept-Language header
-      const i18nCode = i18nEnabled
-        ? `import { getCookie, getHeader } from 'h3'
-import { useRuntimeConfig } from 'nitropack/runtime'
-
-export function getLocale(event) {
-  if (!event) return undefined
-  const config = useRuntimeConfig().auth?.i18n
-  if (!config?.enabled) return undefined
-  // 1. Check locale cookie (set by nuxt-i18n)
-  const cookieLocale = getCookie(event, config.cookie)
-  if (cookieLocale) return cookieLocale
-  // 2. Parse Accept-Language header
-  const acceptLang = getHeader(event, 'accept-language')
-  if (acceptLang) {
-    const match = acceptLang.match(/^([a-z]{2})/)
-    if (match) return match[1]
-  }
-  return undefined
-}`
-        : `export function getLocale() { return undefined }`
-
-      const i18nTemplate = addTemplate({ filename: 'better-auth/i18n.mjs', getContents: () => i18nCode, write: true })
-      nuxt.options.alias['#auth/i18n'] = i18nTemplate.dst
-
-      addTypeTemplate({
-        filename: 'types/auth-i18n.d.ts',
-        getContents: () => `
-declare module '#auth/i18n' {
-  import type { H3Event } from 'h3'
-  export function getLocale(event?: H3Event): string | undefined
-}
-`,
-      }, { nitro: true, node: true })
 
       addTypeTemplate({
         filename: 'types/auth-secondary-storage.d.ts',

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -37,8 +37,6 @@ export interface BetterAuthModuleOptions {
     /** Column/table name casing. Explicit value takes precedence over hub.db.casing. */
     casing?: CasingOption
   }
-  /** Disable i18n integration. Auto-enabled when @nuxtjs/i18n is detected. */
-  i18n?: false
 }
 
 // Runtime config type for public.auth
@@ -51,7 +49,6 @@ export interface AuthRuntimeConfig {
 // Private runtime config (server-only)
 export interface AuthPrivateRuntimeConfig {
   secondaryStorage: boolean
-  i18n?: { enabled: boolean, cookie: string }
 }
 
 export function defineServerAuth<T extends ServerAuthConfig>(config: (ctx: ServerAuthContext) => T): (ctx: ServerAuthContext) => T {

--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -1,7 +1,6 @@
 import type { Auth } from 'better-auth'
 import type { H3Event } from 'h3'
 import { createDatabase, db } from '#auth/database'
-import { getLocale } from '#auth/i18n'
 import { createSecondaryStorage } from '#auth/secondary-storage'
 import createServerAuth from '#auth/server'
 import { betterAuth } from 'better-auth'
@@ -117,5 +116,3 @@ export function serverAuth(event?: H3Event): AuthInstance {
 
   return _auth
 }
-
-export { getLocale }


### PR DESCRIPTION
## Summary
- `getLocale` duplicated `@intlify/utils/h3` utilities already auto-imported by `@nuxtjs/i18n`
- Users can use `tryCookieLocale(event)` and `tryHeaderLocale(event)` directly

## Changes
- Remove `getLocale` helper function and template generation
- Remove `auth.i18n` runtime config and module option
- Update docs to use `@intlify/utils/h3` directly