### PR TITLE
feat: Nitro v3 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,26 @@ jobs:
           BETTER_AUTH_SECRET: ci-test-secret-12345678901234567890
       - run: pnpm build:docs
       - run: pnpm test
+
+  compatibility:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        nuxt:
+          - 4.5.0
+          - npm:nuxt-nightly@5x
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install
+      - run: pnpm pack --pack-destination /tmp
+      - run: cp -R test/compatibility/fixture /tmp/nuxt-better-auth-compatibility
+      - run: pnpm --dir /tmp/nuxt-better-auth-compatibility add --save-exact "nuxt@${{ matrix.nuxt }}" better-auth@1.5.5 vue@3.5.40 /tmp/onmax-nuxt-better-auth-*.tgz
+      - run: pnpm --dir /tmp/nuxt-better-auth-compatibility build
+      - run: node test/compatibility/check.mjs /tmp/nuxt-better-auth-compatibility

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,8 @@ jobs:
       matrix:
         nuxt:
           - 4.5.0
-          - npm:nuxt-nightly@5x
+          # Keep merge proof on a reviewed snapshot; float nightlies only in non-gating surveillance.
+          - npm:nuxt-nightly@5.0.0-29765760.f83eac74
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v6
@@ -46,7 +47,12 @@ jobs:
       - run: pnpm install
       - run: pnpm pack --pack-destination /tmp
       - run: cp -R test/compatibility/fixture /tmp/nuxt-better-auth-compatibility
-      - run: pnpm --dir /tmp/nuxt-better-auth-compatibility add --save-exact "nuxt@${{ matrix.nuxt }}" better-auth@1.5.5 typescript@5.9.3 vue@3.5.40 vue-tsc@3.2.7 /tmp/onmax-nuxt-better-auth-*.tgz
-      - run: pnpm --dir /tmp/nuxt-better-auth-compatibility typecheck
-      - run: pnpm --dir /tmp/nuxt-better-auth-compatibility build
+      - name: Install compatibility dependencies
+        timeout-minutes: 5
+        working-directory: /tmp/nuxt-better-auth-compatibility
+        run: corepack pnpm@11.20.0 add --save-exact "nuxt@${{ matrix.nuxt }}" better-auth@1.5.5 typescript@5.9.3 vue@3.5.40 vue-tsc@3.2.7 /tmp/onmax-nuxt-better-auth-*.tgz
+      - run: corepack pnpm@11.20.0 typecheck
+        working-directory: /tmp/nuxt-better-auth-compatibility
+      - run: corepack pnpm@11.20.0 build
+        working-directory: /tmp/nuxt-better-auth-compatibility
       - run: node test/compatibility/check.mjs /tmp/nuxt-better-auth-compatibility

--- a/src/module.ts
+++ b/src/module.ts
@@ -8,6 +8,7 @@ import { consola as _consola } from 'consola'
 import { dirname, relative } from 'pathe'
 import { version } from '../package.json'
 import { resolveAuthConfigDescriptors } from './module/config-paths'
+import { resolveNitroCompatibilityImports } from './module/compatibility'
 import { registerAuthMiddlewareHook, registerDevtools, registerNuxtHubDatabaseExternalHook, registerPrepareTypesHook, registerRouteRulesMetaHook, registerServerRuntime, registerTemplateHmrHook } from './module/hooks'
 import { setupBetterAuthSchema } from './module/schema'
 import { promptForSecret } from './module/secret'
@@ -106,6 +107,8 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
   },
   async setup(options, nuxt) {
     const resolver = createResolver(import.meta.url)
+    const nitroImports = resolveNitroCompatibilityImports(nuxt._version)
+    nuxt.options.alias['#better-auth/nitro-compat'] = resolver.resolve(`./runtime/server/internal/${nitroImports.runtime}`)
 
     const setup = await resolveAuthModuleSetup({
       nuxt,
@@ -172,6 +175,8 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
         hasHubDb: setup.serverTypes.hasHubDb,
         runtimeTypesPath: resolver.resolve('./runtime/types'),
         sharedServerConfigSafe: isServerConfigSharedTypeSafe(setup.serverTypes.serverConfigPath),
+        h3TypesPath: nitroImports.h3,
+        nitroTypesPath: nitroImports.types,
       })
     }
 
@@ -192,6 +197,7 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
       runtimeTypesAugmentPath: setup.aliases['#nuxt-better-auth'],
       runtimeTypesPath: resolver.resolve('./runtime/types'),
       clientConfigPath: setup.sharedTypes.clientConfigPath,
+      h3TypesPath: nitroImports.h3,
     })
 
     registerTemplateHmrHook(nuxt)

--- a/src/module/compatibility.ts
+++ b/src/module/compatibility.ts
@@ -1,0 +1,16 @@
+export interface NitroCompatibilityImports {
+  h3: 'h3' | 'nitro/h3'
+  runtime: 'nitro2' | 'nitro3'
+  types: 'nitropack/types' | 'nitro/types'
+}
+
+export function resolveNitroCompatibilityImports(nuxtVersion: string): NitroCompatibilityImports {
+  const major = Number.parseInt(nuxtVersion, 10)
+  const nitroV3 = Number.isFinite(major) && major >= 5
+
+  return {
+    h3: nitroV3 ? 'nitro/h3' : 'h3',
+    runtime: nitroV3 ? 'nitro3' : 'nitro2',
+    types: nitroV3 ? 'nitro/types' : 'nitropack/types',
+  }
+}

