### PR TITLE
dx: consistent config helpers (#77)

### DIFF
--- a/docs/app/components/content/landing/hero.yml
+++ b/docs/app/components/content/landing/hero.yml
@@ -13,26 +13,24 @@ tabs:
       })
   - name: server/auth.config.ts
     code: |
+      import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
       import { admin, twoFactor } from 'better-auth/plugins'
 
-      export default defineServerAuth(() => ({
+      export default defineServerAuth({
         socialProviders: {
           github: { clientId: '...', clientSecret: '...' },
           google: { clientId: '...', clientSecret: '...' },
         },
         plugins: [admin(), twoFactor()],
-      }))
+      })
   - name: app/auth.config.ts
     code: |
+      import { defineClientAuth } from '@onmax/nuxt-better-auth/config'
       import { adminClient, twoFactorClient } from 'better-auth/client/plugins'
-      import { createAuthClient } from 'better-auth/vue'
 
-      export function createAppAuthClient(baseURL: string) {
-        return createAuthClient({
-          baseURL,
-          plugins: [adminClient(), twoFactorClient()],
-        })
-      }
+      export default defineClientAuth({
+        plugins: [adminClient(), twoFactorClient()],
+      })
   - name: pages/login.vue
     code: |
       <script setup lang="ts">

--- a/docs/content/1.getting-started/0.index.md
+++ b/docs/content/1.getting-started/0.index.md
@@ -82,19 +82,17 @@ BETTER_AUTH_SECRET="generate-a-32-char-secret"
 ### Create Config Files
 
 ```ts [server/auth.config.ts]
-import { defineServerAuth } from '@onmax/nuxt-better-auth'
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 
-export default defineServerAuth(() => ({
+export default defineServerAuth({
   emailAndPassword: { enabled: true },
-}))
+})
 ```
 
 ```ts [app/auth.config.ts]
-import { createAuthClient } from 'better-auth/vue'
+import { defineClientAuth } from '@onmax/nuxt-better-auth/config'
 
-export function createAppAuthClient(baseURL: string) {
-  return createAuthClient({ baseURL })
-}
+export default defineClientAuth({})
 ```
 
 ### Run

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -95,19 +95,17 @@ The module requires two configuration files:
 Create these files with the following content:
 
 ```ts [server/auth.config.ts]
-import { defineServerAuth } from '@onmax/nuxt-better-auth'
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 
-export default defineServerAuth(() => ({
+export default defineServerAuth({
   emailAndPassword: { enabled: true }
-}))
+})
 ```
 
 ```ts [app/auth.config.ts]
-import { createAuthClient } from 'better-auth/vue'
+import { defineClientAuth } from '@onmax/nuxt-better-auth/config'
 
-export function createAppAuthClient(baseURL: string) {
-  return createAuthClient({ baseURL })
-}
+export default defineClientAuth({})
 ```
 
 ::

--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -79,18 +79,20 @@ Define your authentication logic in `server/auth.config.ts`, including plugins, 
 
 ### defineServerAuth
 
-Use the `defineServerAuth` helper to ensure type safety and access context.
+Use the `defineServerAuth` helper to ensure type safety and access context. It accepts an object or function syntax.
 
 ```ts [server/auth.config.ts]
-import { defineServerAuth } from '@onmax/nuxt-better-auth'
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 
-export default defineServerAuth(() => {
-  return {
-    emailAndPassword: {
-      enabled: true
-    }
-  }
+// Object syntax (simplest)
+export default defineServerAuth({
+  emailAndPassword: { enabled: true }
 })
+
+// Function syntax (access context)
+export default defineServerAuth((ctx) => ({
+  emailAndPassword: { enabled: true }
+}))
 ```
 
 ::note
@@ -101,10 +103,10 @@ The module automatically injects `secret` and `baseURL`. You don't need to confi
 
 ### Context Options
 
