### PR TITLE
Docs audit fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+This changelog is incomplete for alpha releases. Use the GitHub Releases page for full history.
+
 ## 0.0.2-alpha.0
 
 ### Fixed

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -21,7 +21,7 @@ npx nuxi module add @onmax/nuxt-better-auth@alpha
 ### Set Environment Variables
 
 ::tip{icon="i-lucide-sparkles"}
-**Nuxt 3.19+**: Running `nuxt prepare` or `nuxt dev` auto-generates the `.env` file with a secure `BETTER_AUTH_SECRET`.
+When you install the module with `nuxi module add`, it prompts you to generate `BETTER_AUTH_SECRET` and can append it to your `.env`. In CI/test environments it auto-generates the secret.
 ::
 
 Add these environment variables to `.env`:
@@ -58,7 +58,7 @@ NUXT_PUBLIC_SITE_URL=https://your-domain.com
 ### Create Configuration Files
 
 ::tip{icon="i-lucide-sparkles"}
-**Nuxt 3.19+**: Running `nuxt prepare` or `nuxt dev` auto-generates these files. The client config is placed in your `srcDir` (e.g., `app/` or project root).
+During module install, `server/auth.config.ts` and `<srcDir>/auth.config.ts` are scaffolded if missing. The client config is placed in your `srcDir` (e.g., `app/` or project root).
 ::
 
 The module requires two configuration files:

--- a/docs/content/2.core-concepts/1.server-auth.md
+++ b/docs/content/2.core-concepts/1.server-auth.md
@@ -12,6 +12,6 @@ description: When to reach for the full Better Auth server instance.
 | Get current session | `getUserSession(event)` | Check if user is logged in |
 | Require authentication | `requireUserSession(event)` | Protect an API route |
 | Access Better Auth API | `serverAuth(event)` | Call `auth.api.listSessions()` |
-| Get session with options | `requireUserSession(event, { role: 'admin' })` | Role-based protection |
+| Get session with options | `requireUserSession(event, { user: { role: 'admin' } })` | Role-based protection |
 
 :read-more{to="/api/server-utils"}