--- a/src/module/type-templates.ts
+++ b/src/module/type-templates.ts
@@ -5,10 +5,24 @@ interface RegisterServerTypeTemplatesInput {
   hasHubDb: boolean
   runtimeTypesPath: string
   sharedServerConfigSafe: boolean
+  h3TypesPath: 'h3' | 'nitro/h3'
+  nitroTypesPath: 'nitropack/types' | 'nitro/types'
 }
 
 export function registerServerTypeTemplates(input: RegisterServerTypeTemplatesInput): void {
-  const { serverConfigPath, hasHubDb, runtimeTypesPath, sharedServerConfigSafe } = input
+  const { serverConfigPath, hasHubDb, runtimeTypesPath, sharedServerConfigSafe, h3TypesPath, nitroTypesPath } = input
+  const routeRuleAugmentations = (nitroTypesPath === 'nitro/types'
+    ? [nitroTypesPath]
+    : ['nitropack', nitroTypesPath])
+    .map(moduleName => `declare module '${moduleName}' {
+  interface NitroRouteRules {
+    auth?: import('${runtimeTypesPath}').AuthMeta
+  }
+  interface NitroRouteConfig {
+    auth?: import('${runtimeTypesPath}').AuthMeta
+  }
+}`)
+    .join('\n')
   const serverConfigTypeTemplateOptions = sharedServerConfigSafe
     ? { nuxt: true, nitro: true, node: true, shared: true }
     : { nuxt: true, nitro: true, node: true }
@@ -32,7 +46,7 @@ declare module '#auth/secondary-storage' {
     getContents: () => `
 declare module '#auth/database' {
   import type { BetterAuthOptions } from 'better-auth'
-  export function createDatabase(event?: import('h3').H3Event): BetterAuthOptions['database']
+  export function createDatabase(event?: import('${h3TypesPath}').H3Event): BetterAuthOptions['database']
   export const db: ${hasHubDb ? `typeof import('@nuxthub/db')['db']` : 'undefined'}
 }
 `,
@@ -148,7 +162,7 @@ declare module '#nuxt-better-auth' {
 import type createServerAuth from '${serverConfigPath}'
 import type { BetterAuthOptions } from 'better-auth'
 import type { getEndpoints } from 'better-auth/api'
-import type { Serialize, Simplify } from 'nitropack/types'
+import type { Serialize, Simplify } from '${nitroTypesPath}'
 import type { FetchError } from 'ofetch'
 
 type _RawConfig = ReturnType<typeof createServerAuth>
@@ -211,7 +225,7 @@ type _AuthPatternFromRequestPath<Path extends string> = {
 }[_AuthApiPatternPath]
 type _AuthEndpointMethod<Path extends _AuthApiRequestPath> = Extract<keyof _GeneratedAuthInternalApi[_AuthPatternFromRequestPath<Path>], string>
 
-type _AuthFetchMethod<Path extends _AuthApiRequestPath> = Extract<Exclude<import('nitropack/types').NitroFetchOptions<Path>['method'], undefined>, string>
+type _AuthFetchMethod<Path extends _AuthApiRequestPath> = Extract<Exclude<import('${nitroTypesPath}').NitroFetchOptions<Path>['method'], undefined>, string>
 type _AuthFetchDefaultMethod<Path extends _AuthApiRequestPath> = 'get'
 type _AuthFetchResolvedMethod<Path extends _AuthApiRequestPath, Method extends string> = Lowercase<Method> extends _AuthEndpointMethod<Path>
   ? Lowercase<Method>
@@ -313,30 +327,7 @@ declare module 'nuxt/app' {
   export function useLazyFetch(request: string | import('vue').Ref<string> | (() => string), opts?: any): any
 }
 
-declare module 'nitropack' {
-  interface NitroRouteRules {
-    auth?: import('${runtimeTypesPath}').AuthMeta
-  }
-  interface NitroRouteConfig {
-    auth?: import('${runtimeTypesPath}').AuthMeta
-  }
-}
-declare module 'nitropack/types' {
-  interface NitroRouteRules {
-    auth?: import('${runtimeTypesPath}').AuthMeta
-  }
-  interface NitroRouteConfig {
-    auth?: import('${runtimeTypesPath}').AuthMeta
-  }
-}
-declare module 'nitro/types' {
-  interface NitroRouteRules {
-    auth?: import('${runtimeTypesPath}').AuthMeta
-  }
-  interface NitroRouteConfig {
-    auth?: import('${runtimeTypesPath}').AuthMeta
-  }
-}
+${routeRuleAugmentations}
 export {}
 `,
   }, { nitro: true, node: true })
@@ -346,6 +337,7 @@ interface RegisterSharedTypeTemplatesInput {
   runtimeTypesAugmentPath: string
   runtimeTypesPath: string
   clientConfigPath: string
+  h3TypesPath: 'h3' | 'nitro/h3'
 }
 
 export function registerSharedTypeTemplates(input: RegisterSharedTypeTemplatesInput): void {
@@ -355,7 +347,7 @@ export function registerSharedTypeTemplates(input: RegisterSharedTypeTemplatesIn
 import type { AppSession } from '${input.runtimeTypesAugmentPath}'
 export * from '${input.runtimeTypesAugmentPath}'
 export type { AuthMeta, AuthMode, AuthRouteRules, AuthSocialProviderId, Auth, InferUser, InferSession } from '${input.runtimeTypesPath}'
-declare module 'h3' {
+declare module '${input.h3TypesPath}' {
   interface H3EventContext {
     requestSession?: AppSession | null
   }

--- a/src/runtime/app/composables/useAuthRequestFetch.ts
+++ b/src/runtime/app/composables/useAuthRequestFetch.ts
@@ -1,6 +1,7 @@
-import type { NitroFetchOptions } from 'nitropack/types'
 import type { AuthApiEndpointMethod, AuthApiEndpointPath, AuthApiEndpointResponse } from '#nuxt-better-auth'
 import { useRequestFetch } from '#imports'
+
+type RequestFetchOptions = NonNullable<Parameters<ReturnType<typeof useRequestFetch>>[1]>
 
 type AuthRequestFetchExtractedMethod<Options> = Options extends undefined
   ? 'get'
@@ -8,17 +9,17 @@ type AuthRequestFetchExtractedMethod<Options> = Options extends undefined
     ? NormalizedMethod
     : 'get'
 
-type AuthRequestFetchMethodFromOptions<Path extends AuthApiEndpointPath, Options> = NitroFetchOptions<Path> extends Options
+type AuthRequestFetchMethodFromOptions<Options> = RequestFetchOptions extends Options
   ? 'get'
   : AuthRequestFetchExtractedMethod<Options>
 
-type AuthRequestFetchResolvedMethod<Path extends AuthApiEndpointPath, Options> = Extract<AuthRequestFetchMethodFromOptions<Path, Options>, AuthApiEndpointMethod<Path>> extends infer Method extends string
+type AuthRequestFetchResolvedMethod<Path extends AuthApiEndpointPath, Options> = Extract<AuthRequestFetchMethodFromOptions<Options>, AuthApiEndpointMethod<Path>> extends infer Method extends string
   ? Method
   : never
 
 type AuthRequestFetch = <
   Path extends AuthApiEndpointPath,
-  Options extends NitroFetchOptions<Path> = NitroFetchOptions<Path>,
+  Options extends RequestFetchOptions = RequestFetchOptions,
 >(
   request: Path,
   opts?: Options,

--- a/src/runtime/server/api/_better-auth/accounts.get.ts
+++ b/src/runtime/server/api/_better-auth/accounts.get.ts
@@ -1,5 +1,5 @@
-import { defineEventHandler, getQuery } from 'h3'
 import { paginationQuerySchema, sanitizeSearchPattern } from './_schema'
+import { defineEventHandler, getQuery } from '../../internal/nitro-compat'
 
 export default defineEventHandler(async (event) => {
   try {

--- a/src/runtime/server/api/_better-auth/config.get.ts
+++ b/src/runtime/server/api/_better-auth/config.get.ts
@@ -1,5 +1,4 @@
-import { defineEventHandler } from 'h3'
-import { useRuntimeConfig } from '#imports'
+import { defineEventHandler, useRuntimeConfig } from '../../internal/nitro-compat'
 import { serverAuth } from '../../utils/auth'
 
 export default defineEventHandler(async (event) => {

--- a/src/runtime/server/api/_better-auth/sessions.delete.ts
+++ b/src/runtime/server/api/_better-auth/sessions.delete.ts
@@ -1,5 +1,5 @@
-import { createError, defineEventHandler, readBody } from 'h3'
 import { z } from 'zod'
+import { createAuthError, defineEventHandler, readBody } from '../../internal/nitro-compat'
 
 const deleteSessionSchema = z.object({
   id: z.string().min(1, 'Session ID required'),
@@ -12,7 +12,7 @@ export default defineEventHandler(async (event) => {
     const { db } = await import('@nuxthub/db')
     const { schema } = await import('#auth/schema')
     if (!schema?.session)
-      throw createError({ statusCode: 500, message: 'Session table not found' })
+      throw createAuthError(500, 'Session table not found')
 
     const { eq } = await import('drizzle-orm')
     await db.delete(schema.session).where(eq(schema.session.id, body.id))
@@ -21,9 +21,9 @@ export default defineEventHandler(async (event) => {
   }
   catch (error: unknown) {
     if (error instanceof z.ZodError) {
-      throw createError({ statusCode: 400, message: error.errors[0]?.message || 'Invalid request' })
+      throw createAuthError(400, error.errors[0]?.message || 'Invalid request')
     }
     console.error('[DevTools] Delete session failed:', error)
-    throw createError({ statusCode: 500, message: 'Failed to delete session' })
+    throw createAuthError(500, 'Failed to delete session')
   }
 })

--- a/src/runtime/server/api/_better-auth/sessions.get.ts
+++ b/src/runtime/server/api/_better-auth/sessions.get.ts
@@ -1,6 +1,6 @@
 import type { Session } from 'better-auth/types'
-import { defineEventHandler, getQuery } from 'h3'
 import { paginationQuerySchema, sanitizeSearchPattern } from './_schema'
+import { defineEventHandler, getQuery } from '../../internal/nitro-compat'
 
 type SafeSession = Pick<Session, 'id' | 'userId' | 'createdAt' | 'updatedAt' | 'expiresAt' | 'ipAddress' | 'userAgent'>
 

--- a/src/runtime/server/api/_better-auth/users.get.ts
+++ b/src/runtime/server/api/_better-auth/users.get.ts
@@ -1,5 +1,5 @@
-import { defineEventHandler, getQuery } from 'h3'
 import { paginationQuerySchema, sanitizeSearchPattern } from './_schema'
+import { defineEventHandler, getQuery } from '../../internal/nitro-compat'
 
 export default defineEventHandler(async (event) => {
   try {

--- a/src/runtime/server/api/auth/[...all].ts
+++ b/src/runtime/server/api/auth/[...all].ts
@@ -1,8 +1,8 @@
-import type { H3Event } from 'h3'
-import { defineEventHandler, toWebRequest } from 'h3'
+import type { ServerEvent } from '../../internal/nitro-compat'
+import { defineEventHandler, toWebRequest } from '../../internal/nitro-compat'
 import { serverAuth } from '../../utils/auth'
 
-export default defineEventHandler(async (event: H3Event) => {
+export default defineEventHandler(async (event: ServerEvent) => {
   const auth = serverAuth(event)
   return auth.handler(toWebRequest(event))
 })

--- a/src/runtime/server/internal/nitro-compat.ts
+++ b/src/runtime/server/internal/nitro-compat.ts
@@ -1,0 +1,1 @@
+export * from '#better-auth/nitro-compat'

--- a/src/runtime/server/internal/nitro2.ts
+++ b/src/runtime/server/internal/nitro2.ts
@@ -1,0 +1,36 @@
+import type { H3Event } from 'h3'
+import type { AuthRouteRules } from '../../types'
+import {
+  createError,
+  defineEventHandler,
+  getQuery,
+  getRequestHost,
+  getRequestProtocol,
+  getRequestURL,
+  readBody,
+  splitCookiesString,
+  toWebRequest,
+} from 'h3'
+import { getRouteRules, useRuntimeConfig } from 'nitropack/runtime'
+
+export {
+  defineEventHandler,
+  getQuery,
+  getRequestHost,
+  getRequestProtocol,
+  getRequestURL,
+  readBody,
+  splitCookiesString,
+  toWebRequest,
+  useRuntimeConfig,
+}
+
+export type ServerEvent = H3Event
+
+export function getAuthRouteRules(event: ServerEvent): AuthRouteRules {
+  return getRouteRules(event) as AuthRouteRules
+}
+
+export function createAuthError(status: number, statusText: string): Error {
+  return createError({ statusCode: status, statusMessage: statusText })
+}

--- a/src/runtime/server/internal/nitro3.ts
+++ b/src/runtime/server/internal/nitro3.ts
@@ -1,0 +1,76 @@
+import type { H3Event } from 'nitro/h3'
+import type { AuthRouteRules } from '../../types'
+import { getRouteRules } from 'nitro/app'
+import {
+  defineEventHandler,
+  getQuery,
+  getRequestHost,
+  getRequestProtocol,
+  getRequestURL,
+  HTTPError,
+  readBody,
+} from 'nitro/h3'
+import { useRuntimeConfig } from 'nitro/runtime-config'
+
+export {
+  defineEventHandler,
+  getQuery,
+  getRequestHost,
+  getRequestProtocol,
+  getRequestURL,
+  readBody,
+  useRuntimeConfig,
+}
+
+export type ServerEvent = H3Event
+
+export function getAuthRouteRules(event: ServerEvent): AuthRouteRules {
+  return (getRouteRules(event.req.method, getRequestURL(event).pathname).routeRules ?? {}) as AuthRouteRules
+}
+
+export function createAuthError(status: number, statusText: string): Error {
+  return HTTPError.status(status, statusText)
+}
+
+export function toWebRequest(event: ServerEvent): Request {
+  return event.req
+}
+
+export function splitCookiesString(header: string): string[] {
+  const cookies: string[] = []
+  let position = 0
+
+  while (position < header.length) {
+    const start = position
+    let separator: number | undefined
+
+    while (position < header.length) {
+      if (header[position] !== ',') {
+        position += 1
+        continue
+      }
+
+      separator = position
+      position += 1
+      while (position < header.length && /\s/.test(header[position]!))
+        position += 1
+
+      const nextStart = position
+      while (position < header.length && !['=', ';', ','].includes(header[position]!))
+        position += 1
+
+      if (header[position] === '=') {
+        cookies.push(header.slice(start, separator))
+        position = nextStart
+        break
+      }
+
+      position = separator + 1
+    }
+
+    if (separator === undefined || position >= header.length)
+      cookies.push(header.slice(start))
+  }
+
+  return cookies
+}

--- a/src/runtime/server/middleware/route-access.ts
+++ b/src/runtime/server/middleware/route-access.ts
@@ -1,8 +1,7 @@
 import type { AuthMeta, AuthMode, AuthRouteRules } from '../../types'
-import { createError, defineEventHandler, getRequestURL } from 'h3'
-import { getRouteRules } from '#imports'
 import { shouldSkipAuthRouteRules } from '../../internal/auth-route-rules'
 import { matchesUser } from '../../utils/match-user'
+import { createAuthError, defineEventHandler, getAuthRouteRules, getRequestURL } from '../internal/nitro-compat'
 import { getUserSession, requireUserSession } from '../utils/session'
 
 export default defineEventHandler(async (event) => {
@@ -14,7 +13,7 @@ export default defineEventHandler(async (event) => {
   if (shouldSkipAuthRouteRules(path))
     return
 
-  const rules = getRouteRules(event) as AuthRouteRules
+  const rules = getAuthRouteRules(event) as AuthRouteRules
   if (!rules.auth)
     return
 
@@ -24,7 +23,7 @@ export default defineEventHandler(async (event) => {
   if (mode === 'guest') {
     const session = await getUserSession(event)
     if (session)
-      throw createError({ statusCode: 403, statusMessage: 'Authenticated users not allowed' })
+      throw createAuthError(403, 'Authenticated users not allowed')
     return
   }
 
@@ -33,7 +32,7 @@ export default defineEventHandler(async (event) => {
 
     if (typeof auth === 'object' && auth.user) {
       if (!matchesUser(session.user, auth.user))
-        throw createError({ statusCode: 403, statusMessage: 'Access denied' })
+        throw createAuthError(403, 'Access denied')
     }
   }
 })

--- a/src/runtime/server/tsconfig.json
+++ b/src/runtime/server/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
+      "#better-auth/nitro-compat": ["./internal/nitro2"],
       "#nuxt-better-auth": ["../types/augment"]
     }
   },

--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -1,12 +1,11 @@
 import type { BetterAuthOptions } from 'better-auth'
-import type { H3Event } from 'h3'
+import type { ServerEvent } from '../internal/nitro-compat'
 import { betterAuth } from 'better-auth'
-import { getRequestHost, getRequestProtocol } from 'h3'
-import { useRuntimeConfig } from 'nitropack/runtime'
 import { withoutProtocol } from 'ufo'
 import { createDatabase, db } from '#auth/database'
 import { createSecondaryStorage } from '#auth/secondary-storage'
 import createServerAuth from '#auth/server'
+import { getRequestHost, getRequestProtocol, useRuntimeConfig } from '../internal/nitro-compat'
 import { resolveCustomSecondaryStorageRequirement } from './custom-secondary-storage'
 
 type AuthOptions = ReturnType<typeof createServerAuth>
@@ -33,8 +32,8 @@ interface RequestAuthContext {
 
 const fallbackRequestAuthContext = new WeakMap<object, RequestAuthContext>()
 
-function getRequestAuthContext(event: H3Event): RequestAuthContext {
-  const eventWithContext = event as H3Event & { context?: unknown }
+function getRequestAuthContext(event: ServerEvent): RequestAuthContext {
+  const eventWithContext = event as ServerEvent & { context?: unknown }
   if (eventWithContext.context && typeof eventWithContext.context === 'object')
     return eventWithContext.context as RequestAuthContext
 
@@ -88,7 +87,7 @@ function resolveConfiguredSiteUrl(config: ReturnType<typeof useRuntimeConfig>): 
   return validateURL(config.public.siteUrl)
 }
 
-function resolveEventOrigin(event?: H3Event): string | undefined {
+function resolveEventOrigin(event?: ServerEvent): string | undefined {
   if (!event)
     return undefined
 
@@ -179,7 +178,7 @@ function resolveDevFallback(): { origin: string, source: string } | undefined {
   return { origin: 'http://localhost:3000', source: 'development fallback' }
 }
 
-function getBaseURL(event?: H3Event): string {
+function getBaseURL(event?: ServerEvent): string {
   const config = useRuntimeConfig()
   const configuredSiteUrl = resolveConfiguredSiteUrl(config)
   if (configuredSiteUrl)
@@ -273,7 +272,7 @@ function withDevTrustedOrigins(
 }
 
 /** Returns Better Auth instance. Caches per resolved host (or single instance when siteUrl is explicit). */
-export function serverAuth(event?: H3Event): AuthInstance {
+export function serverAuth(event?: ServerEvent): AuthInstance {
   const runtimeConfig = useRuntimeConfig()
   const betterAuthSecret = runtimeConfig.betterAuthSecret || ''
   if (!import.meta.dev && !betterAuthSecret)

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -1,7 +1,7 @@
-import type { H3Event } from 'h3'
 import type { AppSession, AuthSession, RequireSessionOptions } from '#nuxt-better-auth'
-import { createError, splitCookiesString } from 'h3'
 import { matchesUser } from '../../utils/match-user'
+import type { ServerEvent } from '../internal/nitro-compat'
+import { createAuthError, splitCookiesString } from '../internal/nitro-compat'
 import { serverAuth } from './auth'
 
 const requestSessionLoadKey = Symbol.for('nuxt-better-auth.requestSessionLoad')
@@ -53,8 +53,8 @@ interface SessionWithHeaders {
 
 const fallbackRequestSessionContext = new WeakMap<object, RequestSessionContext>()
 
-function getRequestSessionContext(event: H3Event): RequestSessionContext {
-  const eventWithContext = event as H3Event & { context?: unknown }
+function getRequestSessionContext(event: ServerEvent): RequestSessionContext {
+  const eventWithContext = event as ServerEvent & { context?: unknown }
   if (eventWithContext.context && typeof eventWithContext.context === 'object')
     return eventWithContext.context as RequestSessionContext
 
@@ -66,16 +66,21 @@ function getRequestSessionContext(event: H3Event): RequestSessionContext {
   return context
 }
 
-function getRequestHeaders(event: H3Event): Headers {
-  return getRequestSessionContext(event).requestHeaders ?? event.headers
+function getIncomingRequestHeaders(event: ServerEvent): Headers {
+  const requestHeaders = (event as ServerEvent & { req?: { headers?: Headers } }).req?.headers
+  return requestHeaders instanceof Headers ? requestHeaders : (event as ServerEvent & { headers: Headers }).headers
 }
 
-function loadSession(event: H3Event): Promise<AppSession | null> {
+function getRequestHeaders(event: ServerEvent): Headers {
+  return getRequestSessionContext(event).requestHeaders ?? getIncomingRequestHeaders(event)
+}
+
+function loadSession(event: ServerEvent): Promise<AppSession | null> {
   const auth = serverAuth(event)
   return auth.api.getSession({ headers: getRequestHeaders(event) }) as Promise<AppSession | null>
 }
 
-function loadFreshSession(event: H3Event): Promise<SessionWithHeaders> {
+function loadFreshSession(event: ServerEvent): Promise<SessionWithHeaders> {
   const auth = serverAuth(event)
   return auth.api.getSession({
     headers: getRequestHeaders(event),
@@ -84,7 +89,7 @@ function loadFreshSession(event: H3Event): Promise<SessionWithHeaders> {
   }) as unknown as Promise<SessionWithHeaders>
 }
 
-function getServerAuthContext(event: H3Event): Promise<ServerAuthContextLike> {
+function getServerAuthContext(event: ServerEvent): Promise<ServerAuthContextLike> {
   const auth = serverAuth(event) as ReturnType<typeof serverAuth> & { $context: Promise<ServerAuthContextLike> }
   return auth.$context
 }
@@ -177,8 +182,8 @@ async function serializeSignedCookie(name: string, value: string, secret: string
   return serializeCookieHeader(name, await signCookieValue(value, secret), attributes, true)
 }
 
-function appendCookieHeader(event: H3Event, header: string): void {
-  const nodeResponse = (event as H3Event & {
+function appendCookieHeader(event: ServerEvent, header: string): void {
+  const nodeResponse = (event as ServerEvent & {
     node?: {
       res?: {
         getHeader?: (name: string) => string | string[] | number | undefined
@@ -201,7 +206,11 @@ function appendCookieHeader(event: H3Event, header: string): void {
     return
   }
 
-  const responseHeaders = (event as H3Event & { response?: { headers?: Headers } }).response?.headers
+  const eventWithResponse = event as ServerEvent & {
+    res?: { headers?: Headers }
+    response?: { headers?: Headers }
+  }
+  const responseHeaders = eventWithResponse.res?.headers ?? eventWithResponse.response?.headers
   responseHeaders?.append('set-cookie', header)
 }
 
@@ -215,7 +224,7 @@ function getSetCookieHeaders(headers: Headers): string[] {
   return header ? splitCookiesString(header) : []
 }
 
-function appendSetCookieHeaders(event: H3Event, headers: Headers): void {
+function appendSetCookieHeaders(event: ServerEvent, headers: Headers): void {
   for (const header of getSetCookieHeaders(headers))
     appendCookieHeader(event, header)
 }
@@ -252,16 +261,16 @@ function extractResponseCookieValue(header: string): string {
   return cookiePair.slice(cookiePair.indexOf('=') + 1)
 }
 
-function getChunkedCookieNames(event: H3Event, cookieName: string): string[] {
+function getChunkedCookieNames(event: ServerEvent, cookieName: string): string[] {
   const cookieNames = new Set<string>([cookieName])
-  for (const name of parseRequestCookies(event.headers.get('cookie')).keys()) {
+  for (const name of parseRequestCookies(getIncomingRequestHeaders(event).get('cookie')).keys()) {
     if (name.startsWith(`${cookieName}.`))
       cookieNames.add(name)
   }
   return Array.from(cookieNames)
 }
 
-function expireCookie(event: H3Event, cookieName: string, attributes: CookieOptions): void {
+function expireCookie(event: ServerEvent, cookieName: string, attributes: CookieOptions): void {
   appendCookieHeader(event, serializeCookie(cookieName, '', {
     ...attributes,
     expires: new Date(0),
@@ -269,15 +278,16 @@ function expireCookie(event: H3Event, cookieName: string, attributes: CookieOpti
   }))
 }
 
-function expireCookies(event: H3Event, cookie: { name: string, attributes: CookieOptions }): void {
+function expireCookies(event: ServerEvent, cookie: { name: string, attributes: CookieOptions }): void {
   for (const cookieName of getChunkedCookieNames(event, cookie.name))
     expireCookie(event, cookieName, cookie.attributes)
 }
 
-function updateRequestHeaders(event: H3Event, sessionCookie: string, clearedCookieNames: string[]): void {
+function updateRequestHeaders(event: ServerEvent, sessionCookie: string, clearedCookieNames: string[]): void {
   const requestContext = getRequestSessionContext(event)
-  const requestHeaders = new Headers(event.headers)
-  const cookies = parseRequestCookies(event.headers.get('cookie'))
+  const incomingHeaders = getIncomingRequestHeaders(event)
+  const requestHeaders = new Headers(incomingHeaders)
+  const cookies = parseRequestCookies(incomingHeaders.get('cookie'))
 
   for (const name of clearedCookieNames)
     cookies.delete(name)
@@ -294,7 +304,7 @@ function updateRequestHeaders(event: H3Event, sessionCookie: string, clearedCook
   requestContext.requestHeaders = requestHeaders
 }
 
-export async function getRequestSession(event: H3Event): Promise<AppSession | null> {
+export async function getRequestSession(event: ServerEvent): Promise<AppSession | null> {
   const context = getRequestSessionContext(event)
   if (context.requestSession !== undefined)
     return context.requestSession
@@ -316,7 +326,7 @@ export async function getRequestSession(event: H3Event): Promise<AppSession | nu
   }
 }
 
-export async function getUserSession(event: H3Event): Promise<AppSession | null> {
+export async function getUserSession(event: ServerEvent): Promise<AppSession | null> {
   const context = getRequestSessionContext(event)
   if (context.requestSession !== undefined)
     return context.requestSession
@@ -328,7 +338,7 @@ export async function getUserSession(event: H3Event): Promise<AppSession | null>
   return loadSession(event)
 }
 
-export async function refreshSessionCookieCache(event: H3Event): Promise<AppSession | null> {
+export async function refreshSessionCookieCache(event: ServerEvent): Promise<AppSession | null> {
   const context = getRequestSessionContext(event)
   const inFlight = context[requestSessionLoadKey]
   if (inFlight)
@@ -351,7 +361,7 @@ export async function refreshSessionCookieCache(event: H3Event): Promise<AppSess
   }
 }
 
-export async function setSessionCookie(event: H3Event, token: string): Promise<void> {
+export async function setSessionCookie(event: ServerEvent, token: string): Promise<void> {
   const context = await getServerAuthContext(event)
   const sessionCookie = await serializeSignedCookie(
     context.authCookies.sessionToken.name,
@@ -376,26 +386,26 @@ export async function setSessionCookie(event: H3Event, token: string): Promise<v
   ])
 }
 
-export async function createSession(event: H3Event, userId: string): Promise<AuthSession> {
+export async function createSession(event: ServerEvent, userId: string): Promise<AuthSession> {
   const context = await getServerAuthContext(event)
   return context.internalAdapter.createSession?.(userId, false) as Promise<AuthSession>
 }
 
-export async function requireUserSession(event: H3Event, options?: RequireSessionOptions): Promise<AppSession> {
+export async function requireUserSession(event: ServerEvent, options?: RequireSessionOptions): Promise<AppSession> {
   const session = await getRequestSession(event)
 
   if (!session)
-    throw createError({ statusCode: 401, statusMessage: 'Authentication required' })
+    throw createAuthError(401, 'Authentication required')
 
   if (options?.user) {
     if (!matchesUser(session.user, options.user))
-      throw createError({ statusCode: 403, statusMessage: 'Access denied' })
+      throw createAuthError(403, 'Access denied')
   }
 
   if (options?.rule) {
     const allowed = await options.rule({ user: session.user, session: session.session })
     if (!allowed)
-      throw createError({ statusCode: 403, statusMessage: 'Access denied' })
+      throw createAuthError(403, 'Access denied')
   }
 
   return session

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,4 +1,3 @@
-import type { NitroRouteRules } from 'nitropack/types'
 import type { AuthSocialProviderRegistry, AuthUser, UserMatch } from '#nuxt-better-auth'
 
 // Re-export augmentable types
@@ -26,4 +25,4 @@ export type AuthMeta = false | AuthMode | {
 }
 
 // Route rules with auth
-export type AuthRouteRules = NitroRouteRules & { auth?: AuthMeta }
+export type AuthRouteRules = Record<string, unknown> & { auth?: AuthMeta }

--- a/test/cases/plugins-type-inference/virtual-modules.d.ts
+++ b/test/cases/plugins-type-inference/virtual-modules.d.ts
@@ -6,3 +6,18 @@ declare module '#auth/database' {
 declare module '#auth/secondary-storage' {
   export function createSecondaryStorage(...args: any[]): any
 }
+
+declare module '#better-auth/nitro-compat' {
+  export type ServerEvent = import('h3').H3Event
+  export function createAuthError(status: number, statusText: string): Error
+  export function defineEventHandler<T>(handler: T): T
+  export function getQuery(event: any): Record<string, string | undefined>
+  export function getRequestHost(event: any, options?: any): string
+  export function getRequestProtocol(event: any, options?: any): string
+  export function getRequestURL(event: any): URL
+  export function getAuthRouteRules(event: any): Record<string, unknown>
+  export function readBody<T>(event: any): Promise<T>
+  export function splitCookiesString(header: string): string[]
+  export function toWebRequest(event: any): Request
+  export function useRuntimeConfig(): any
+}

--- a/test/compatibility/check.mjs
+++ b/test/compatibility/check.mjs
@@ -1,0 +1,55 @@
+import { spawn } from 'node:child_process'
+import { resolve } from 'node:path'
+
+const fixtureDir = resolve(process.argv[2] || '')
+const port = '43175'
+
+async function main() {
+  let output = ''
+  const server = spawn(process.execPath, ['.output/server/index.mjs'], {
+    cwd: fixtureDir,
+    env: {
+      ...process.env,
+      HOST: '127.0.0.1',
+      PORT: port,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  server.stdout.on('data', chunk => output += String(chunk))
+  server.stderr.on('data', chunk => output += String(chunk))
+
+  try {
+    const timeoutAt = Date.now() + 20_000
+    let response
+
+    while (Date.now() < timeoutAt) {
+      if (server.exitCode !== null)
+        break
+
+      try {
+        response = await fetch(`http://127.0.0.1:${port}/api/auth/ok`)
+        if (response.ok)
+          break
+      }
+      catch {}
+
+      await new Promise(resolve => setTimeout(resolve, 250))
+    }
+
+    if (!response?.ok)
+      throw new Error(`Compatibility server did not respond successfully.\n${output}`)
+
+    const body = await response.json()
+    if (body?.ok !== true)
+      throw new Error(`Unexpected auth response: ${JSON.stringify(body)}`)
+  }
+  finally {
+    server.kill('SIGTERM')
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/test/compatibility/fixture/app/app.vue
+++ b/test/compatibility/fixture/app/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <main>Nuxt Better Auth compatibility</main>
+</template>

--- a/test/compatibility/fixture/app/auth.config.ts
+++ b/test/compatibility/fixture/app/auth.config.ts
@@ -1,0 +1,3 @@
+import { defineClientAuth } from '@onmax/nuxt-better-auth/config'
+
+export default defineClientAuth({})

--- a/test/compatibility/fixture/nuxt.config.ts
+++ b/test/compatibility/fixture/nuxt.config.ts
@@ -1,0 +1,9 @@
+export default defineNuxtConfig({
+  modules: ['@onmax/nuxt-better-auth'],
+  runtimeConfig: {
+    betterAuthSecret: 'test-secret-for-testing-only-32chars!',
+    public: {
+      siteUrl: 'http://localhost:3000',
+    },
+  },
+})

--- a/test/compatibility/fixture/package.json
+++ b/test/compatibility/fixture/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "nuxt-better-auth-compatibility",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "build": "nuxt build"
+  }
+}