-The `defineServerAuth` callback receives a context object with useful properties:
+When using the function syntax, `defineServerAuth` callback receives a context object with useful properties:
 
 ```ts [server/auth.config.ts]
-import { defineServerAuth } from '@onmax/nuxt-better-auth'
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 
 export default defineServerAuth(({ db, runtimeConfig }) => ({

--- a/docs/content/1.getting-started/3.client-setup.md
+++ b/docs/content/1.getting-started/3.client-setup.md
@@ -4,38 +4,41 @@ description: Configure the client-side authentication client.
 navigation.icon: i-lucide-monitor
 ---
 
-## Create the Client Factory
+## Create the Client Config
 
-Create `app/auth.config.ts` and export a `createAppAuthClient` function.
+Create `app/auth.config.ts` with a default export using `defineClientAuth`.
 
-::note
-This factory function exists because the module needs to inject the correct `baseURL` at runtime. The module calls this function and provides the URL automatically.
-::
+The `defineClientAuth` helper supports two syntaxes: an object for simple configurations, or a function when you need access to context like the resolved site URL.
 
 ```ts [app/auth.config.ts]
-import { createAuthClient } from 'better-auth/vue'
+import { defineClientAuth } from '@onmax/nuxt-better-auth/config'
 
-export function createAppAuthClient(baseURL: string) {
-  return createAuthClient({ baseURL })
-}
+// Object syntax (simplest)
+export default defineClientAuth({})
+
+// Function syntax (access context)
+export default defineClientAuth(({ siteUrl }) => ({
+  // siteUrl contains the resolved base URL
+}))
 ```
+
+::note
+The helper creates a factory function that the module calls with the correct `baseURL` at runtime.
+::
 
 ## Using Plugins
 
 If you added a plugin in your server config (`server/auth.config.ts`), make sure to add its client equivalent here.
 
 ```ts [app/auth.config.ts]
-import { createAuthClient } from 'better-auth/vue'
+import { defineClientAuth } from '@onmax/nuxt-better-auth/config'
 import { adminClient } from 'better-auth/client/plugins'
 
-export function createAppAuthClient(baseURL: string) {
-  return createAuthClient({
-    baseURL,
-    plugins: [
-      adminClient() // Must match the server plugin
-    ]
-  })
-}
+export default defineClientAuth({
+  plugins: [
+    adminClient() // Must match the server plugin
+  ]
+})
 ```
 
 ## Common Plugin Combinations
@@ -43,15 +46,12 @@ export function createAppAuthClient(baseURL: string) {
 ### Admin + Two Factor
 
 ```ts [app/auth.config.ts]
-import { createAuthClient } from 'better-auth/vue'
+import { defineClientAuth } from '@onmax/nuxt-better-auth/config'
 import { adminClient, twoFactorClient } from 'better-auth/client/plugins'
 
-export function createAppAuthClient(baseURL: string) {
-  return createAuthClient({
-    baseURL,
-    plugins: [adminClient(), twoFactorClient()]
-  })
-}
+export default defineClientAuth({
+  plugins: [adminClient(), twoFactorClient()]
+})
 ```
 
 :read-more{to="https://www.better-auth.com/docs/plugins" title="All Better Auth plugins"}

--- a/docs/content/1.getting-started/4.type-augmentation.md
+++ b/docs/content/1.getting-started/4.type-augmentation.md
@@ -20,11 +20,11 @@ If you add the `admin` plugin:
 
 ```ts [server/auth.config.ts]
 import { admin } from 'better-auth/plugins'
-import { defineServerAuth } from '@onmax/nuxt-better-auth'
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 
-export default defineServerAuth(() => ({
+export default defineServerAuth({
   plugins: [admin()]
-}))
+})
 ```
 
 You can immediately access the `role` property in your Vue components:

--- a/docs/content/2.core-concepts/2.sessions.md
+++ b/docs/content/2.core-concepts/2.sessions.md
@@ -95,13 +95,15 @@ const { fetchSession, ready } = useUserSession()
 Configure session duration in your auth config:
 
 ```ts [server/auth.config.ts]