--- a/docs/content/2.core-concepts/2.sessions.md
+++ b/docs/content/2.core-concepts/2.sessions.md
@@ -18,12 +18,12 @@ const {
 
 ## SSR behavior
 
-During server-side rendering (SSR), the module initializes empty session state. When the browser loads the page (hydration), a client plugin fetches the actual session.
+During server-side rendering (SSR), the module attempts to fetch the session using the incoming request cookies and populates state before rendering. A client plugin then keeps the state in sync after hydration.
 
-- **Server render:** `user` and `session` are `null`, `ready` is `false`
-- **After hydration:** `user` and `session` contain data, `ready` is `true`
+- **Server render:** `user` and `session` are set when a valid session cookie exists, `ready` is `true`
+- **After hydration:** state stays in sync with client-side updates
 
-Use `ready` or `<BetterAuthState>` when you need to wait for hydration. Hydration attaches Vue to the server-rendered HTML and makes it interactive.
+For prerendered or cached pages, the client plugin fetches the session after mount. Use `ready` or `<BetterAuthState>` to avoid flashes in those cases.
 
 ## Cookie vs Database Sessions
 
@@ -48,31 +48,14 @@ const { user, loggedIn, ready } = useUserSession()
 
 ## Server-Side Session Access
 
-For pages that need session data during SSR without waiting for hydration:
+For server handlers and API routes, use the server utilities:
 
-```vue [pages/dashboard.vue]
-<script setup lang="ts">
-definePageMeta({ auth: 'user' })
-const { user, ready, fetchSession } = useUserSession()
-
-if (import.meta.server) {
-  await fetchSession({ headers: useRequestHeaders(['cookie']) })
-}
-</script>
-
-<template>
-  <BetterAuthState>
-    <template #default>
-      <p v-if="ready">Welcome {{ user?.name }}</p>
-    </template>
-    <template #placeholder>
-      <p>Loading session...</p>
-    </template>
-  </BetterAuthState>
-</template>
+```ts [server/api/profile.get.ts]
+export default defineEventHandler(async (event) => {
+  const { user } = await requireUserSession(event)
+  return { id: user.id, email: user.email }
+})
 ```
-
-Without server-side session initialization, the page briefly shows a loading state before hydration completes.
 
 ## Session Refresh
 
@@ -99,8 +82,10 @@ import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 
 export default defineServerAuth({
   session: {
-    cookie: {
-      maxAge: 60 * 60 * 24 * 7, // 7 days
+    expiresIn: 60 * 60 * 24 * 7, // 7 days
+    cookieCache: {
+      enabled: true,
+      maxAge: 5 * 60, // 5 minutes
     },
   },
 })

--- a/docs/content/2.core-concepts/3.route-protection.md
+++ b/docs/content/2.core-concepts/3.route-protection.md
@@ -21,12 +21,13 @@ Role arrays use **OR** logic: the user needs any one of the listed values.
 auth: { user: { role: ['admin', 'moderator'] } }
 ```
 
-For **AND** logic (user needs multiple conditions), use a `rule` callback:
+For **AND** logic (user needs multiple conditions), use `requireUserSession` with a `rule` callback in your server handlers:
 
-```ts
-auth: {
-  rule: (session) => session.user.role === 'admin' && session.user.verified
-}
+```ts [server/api/admin/report.ts]
+await requireUserSession(event, {
+  user: { role: 'admin' },
+  rule: ({ user }) => user.verified === true,
+})
 ```
 
 ## 1. Route Rules

--- a/docs/content/2.core-concepts/5.security-caveats.md
+++ b/docs/content/2.core-concepts/5.security-caveats.md
@@ -32,10 +32,12 @@ By default, unauthorized requests to protected routes receive a 401 response. To
 
 **Redirect to login instead of 401:**
 ```ts [server/middleware/auth.ts]
+import { sendRedirect } from 'h3'
+
 export default defineEventHandler(async (event) => {
   const session = await getUserSession(event)
   if (!session && event.path.startsWith('/api/protected')) {
-    throw createError({ statusCode: 401, message: 'Unauthorized' })
+    return sendRedirect(event, '/login', 302)
   }
 })
 ```

--- a/docs/content/3.guides/1.role-based-access.md
+++ b/docs/content/3.guides/1.role-based-access.md
@@ -58,21 +58,6 @@ For complex authorization, use custom middleware or `requireUserSession` with a 
 
 For authorization logic that can't be expressed with field matching:
 
-```ts [nuxt.config.ts]
-export default defineNuxtConfig({
-  routeRules: {
-    '/admin/**': {
-      auth: {
-        rule: (session) => {
-          // User must be admin AND have verified email
-          return session.user.role === 'admin' && session.user.emailVerified
-        }
-      }
-    }
-  }
-})
-```
-
 ```ts [server/api/reports.ts]
 export default defineEventHandler(async (event) => {
   await requireUserSession(event, {

--- a/docs/content/3.guides/2.oauth-providers.md
+++ b/docs/content/3.guides/2.oauth-providers.md
@@ -62,7 +62,12 @@ const { signIn } = useUserSession()
 ```
 
 ::important
-OAuth requires a database to store user accounts and linked providers. Database-less mode (JWE sessions) only works with email/password authentication where you handle user storage externally.
+OAuth can work without a database using stateless (JWE) session cookies, but there are tradeoffs:
+- No persistent account/session management (cannot list or revoke sessions)
+- Limited server-side visibility into linked accounts
+- You must accept that account state lives in encrypted cookies
+
+If you need durable account records or admin/session management, use a database-backed setup.
 ::
 
 ::

--- a/docs/content/3.guides/4.database-less-mode.md
+++ b/docs/content/3.guides/4.database-less-mode.md
@@ -39,6 +39,16 @@ Cannot list or revoke sessions across devices.
 
 **Workaround:** Implement device tracking in your application layer if needed.
 
+### OAuth Considerations
+
+OAuth can work in database-less mode, but account state is stored in encrypted cookies (JWE) instead of a database. This limits server-side management and auditing.
+
+#### When to avoid DB-less OAuth
+
+- You need to list/revoke sessions across devices
+- You need durable account records (admin tools, audits)
+- You rely on server-side account linking or management
+
 ## Nuxt Configuration
 
 Simply don't configure a database adapter:

--- a/docs/content/3.guides/5.external-auth-backend.md
+++ b/docs/content/3.guides/5.external-auth-backend.md
@@ -25,22 +25,30 @@ export default defineNuxtConfig({
 })
 ```
 
-### 2. Configure Client to Point to External Server
+### 2. Point the Client to the External Server
 
-```ts [app/auth.config.ts]
-import { defineClientAuth } from '@onmax/nuxt-better-auth/config'
-
-export default defineClientAuth({
-  baseURL: 'https://auth.example.com', // Your external auth server
-})
-```
-
-### 3. Set Site URL (Optional)
-
-Auto-detected on Vercel/Cloudflare/Netlify. For other platforms:
+`defineClientAuth` is wrapped by the module at runtime, so `baseURL` here is **overridden**.
+To target an external auth server, set the site URL:
 
 ```ini [.env]
-NUXT_PUBLIC_SITE_URL="https://your-frontend.com"
+NUXT_PUBLIC_SITE_URL="https://auth.example.com"
+```
+
+This value becomes the Better Auth client base URL in client-only mode.
+
+### 3. Set Redirect Paths (Optional)
+
+Control where users are sent after auth checks:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  auth: {
+    redirects: {
+      login: '/login',
+      guest: '/',
+    },
+  },
+})
 ```
 
 ## What Changes in Client-Only Mode
@@ -68,7 +76,8 @@ In client-only mode, all auth requests go directly to your external server. Ensu
 ::
 
 ::note
-`NUXT_PUBLIC_SITE_URL` should be your **frontend URL** (for redirects). The auth server URL is configured via `baseURL` in `app/auth.config.ts`.
+In client-only mode, `NUXT_PUBLIC_SITE_URL` is used as the auth client base URL.
+Use `auth.redirects` in `nuxt.config.ts` to control frontend navigation paths.
 ::
 
 ::note
@@ -85,10 +94,14 @@ In client-only mode, session data is fetched **client-side only**. This means:
 
 ```vue
 <template>
-  <BetterAuthState v-slot="{ isLoading, user }">
-    <div v-if="isLoading">Loading...</div>
-    <div v-else-if="user">Welcome, {{ user.name }}</div>
-    <div v-else>Please log in</div>
+  <BetterAuthState>
+    <template #default="{ user }">
+      <div v-if="user">Welcome, {{ user.name }}</div>
+      <div v-else>Please log in</div>
+    </template>
+    <template #placeholder>
+      <div>Loading...</div>
+    </template>
   </BetterAuthState>
 </template>
 ```

--- a/docs/content/3.guides/6.migrate-from-nuxt-auth-utils.md
+++ b/docs/content/3.guides/6.migrate-from-nuxt-auth-utils.md
@@ -232,10 +232,18 @@ const { user } = await requireUserSession(event, {
 ### Password Hashing Migration
 
 ::important
-nuxt-auth-utils uses **scrypt** for password hashing. Better Auth uses **Argon2id** by default. Existing password hashes will not work without migration.
+nuxt-auth-utils uses **scrypt** for password hashing. Better Auth also uses **scrypt** by default (unless you configured a custom password hasher). If you used defaults in both systems, existing password hashes should continue to work.
 ::
 
-#### Option 1: Require Password Resets (Recommended)
+#### Step 0: Validate Hash Compatibility (Recommended)
+
+Before doing any migration work, validate that a known test user's password hash verifies correctly in a staging environment.
+
+If you used the **default** nuxt-auth-utils hashing settings, you can usually keep existing hashes without any migration.
+
+If you customized hashing in nuxt-auth-utils or Better Auth, treat this as a migration and use one of the options below.
+
+#### Option 1: Require Password Resets
 
 The simplest approach: require all users to reset their passwords during migration.
 
@@ -243,7 +251,7 @@ The simplest approach: require all users to reset their passwords during migrati
 2. Direct users to password reset flow on first login
 3. New passwords will use Argon2id
 
-#### Option 2: Support Both Hash Formats
+#### Option 2: Support Both Hash Formats (Custom Hashing)
 
 Implement a custom password verifier that tries both formats:
 
@@ -261,7 +269,7 @@ export default defineServerAuth({
 })
 ```
 
-#### Option 3: Gradual Migration
+#### Option 3: Gradual Migration (Custom Hashing)
 
 Verify with scrypt first, then re-hash with Argon2id on successful login:
 

--- a/docs/content/4.integrations/3.i18n.md
+++ b/docs/content/4.integrations/3.i18n.md
@@ -132,8 +132,8 @@ export default defineServerAuth(() => ({
 | `PASSWORD_TOO_SHORT` | Password too short |
 | `RATE_LIMIT_EXCEEDED` | Too many requests |
 
-::callout{icon="i-lucide-book" to="https://www.better-auth.com/docs/concepts/error-handling"}
-See [Better Auth Error Handling](https://www.better-auth.com/docs/concepts/error-handling) for the complete list of error codes.
+::callout{icon="i-lucide-book" to="https://www.better-auth.com/docs/concepts/client#error-codes"}
+See [Better Auth Error Codes](https://www.better-auth.com/docs/concepts/client#error-codes) for the complete list of error codes.
 ::
 
 ::callout{icon="i-lucide-globe" to="https://github.com/better-auth/better-auth-localization"}

--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -21,7 +21,7 @@ const { loggedIn, user, session, client, signIn, signOut } = useUserSession()
   ::field{name="session" type="Ref<AuthSession | null>"}
     The current session object.
   ::
-  ::field{name="ready" type="Ref<boolean>"}
+  ::field{name="ready" type="ComputedRef<boolean>"}
     `true` when the initial session fetch is complete.
   ::
   ::field{name="client" type="AuthClient | null"}

--- a/docs/content/5.api/4.types.md
+++ b/docs/content/5.api/4.types.md
@@ -12,7 +12,6 @@ import type {
   AuthUser,
   RequireSessionOptions,
   UserMatch,
-  SignOutOptions,
 } from '@onmax/nuxt-better-auth'
 ```
 
@@ -93,7 +92,7 @@ Used for user matching in `AuthMeta.user` and `RequireSessionOptions.user` (OR l
 
 The options object for `requireUserSession(event, options?)`.
 
-### `SignOutOptions`
+### `signOut` options
 
 Used by `signOut(options?)` to run a post-sign-out callback:
 

--- a/docs/content/6.troubleshooting/1.faq.md
+++ b/docs/content/6.troubleshooting/1.faq.md
@@ -68,7 +68,7 @@ Use Better Auth's email plugin:
 
 ## NuxtHub version requirement
 
-If using NuxtHub for database features, you need `@nuxthub/core` version **0.10.0** or higher. NuxtHub is optional - see [NuxtHub Integration](/integrations/nuxthub) for details.
+If using NuxtHub for database features, you need `@nuxthub/core` version **0.10.5** or higher. NuxtHub is optional - see [NuxtHub Integration](/integrations/nuxthub) for details.
 
 ```bash
 pnpm add @nuxthub/core@latest
@@ -79,13 +79,13 @@ pnpm add @nuxthub/core@latest
 The module validates config files at build time.
 Create `server/auth.config.ts` exporting `defineServerAuth(...)`.
 
-## "Missing app/auth.config.ts"
+## "Missing <srcDir>/auth.config.ts"
 
-The module expects a client config file at `app/auth.config.ts` exporting `createAppAuthClient` via `defineClientAuth()`.
+The module expects a client config file at `<srcDir>/auth.config.ts` exporting `defineClientAuth(...)` as default.
 
 ## "auth.config.ts validation failed"
 
-- Ensure the file exports `createServerAuth` via `defineServerAuth()`.
+- Ensure the file exports `defineServerAuth(...)`.
 - Do not set `secret`/`baseURL` manually (the module injects these).
 - Confirm the file is at the expected path (default: `server/auth.config.ts`).
 


### PR DESCRIPTION
## Summary
- Fix migration hashing guidance and related docs
- Clarify OAuth database-less tradeoffs
- Align session and route protection docs with current API
- Update clientOnly baseURL guidance, error codes link, and misc fixes

## Tests
- `pnpm build:docs` (fails: better-sqlite3 NODE_MODULE_VERSION mismatch)