--- a/test/compatibility/fixture/pnpm-workspace.yaml
+++ b/test/compatibility/fixture/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  '@prisma/client': false
+  '@prisma/engines': false
+  esbuild: true
+  prisma: false

--- a/test/compatibility/fixture/server/auth.config.ts
+++ b/test/compatibility/fixture/server/auth.config.ts
@@ -1,0 +1,3 @@
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
+
+export default defineServerAuth({})

--- a/test/get-request-session.test.ts
+++ b/test/get-request-session.test.ts
@@ -5,6 +5,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const getSessionMock = vi.fn()
 const createSessionMock = vi.fn()
 
+vi.mock('#better-auth/nitro-compat', async () => {
+  const { splitCookiesString } = await import('h3')
+  return {
+    createAuthError: (status: number, statusText: string) => Object.assign(new Error(statusText), {
+      status,
+      statusCode: status,
+      statusText,
+      statusMessage: statusText,
+    }),
+    splitCookiesString,
+  }
+})
+
 const authContextMock = {
   authCookies: {
     sessionToken: {
@@ -83,6 +96,15 @@ function createEventWithoutContext() {
   } as any
 }
 
+function createNitroV3Event() {
+  return {
+    context: {},
+    req: new Request('https://example.test/api/test'),
+    res: { headers: new Headers() },
+    url: new URL('https://example.test/api/test'),
+  } as any
+}
+
 describe('getRequestSession', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -143,6 +165,19 @@ describe('getRequestSession', () => {
     expect(first).toBe(second)
     expect(third).toBe(first)
     expect('context' in event).toBe(false)
+  })
+
+  it('reads request headers from Nitro 3 events', async () => {
+    getSessionMock.mockResolvedValue({
+      user: { id: 'u1' },
+      session: { id: 's1' },
+    })
+    const { getRequestSession } = await import('../src/runtime/server/utils/session')
+    const event = createNitroV3Event()
+
+    await getRequestSession(event)
+
+    expect(getSessionMock).toHaveBeenCalledWith({ headers: event.req.headers })
   })
 })
 
@@ -345,6 +380,15 @@ describe('setSessionCookie', () => {
     expect(header[1]).toContain('Max-Age=0')
     expect(header[2]).toContain(`${authContextMock.authCookies.dontRememberToken.name}=`)
     expect(header[2]).toContain('Max-Age=0')
+  })
+
+  it('writes cookies to Nitro 3 response headers', async () => {
+    const { setSessionCookie } = await import('../src/runtime/server/utils/session')
+    const event = createNitroV3Event()
+
+    await setSessionCookie(event, 'session-token')
+
+    expect(event.res.headers.get('set-cookie')).toContain(authContextMock.authCookies.sessionToken.name)
   })
 
   it('expires chunked session cache cookies left on the request', async () => {

--- a/test/module-compatibility.test.ts
+++ b/test/module-compatibility.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { resolveNitroCompatibilityImports } from '../src/module/compatibility'
+
+describe('nuxt Nitro compatibility imports', () => {
+  it('uses Nitro 2 imports for Nuxt 4', () => {
+    expect(resolveNitroCompatibilityImports('4.5.0')).toEqual({
+      h3: 'h3',
+      runtime: 'nitro2',
+      types: 'nitropack/types',
+    })
+  })
+
+  it('uses Nitro 3 imports for Nuxt 5', () => {
+    expect(resolveNitroCompatibilityImports('5.0.0-29745766.482f3357')).toEqual({
+      h3: 'nitro/h3',
+      runtime: 'nitro3',
+      types: 'nitro/types',
+    })
+  })
+})

--- a/test/require-user-session-typing.test.ts
+++ b/test/require-user-session-typing.test.ts
@@ -10,13 +10,28 @@ describe('requireUserSession typing regression #130', () => {
     const testDir = mkdtempSync(join(tmpdir(), 'nuxt-better-auth-session-types-'))
     try {
       const runtimeDir = join(testDir, 'runtime')
+      const serverInternalDir = join(runtimeDir, 'server', 'internal')
       const serverUtilsDir = join(runtimeDir, 'server', 'utils')
       const runtimeUtilsDir = join(runtimeDir, 'utils')
 
+      mkdirSync(serverInternalDir, { recursive: true })
       mkdirSync(serverUtilsDir, { recursive: true })
       mkdirSync(runtimeUtilsDir, { recursive: true })
 
       copyFileSync(join(import.meta.dirname, '../src/runtime/server/utils/session.ts'), join(serverUtilsDir, 'session.ts'))
+
+      writeFileSync(join(serverInternalDir, 'nitro-compat.ts'), `export interface ServerEvent {
+  headers: Headers
+}
+
+export function createAuthError(status: number, statusText: string): Error {
+  return Object.assign(new Error(statusText), { status, statusCode: status, statusText, statusMessage: statusText })
+}
+
+export function splitCookiesString(header: string): string[] {
+  return [header]
+}
+`)
 
       writeFileSync(join(serverUtilsDir, 'auth.ts'), `export function serverAuth(_event?: unknown) {
   return {
@@ -73,9 +88,6 @@ export type UserMatch<T> = { [K in keyof T]?: T[K] | T[K][] }
   export interface H3Event {
     headers: Headers
   }
-
-  export function createError(input: { statusCode: number, statusMessage: string }): Error
-  export function splitCookiesString(header: string): string[]
 }
 `)
 
@@ -109,6 +121,7 @@ export async function check(event: H3Event) {
   },
   "files": [
     "./runtime/server/utils/session.ts",
+    "./runtime/server/internal/nitro-compat.ts",
     "./runtime/server/utils/auth.ts",
     "./runtime/utils/match-user.ts",
     "./runtime/types.ts",

--- a/test/route-access-middleware.test.ts
+++ b/test/route-access-middleware.test.ts
@@ -4,17 +4,17 @@ const getRouteRules = vi.fn(() => ({}))
 const getUserSession = vi.fn()
 const requireUserSession = vi.fn()
 
-vi.mock('h3', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('h3')>()
-  return {
-    ...actual,
-    createError: (error: unknown) => error,
-    defineEventHandler: (handler: unknown) => handler,
-    getRequestURL: (event: { path: string }) => new URL(event.path, 'https://example.test'),
-  }
-})
+vi.mock('h3', async importOriginal => ({
+  ...await importOriginal<typeof import('h3')>(),
+  createError: (error: unknown) => error,
+  defineEventHandler: (handler: unknown) => handler,
+  getRequestURL: (event: { path: string }) => new URL(event.path, 'https://example.test'),
+}))
 
-vi.mock('#imports', () => ({ getRouteRules }))
+vi.mock('nitropack/runtime', () => ({
+  getRouteRules,
+  useRuntimeConfig: vi.fn(),
+}))
 
 vi.mock('../src/runtime/server/utils/session', () => ({
   getUserSession,
@@ -24,7 +24,7 @@ vi.mock('../src/runtime/server/utils/session', () => ({
 async function loadMiddleware() {
   vi.resetModules()
   const mod = await import('../src/runtime/server/middleware/route-access')
-  return mod.default as (event: { path: string }) => Promise<void>
+  return mod.default as (event: any) => Promise<void>
 }
 
 describe('route-access middleware', () => {
@@ -53,9 +53,11 @@ describe('route-access middleware', () => {
     requireUserSession.mockResolvedValue({ user: { id: 'user-1' } })
 
     const middleware = await loadMiddleware()
-    await middleware({ path: '/api/test/me' })
+    const event = { path: '/api/test/me' }
+    await middleware(event)
 
     expect(getRouteRules).toHaveBeenCalledTimes(1)
+    expect(getRouteRules).toHaveBeenCalledWith(event)
     expect(requireUserSession).toHaveBeenCalledTimes(1)
   })
 })

--- a/test/server-auth-database-cache.test.ts
+++ b/test/server-auth-database-cache.test.ts
@@ -23,7 +23,9 @@ vi.mock('better-auth', () => ({
   betterAuth: betterAuthMock,
 }))
 
-vi.mock('nitropack/runtime', () => ({
+vi.mock('../src/runtime/server/internal/nitro-compat', () => ({
+  getRequestHost: () => 'example.com',
+  getRequestProtocol: () => 'https',
   useRuntimeConfig: useRuntimeConfigMock,
 }))
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,5 @@
 import { configDefaults, defineConfig } from 'vitest/config'
+import { fileURLToPath } from 'node:url'
 
 const integrationTests = [
   'test/module.test.ts',
@@ -8,10 +9,17 @@ const integrationTests = [
   'test/server-auth-base-url-cache.test.ts',
 ]
 
+const nitroCompatibilityAlias = {
+  '#better-auth/nitro-compat': fileURLToPath(new URL('./src/runtime/server/internal/nitro2.ts', import.meta.url)),
+}
+
 export default defineConfig({
   test: {
     projects: [
       {
+        resolve: {
+          alias: nitroCompatibilityAlias,
+        },
         test: {
           name: 'unit',
           include: ['test/**/*.test.ts'],
@@ -19,6 +27,9 @@ export default defineConfig({
         },
       },
       {
+        resolve: {
+          alias: nitroCompatibilityAlias,
+        },
         test: {
           name: 'integration',
           include: integrationTests,


### PR DESCRIPTION
## Summary

- support Nuxt 4/Nitro 2 and Nuxt 5/Nitro 3 from the same module release
- select the matching runtime and type imports during Nuxt setup, so consumer bundles never include unavailable cross-major APIs
- add clean packed-consumer build and runtime checks for Nuxt 4.5 and the Nuxt 5 nightly

## Root cause

The server runtime imported H3 and Nitro 2 entry points directly. Replacing those imports with Nitro 3 entry points would break Nuxt 4, while runtime feature detection would still leave unavailable static imports in consumer bundles. The module now resolves one source-level compatibility implementation for the active Nuxt major.

Closes #86

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm prepack`
- `pnpm dev:build`
- `pnpm build:docs`
- `pnpm test` (GitHub CI)
- `pnpm exec vitest run --project integration` (5 files, 20 tests)
- GitHub compatibility matrix: Nuxt 4.5/Nitro 2 and Nuxt 5 nightly/Nitro 3 both install the packed module, build, start, and serve the Better Auth endpoint