-export default defineServerAuth(() => ({
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
+
+export default defineServerAuth({
   session: {
     cookie: {
       maxAge: 60 * 60 * 24 * 7, // 7 days
     },
   },
-}))
+})
 ```
 
 :read-more{to="/api/components" title="BetterAuthState component"}

--- a/docs/content/2.core-concepts/5.security-caveats.md
+++ b/docs/content/2.core-concepts/5.security-caveats.md
@@ -12,12 +12,14 @@ Client-side redirects improve UX but don't prevent unauthorized access. Always v
 Better Auth performs origin checks for cookie-based requests (it validates `Origin` / `Referer`). If you use multiple domains (custom domains, preview URLs, etc.), add them to `trustedOrigins` in your auth config.
 
 ```ts [server/auth.config.ts]
-export default defineServerAuth(() => ({
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
+
+export default defineServerAuth({
   trustedOrigins: [
     'http://localhost:3000',
     'https://your-domain.com',
   ],
-}))
+})
 ```
 
 ## API enforcement behavior

--- a/docs/content/3.guides/1.role-based-access.md
+++ b/docs/content/3.guides/1.role-based-access.md
@@ -7,7 +7,8 @@ description: Protect routes using generic field matching on AuthUser.
 
 ```ts [server/auth.config.ts]
 import { admin } from 'better-auth/plugins'
-export default defineServerAuth(() => ({ plugins: [admin()] }))
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
+export default defineServerAuth({ plugins: [admin()] })
 
 // nuxt.config.ts - role is now typed!
 routeRules: {

--- a/docs/content/3.guides/2.oauth-providers.md
+++ b/docs/content/3.guides/2.oauth-providers.md
@@ -31,16 +31,16 @@ GOOGLE_CLIENT_SECRET="your-client-secret"
 ### Configure `server/auth.config.ts`
 
 ```ts [server/auth.config.ts]
-import { defineServerAuth } from '@onmax/nuxt-better-auth'
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 
-export default defineServerAuth(() => ({
+export default defineServerAuth({
   socialProviders: {
     google: {
       clientId: process.env.GOOGLE_CLIENT_ID as string,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
     },
   },
-}))
+})
 ```
 
 ### Add a Sign-In Button

--- a/docs/content/3.guides/3.custom-database.md
+++ b/docs/content/3.guides/3.custom-database.md
@@ -16,37 +16,37 @@ Better Auth supports any database through adapters. Use this guide when you need
 ## Drizzle Adapter
 
 ```ts [server/auth.config.ts]
-import { defineServerAuth } from '@onmax/nuxt-better-auth'
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { drizzle } from 'drizzle-orm/node-postgres'
 
 const db = drizzle(process.env.DATABASE_URL!)
 
-export default defineServerAuth(() => ({
+export default defineServerAuth({
   database: drizzleAdapter(db, { provider: 'pg' }),
   emailAndPassword: { enabled: true },
-}))
+})
 ```
 
 ## Prisma Adapter
 
 ```ts [server/auth.config.ts]
-import { defineServerAuth } from '@onmax/nuxt-better-auth'
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 import { prismaAdapter } from 'better-auth/adapters/prisma'
 import { PrismaClient } from '@prisma/client'
 
 const prisma = new PrismaClient()
 
-export default defineServerAuth(() => ({
+export default defineServerAuth({
   database: prismaAdapter(prisma, { provider: 'postgresql' }),
   emailAndPassword: { enabled: true },
-}))
+})
 ```
 
 ## Kysely Adapter
 
 ```ts [server/auth.config.ts]
-import { defineServerAuth } from '@onmax/nuxt-better-auth'
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 import { kyselyAdapter } from 'better-auth/adapters/kysely'
 import { Kysely, PostgresDialect } from 'kysely'
 import { Pool } from 'pg'
@@ -55,10 +55,10 @@ const db = new Kysely({
   dialect: new PostgresDialect({ pool: new Pool({ connectionString: process.env.DATABASE_URL }) }),
 })
 
-export default defineServerAuth(() => ({
+export default defineServerAuth({
   database: kyselyAdapter(db, { dialect: 'postgres', type: 'pg' }),
   emailAndPassword: { enabled: true },
-}))
+})
 ```
 
 ## Schema Setup

--- a/docs/content/3.guides/4.database-less-mode.md
+++ b/docs/content/3.guides/4.database-less-mode.md
@@ -54,7 +54,9 @@ export default defineNuxtConfig({
 Enable JWE sessions and cookie-based OAuth state:
 
 ```ts [server/auth.config.ts]
-export default defineServerAuth(({ runtimeConfig }) => ({
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
+
+export default defineServerAuth({
   socialProviders: {
     github: { clientId: '...', clientSecret: '...' },
   },
@@ -69,7 +71,7 @@ export default defineServerAuth(({ runtimeConfig }) => ({
     storeStateStrategy: 'cookie',
     storeAccountCookie: true,
   },
-}))
+})
 ```
 
 This stores sessions and OAuth state in encrypted cookies instead of a database.

--- a/docs/content/3.guides/5.external-auth-backend.md
+++ b/docs/content/3.guides/5.external-auth-backend.md
@@ -28,18 +28,12 @@ export default defineNuxtConfig({
 ### 2. Configure Client to Point to External Server
 
 ```ts [app/auth.config.ts]
-import { createAuthClient } from 'better-auth/vue'
+import { defineClientAuth } from '@onmax/nuxt-better-auth/config'
 
-export function createAppAuthClient(_baseURL: string) {
-  return createAuthClient({
-    baseURL: 'https://auth.example.com', // Your external auth server (ignores injected _baseURL)
-  })
-}
+export default defineClientAuth({
+  baseURL: 'https://auth.example.com', // Your external auth server
+})
 ```
-
-::note
-The function signature must include `baseURL` for compatibility, but you ignore it and hardcode your external server URL instead.
-::
 
 ### 3. Set Site URL (Optional)
 

--- a/docs/content/3.guides/6.migrate-from-nuxt-auth-utils.md
+++ b/docs/content/3.guides/6.migrate-from-nuxt-auth-utils.md
@@ -57,14 +57,15 @@ export default defineOAuthGitHubEventHandler({
 ```ts
 // nuxt-better-auth - Declarative config
 // server/auth.config.ts
-export default defineServerAuth(() => ({
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
+export default defineServerAuth({
   socialProviders: {
     github: {
       clientId: process.env.NUXT_OAUTH_GITHUB_CLIENT_ID!,
       clientSecret: process.env.NUXT_OAUTH_GITHUB_CLIENT_SECRET!
     }
   }
-}))
+})
 ```
 
 ## Migration Steps
@@ -106,7 +107,9 @@ export default defineOAuthGitHubEventHandler({
 **After:**
 
 ```ts [server/auth.config.ts]
-export default defineServerAuth(() => ({
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
+
+export default defineServerAuth({
   socialProviders: {
     github: {
       clientId: process.env.NUXT_OAUTH_GITHUB_CLIENT_ID!,
@@ -114,7 +117,7 @@ export default defineServerAuth(() => ({
       scope: ['user:email']
     }
   }
-}))
+})
 ```
 
 Delete your OAuth route files (`server/routes/auth/*.ts`) - Better Auth handles routes automatically at `/api/auth/**`.
@@ -246,15 +249,16 @@ Implement a custom password verifier that tries both formats:
 
 ```ts [server/auth.config.ts]
 import { scrypt, timingSafeEqual } from 'node:crypto'
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 
 async function verifyLegacyHash(password: string, hash: string): Promise<boolean> {
   // Implement scrypt verification for legacy hashes
   // Return true if password matches legacy hash
 }
 
-export default defineServerAuth(() => ({
+export default defineServerAuth({
   // Custom verification logic
-}))
+})
 ```
 
 #### Option 3: Gradual Migration

--- a/docs/content/3.guides/7.two-factor-auth.md
+++ b/docs/content/3.guides/7.two-factor-auth.md
@@ -10,10 +10,10 @@ Better Auth ships a `twoFactor` plugin with TOTP, OTP, and backup codes. It requ
 ### Enable the Plugin (Server)
 
 ```ts [server/auth.config.ts]
-import { defineServerAuth } from '@onmax/nuxt-better-auth'
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 import { twoFactor } from 'better-auth/plugins/two-factor'
 
-export default defineServerAuth(() => ({
+export default defineServerAuth({
   emailAndPassword: { enabled: true },
   plugins: [
     twoFactor({
@@ -21,28 +21,25 @@ export default defineServerAuth(() => ({
       totpOptions: { issuer: 'My Nuxt App' },
     }),
   ],
-}))
+})
 ```
 
 ### Register Client Plugin
 
 ```ts [app/auth.config.ts]
 import { navigateTo } from '#imports'
-import { createAuthClient } from 'better-auth/vue'
+import { defineClientAuth } from '@onmax/nuxt-better-auth/config'
 import { twoFactorClient } from 'better-auth/client/plugins'
 
-export function createAppAuthClient(baseURL: string) {
-  return createAuthClient({
-    baseURL,
-    plugins: [
-      twoFactorClient({
-        onTwoFactorRedirect() {
-          navigateTo('/two-factor')
-        },
-      }),
-    ],
-  })
-}
+export default defineClientAuth({
+  plugins: [
+    twoFactorClient({
+      onTwoFactorRedirect() {
+        navigateTo('/two-factor')
+      },
+    }),
+  ],
+})
 ```
 
 ### Enable 2FA for a User (TOTP)

--- a/docs/content/4.integrations/1.nuxthub.md
+++ b/docs/content/4.integrations/1.nuxthub.md
@@ -134,6 +134,8 @@ The module analyzes your `server/auth.config.ts` at build time:
 With NuxtHub, you get access to the Drizzle database instance in your server config:
 
 ```ts [server/auth.config.ts]
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
+
 export default defineServerAuth(({ db }) => ({
   // db is the Drizzle instance from NuxtHub
 }))

--- a/docs/content/4.integrations/3.convex.md
+++ b/docs/content/4.integrations/3.convex.md
@@ -89,14 +89,15 @@ The adapter replaces the standard database configuration in your auth config. Th
 import { components } from '#convex/api'
 import { createClient } from '@convex-dev/better-auth'
 import { convex } from '@convex-dev/better-auth/server/plugins'
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 
 const authComponent = createClient(components.betterAuth)
 
-export default defineServerAuth(() => ({
+export default defineServerAuth({
   database: authComponent.adapter(),
   plugins: [convex()],
   emailAndPassword: { enabled: true },
-}))
+})
 ```
 
 ::callout{icon="i-lucide-book" to="https://github.com/get-convex/convex-better-auth" target="_blank"}

--- a/docs/content/4.integrations/3.i18n.md
+++ b/docs/content/4.integrations/3.i18n.md
@@ -101,6 +101,7 @@ For auth config callbacks like `sendResetPassword`, use `@intlify/utils/h3` to d
 
 ```ts [server/auth.config.ts]
 import { tryCookieLocale, tryHeaderLocale } from '@intlify/utils/h3'
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 
 export default defineServerAuth(() => ({
   emailAndPassword: {

--- a/docs/content/6.troubleshooting/1.faq.md
+++ b/docs/content/6.troubleshooting/1.faq.md
@@ -41,13 +41,15 @@ Yes. Better Auth supports any database with a Drizzle, Prisma, or Kysely adapter
 Configure in Better Auth, then augment types:
 
 ```ts [server/auth.config.ts]
-export default defineServerAuth(() => ({
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
+
+export default defineServerAuth({
   user: {
     additionalFields: {
       role: { type: 'string', defaultValue: 'user' }
     }
   }
-}))
+})
 ```
 
 :read-more{to="https://www.better-auth.com/docs/concepts/users-accounts#additional-fields"}
@@ -79,11 +81,11 @@ Create `server/auth.config.ts` exporting `defineServerAuth(...)`.
 
 ## "Missing app/auth.config.ts"
 
-The module expects a client config file at `app/auth.config.ts` exporting `createAppAuthClient(baseURL)`.
+The module expects a client config file at `app/auth.config.ts` exporting `createAppAuthClient` via `defineClientAuth()`.
 
 ## "auth.config.ts validation failed"
 
-- Ensure the file is **default-exported** and wrapped with `defineServerAuth`.
+- Ensure the file exports `createServerAuth` via `defineServerAuth()`.
 - Do not set `secret`/`baseURL` manually (the module injects these).
 - Confirm the file is at the expected path (default: `server/auth.config.ts`).
 

--- a/playground/app/auth.config.ts
+++ b/playground/app/auth.config.ts
@@ -1,21 +1,18 @@
 import { navigateTo } from '#imports'
 import { passkeyClient } from '@better-auth/passkey/client'
 import { adminClient, lastLoginMethodClient, multiSessionClient, twoFactorClient } from 'better-auth/client/plugins'
-import { createAuthClient } from 'better-auth/vue'
+import { defineClientAuth } from '../../src/runtime/config'
 
-export function createAppAuthClient(baseURL: string) {
-  return createAuthClient({
-    baseURL,
-    plugins: [
-      adminClient(),
-      passkeyClient(),
-      multiSessionClient(),
-      lastLoginMethodClient(),
-      twoFactorClient({
-        onTwoFactorRedirect() {
-          navigateTo('/two-factor')
-        },
-      }),
-    ],
-  })
-}
+export default defineClientAuth({
+  plugins: [
+    adminClient(),
+    passkeyClient(),
+    multiSessionClient(),
+    lastLoginMethodClient(),
+    twoFactorClient({
+      onTwoFactorRedirect() {
+        navigateTo('/two-factor')
+      },
+    }),
+  ],
+})

--- a/skills/nuxt-better-auth/references/client-only.md
+++ b/skills/nuxt-better-auth/references/client-only.md
@@ -18,13 +18,11 @@ export default defineNuxtConfig({
 ### 2. Point client to external server
 
 ```ts [app/auth.config.ts]
-import { createAuthClient } from 'better-auth/vue'
+import { defineClientAuth } from '@onmax/nuxt-better-auth/config'
 
-export function createAppAuthClient(_baseURL: string) {
-  return createAuthClient({
-    baseURL: 'https://auth.example.com', // External auth server
-  })
-}
+export default defineClientAuth({
+  baseURL: 'https://auth.example.com', // External auth server
+})
 ```
 
 ### 3. Set frontend URL

--- a/skills/nuxt-better-auth/references/database.md
+++ b/skills/nuxt-better-auth/references/database.md
@@ -81,7 +81,7 @@ Database adapter injected via context:
 
 ```ts
 // server/auth.config.ts
-import { defineServerAuth } from '#auth/server'
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 
 export default defineServerAuth(({ db }) => ({
   database: db,  // Already configured when hub.database: true
@@ -96,13 +96,13 @@ Without NuxtHub, configure manually:
 ```ts
 // server/auth.config.ts
 import { drizzle } from 'drizzle-orm/...'
-import { defineServerAuth } from '#auth/server'
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 
 const db = drizzle(...)
 
-export default defineServerAuth(() => ({
+export default defineServerAuth({
   database: drizzleAdapter(db, { provider: 'sqlite' })
-}))
+})
 ```
 
 ## Migrations

--- a/skills/nuxt-better-auth/references/installation.md
+++ b/skills/nuxt-better-auth/references/installation.md
@@ -44,18 +44,29 @@ NUXT_PUBLIC_SITE_URL=https://your-domain.com
 
 ```ts
 // server/auth.config.ts
-import { defineServerAuth } from '#auth/server'
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 
-export default defineServerAuth(({ runtimeConfig, db }) => ({
+// Object syntax (simplest)
+export default defineServerAuth({
   emailAndPassword: { enabled: true },
   // OAuth providers
+  socialProviders: {
+    github: {
+      clientId: process.env.GITHUB_CLIENT_ID as string,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET as string
+    }
+  },
+})
+
+// Or function syntax (access context like runtimeConfig, db)
+export default defineServerAuth(({ runtimeConfig, db }) => ({
+  emailAndPassword: { enabled: true },
   socialProviders: {
     github: {
       clientId: runtimeConfig.github.clientId,
       clientSecret: runtimeConfig.github.clientSecret
     }
   },
-  // Session configuration (optional)
   session: {
     expiresIn: 60 * 60 * 24 * 7,      // 7 days (default)
     updateAge: 60 * 60 * 24,           // Update every 24h (default)
@@ -88,11 +99,17 @@ Context available in `defineServerAuth`:
 
 ```ts
 // app/auth.config.ts
-import { createAppAuthClient } from '#auth/client'
+import { defineClientAuth } from '@onmax/nuxt-better-auth/config'
 
-export default createAppAuthClient({
+// Object syntax (simplest)
+export default defineClientAuth({
   // Client-side plugin options (e.g., passkey, twoFactor)
 })
+
+// Or function syntax (access context like siteUrl)
+export default defineClientAuth(({ siteUrl }) => ({
+  // siteUrl contains the resolved base URL
+}))
 ```
 
 ## NuxtHub Integration

--- a/skills/nuxt-better-auth/references/plugins.md
+++ b/skills/nuxt-better-auth/references/plugins.md
@@ -6,9 +6,10 @@ The module supports all Better Auth plugins. Configure in both server and client
 
 ```ts
 // server/auth.config.ts
-import { defineServerAuth } from '#auth/server'
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
+import { admin, twoFactor, passkey, multiSession } from 'better-auth/plugins'
 
-export default defineServerAuth(({ runtimeConfig }) => ({
+export default defineServerAuth({
   emailAndPassword: { enabled: true },
   plugins: [
     admin(),
@@ -16,17 +17,17 @@ export default defineServerAuth(({ runtimeConfig }) => ({
     passkey(),
     multiSession()
   ]
-}))
+})
 ```
 
 ## Client Plugin Setup
 
 ```ts
 // app/auth.config.ts
-import { createAppAuthClient } from '#auth/client'
+import { defineClientAuth } from '@onmax/nuxt-better-auth/config'
 import { adminClient, twoFactorClient, passkeyClient, multiSessionClient } from 'better-auth/client/plugins'
 
-export default createAppAuthClient({
+export default defineClientAuth({
   plugins: [
     adminClient(),
     twoFactorClient(),

--- a/skills/nuxt-better-auth/references/types.md
+++ b/skills/nuxt-better-auth/references/types.md
@@ -111,14 +111,16 @@ Extend user type via Better Auth config:
 
 ```ts
 // server/auth.config.ts
-export default defineServerAuth(() => ({
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
+
+export default defineServerAuth({
   user: {
     additionalFields: {
       plan: { type: 'string' },
       credits: { type: 'number' }
     }
   }
-}))
+})
 ```
 
 Types automatically include these fields:

--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -1,6 +1,6 @@
 import type { AppAuthClient, AuthSession, AuthUser } from '#nuxt-better-auth'
 import type { ComputedRef, Ref } from 'vue'
-import { createAppAuthClient } from '#auth/client'
+import createAppAuthClient from '#auth/client'
 import { computed, nextTick, useRequestHeaders, useRequestURL, useRuntimeConfig, useState, watch } from '#imports'
 
 export interface SignOutOptions { onSuccess?: () => void | Promise<void> }

--- a/src/schema-generator.ts
+++ b/src/schema-generator.ts
@@ -69,12 +69,12 @@ export async function loadUserAuthConfig(configPath: string, throwOnError = fals
   globalThis.defineServerAuth._count++
 
   try {
-    const mod = await jiti.import(configPath) as { default?: unknown } | ((...args: unknown[]) => unknown)
-    const configFn = typeof mod === 'object' && mod !== null && 'default' in mod ? mod.default : mod
+    const mod = await jiti.import(configPath) as { default?: unknown }
+    const configFn = mod.default
     if (typeof configFn === 'function') {
       return configFn({ runtimeConfig: {}, db: null })
     }
-    consola.warn('[@onmax/nuxt-better-auth] auth.config.ts does not export a function. Expected: export default defineServerAuth(...)')
+    consola.warn('[@onmax/nuxt-better-auth] auth.config.ts does not export default. Expected: export default defineServerAuth(...)')
     if (throwOnError) {
       throw new Error('auth.config.ts must export default defineServerAuth(...)')
     }

--- a/test/fixtures/basic/.nuxtrc
+++ b/test/fixtures/basic/.nuxtrc
@@ -1,0 +1,1 @@
+setups.@onmax/nuxt-better-auth="0.0.2-alpha.14"

--- a/test/fixtures/basic/app/auth.config.ts
+++ b/test/fixtures/basic/app/auth.config.ts
@@ -1,5 +1,3 @@
-import { createAuthClient } from 'better-auth/vue'
+import { defineClientAuth } from '../../../../src/runtime/config'
 
-export function createAppAuthClient(baseURL: string) {
-  return createAuthClient({ baseURL })
-}
+export default defineClientAuth({})

--- a/test/fixtures/basic/server/auth.config.ts
+++ b/test/fixtures/basic/server/auth.config.ts
@@ -1,6 +1,6 @@
 import { defineServerAuth } from '../../../../src/runtime/config'
 
-export default defineServerAuth(() => ({
+export default defineServerAuth({
   appName: 'Test App',
   emailAndPassword: { enabled: true },
-}))
+})

--- a/test/fixtures/no-db/.nuxtrc
+++ b/test/fixtures/no-db/.nuxtrc
@@ -1,0 +1,1 @@
+setups.@onmax/nuxt-better-auth="0.0.2-alpha.14"

--- a/test/fixtures/no-db/app/auth.config.ts
+++ b/test/fixtures/no-db/app/auth.config.ts
@@ -1,5 +1,3 @@
-import { createAuthClient } from 'better-auth/vue'
+import { defineClientAuth } from '../../../../src/runtime/config'
 
-export function createAppAuthClient(baseURL: string) {
-  return createAuthClient({ baseURL })
-}
+export default defineClientAuth({})

--- a/test/fixtures/no-db/server/auth.config.ts
+++ b/test/fixtures/no-db/server/auth.config.ts
@@ -1,9 +1,9 @@
 import { defineServerAuth } from '../../../../src/runtime/config'
 
-export default defineServerAuth(() => ({
+export default defineServerAuth({
   appName: 'Database-less Test App',
   // OAuth only - email/password needs database
   socialProviders: {
     github: { clientId: 'test', clientSecret: 'test' },
   },
-}))
+})

--- a/test/fixtures/no-hub/.nuxtrc
+++ b/test/fixtures/no-hub/.nuxtrc
@@ -1,0 +1,1 @@
+setups.@onmax/nuxt-better-auth="0.0.2-alpha.14"

--- a/test/fixtures/no-hub/app/auth.config.ts
+++ b/test/fixtures/no-hub/app/auth.config.ts
@@ -1,5 +1,6 @@
-import { createAuthClient } from 'better-auth/vue'
+import { defineClientAuth } from '../../../../src/runtime/config'
 
-export function createAppAuthClient(baseURL: string) {
-  return createAuthClient({ baseURL })
-}
+// Function syntax - demonstrates context access
+export default defineClientAuth(ctx => ({
+  fetchOptions: { headers: { 'x-requested-from': ctx.siteUrl } },
+}))

--- a/test/fixtures/no-hub/server/auth.config.ts
+++ b/test/fixtures/no-hub/server/auth.config.ts
@@ -1,9 +1,10 @@
 import { defineServerAuth } from '../../../../src/runtime/config'
 
-export default defineServerAuth(() => ({
+// Function syntax - demonstrates runtimeConfig access
+export default defineServerAuth(({ runtimeConfig }) => ({
   appName: 'No-Hub Test App',
   // OAuth only - email/password needs database
   socialProviders: {
-    github: { clientId: 'test', clientSecret: 'test' },
+    github: { clientId: runtimeConfig.github?.clientId || 'test', clientSecret: runtimeConfig.github?.clientSecret || 'test' },
   },
 }))


### PR DESCRIPTION
## Summary
Switch from named exports to default exports to align with Nuxt conventions (`nuxt.config.ts`, `app.config.ts`).

## Before
```ts
// server/auth.config.ts
export const createServerAuth = defineServerAuth({ ... })

// app/auth.config.ts
export const createAppAuthClient = defineClientAuth({ ... })
```

## After
```ts
// server/auth.config.ts
export default defineServerAuth({ ... })

// app/auth.config.ts
export default defineClientAuth({ ... })
```

## Test plan
- [x] `pnpm dev:prepare`
- [x] `pnpm typecheck`
- [x] `pnpm test` - 63 tests pass
- [x] `pnpm run prepack`

Closes #77