### PR TITLE
fix(docs): clarify custom DB CLI + deps

### DIFF
--- a/docs/content/1.getting-started/3.client-setup.md
+++ b/docs/content/1.getting-started/3.client-setup.md
@@ -23,7 +23,7 @@ export default defineClientAuth(({ siteUrl }) => ({
 ```
 
 ::note
-The helper creates a factory function that the module calls with the correct `baseURL` at runtime.
+`defineClientAuth` returns a config factory. The module calls it with the resolved `baseURL` and creates the client at runtime.
 ::
 
 ## Using Plugins
@@ -38,6 +38,25 @@ export default defineClientAuth({
   plugins: [
     adminClient() // Must match the server plugin
   ]
+})
+```
+
+## Extending Client Config via Hook
+
+Modules can inject client plugins without requiring users to edit `app/auth.config.ts`.
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  hooks: {
+    'better-auth:client:extend'(config) {
+      config.plugins = [
+        {
+          from: 'better-auth/client/plugins',
+          name: 'adminClient',
+        },
+      ]
+    },
+  },
 })
 ```
 

--- a/docs/content/3.guides/3.custom-database.md
+++ b/docs/content/3.guides/3.custom-database.md
@@ -13,6 +13,16 @@ Better Auth supports any database through adapters. Use this guide when you need
 | OAuth-only, no persistence | [Database-less Mode](/guides/database-less-mode) |
 | Existing database, custom setup | **This guide** |
 
+## Install Better Auth
+
+Adapter imports come from the `better-auth` package, so you must install it in your app.
+
+```bash
+pnpm add better-auth
+```
+
+`better-auth` is a peer dependency of `@onmax/nuxt-better-auth`. Keep the major versions aligned to avoid mismatches.
+
 ## Drizzle Adapter
 
 ```ts [server/auth.config.ts]
@@ -66,10 +76,37 @@ export default defineServerAuth({
 You must create the required tables manually. Better Auth provides a CLI to generate schemas:
 
 ```bash
-npx better-auth generate
+npx @better-auth/cli@latest generate
 ```
 
 This generates migration files for your adapter. Apply them with your database tool.
+
+### CLI config (Nuxt)
+
+The CLI reads a Better Auth instance from `auth.ts`, not your `server/auth.config.ts`. Add a dedicated `auth.ts` file for CLI generation.
+
+```ts [auth.ts]
+import { betterAuth } from 'better-auth'
+import { drizzleAdapter } from 'better-auth/adapters/drizzle'
+import { drizzle } from 'drizzle-orm/node-postgres'
+
+const db = drizzle(process.env.DATABASE_URL!)
+
+export const auth = betterAuth({
+  database: drizzleAdapter(db, { provider: 'pg' }),
+  emailAndPassword: { enabled: true },
+})
+```
+
+If you use Prisma or Kysely, swap the adapter section to match your setup.
+
+Use `--config` if you place the file elsewhere:
+
+```bash
+npx @better-auth/cli@latest generate --config server/auth/auth.ts
+```
+
+Keep this config in sync with `server/auth.config.ts` so the generated schema matches your runtime plugins and options.
 
 ::callout{icon="i-lucide-book" to="https://www.better-auth.com/docs/concepts/database"}
 See **Better Auth database docs** for full schema reference and adapter options.

--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -1,18 +1,21 @@
-import type { AppAuthClient, AuthSession, AuthUser } from '#nuxt-better-auth'
+import type { AuthSession, AuthUser } from '#nuxt-better-auth'
 import type { ComputedRef, Ref } from 'vue'
-import createAppAuthClient from '#auth/client'
+import getClientConfig from '#auth/client'
 import { computed, nextTick, useRequestHeaders, useRequestURL, useRuntimeConfig, useState, watch } from '#imports'
+import { createAuthClient } from 'better-auth/vue'
+
+type AuthClient = ReturnType<typeof createAuthClient>
 
 export interface SignOutOptions { onSuccess?: () => void | Promise<void> }
 
 export interface UseUserSessionReturn {
-  client: AppAuthClient | null
+  client: AuthClient | null
   session: Ref<AuthSession | null>
   user: Ref<AuthUser | null>
   loggedIn: ComputedRef<boolean>
   ready: ComputedRef<boolean>
-  signIn: NonNullable<AppAuthClient>['signIn']
-  signUp: NonNullable<AppAuthClient>['signUp']
+  signIn: NonNullable<AuthClient>['signIn']
+  signUp: NonNullable<AuthClient>['signUp']
   signOut: (options?: SignOutOptions) => Promise<void>
   waitForSession: () => Promise<void>
   fetchSession: (options?: { headers?: HeadersInit, force?: boolean }) => Promise<void>
@@ -20,11 +23,13 @@ export interface UseUserSessionReturn {
 }
 
 // Singleton client instance to ensure consistent state across all useUserSession calls
-let _client: AppAuthClient | null = null
-function getClient(baseURL: string): AppAuthClient {
-  if (!_client)
-    _client = createAppAuthClient(baseURL)
-  return _client
+let _client: AuthClient | null = null
+function getClient(baseURL: string): AuthClient {
+  if (!_client) {
+    const config = getClientConfig(baseURL)
+    _client = createAuthClient(config)
+  }
+  return _client!
 }
 
 export function useUserSession(): UseUserSessionReturn {
@@ -32,8 +37,8 @@ export function useUserSession(): UseUserSessionReturn {
   const requestURL = useRequestURL()
 
   // Client only - create better-auth client for client-side operations (singleton)
-  const client: AppAuthClient | null = import.meta.client
-    ? getClient(runtimeConfig.public.siteUrl || requestURL.origin)
+  const client: AuthClient | null = import.meta.client
+    ? getClient((runtimeConfig.public.siteUrl as string) || requestURL.origin)
     : null
 
   // Shared state via useState for SSR hydration
@@ -99,8 +104,8 @@ export function useUserSession(): UseUserSessionReturn {
   }
 
   // Wrap signIn methods to wait for session sync before calling onSuccess
-  type SignIn = NonNullable<AppAuthClient>['signIn']
-  type SignUp = NonNullable<AppAuthClient>['signUp']
+  type SignIn = NonNullable<AuthClient>['signIn']
+  type SignUp = NonNullable<AuthClient>['signUp']
 
   // Wraps onSuccess callback to sync session before executing
   function wrapOnSuccess(cb: (ctx: unknown) => void | Promise<void>) {

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -2,7 +2,6 @@ import type { BetterAuthOptions } from 'better-auth'
 import type { ClientOptions } from 'better-auth/client'
 import type { CasingOption } from '../schema-generator'
 import type { ServerAuthContext } from './types/augment'
-import { createAuthClient } from 'better-auth/vue'
 
 // Re-export for declaration merging with generated types
 export type { ServerAuthContext }
@@ -56,10 +55,10 @@ export function defineServerAuth<T extends ServerAuthConfig>(config: T | ((ctx: 
   return typeof config === 'function' ? config : () => config
 }
 
-export function defineClientAuth<T extends ClientAuthConfig>(config: T | ((ctx: ClientAuthContext) => T)): (baseURL: string) => ReturnType<typeof createAuthClient<T>> {
+export function defineClientAuth<T extends ClientAuthConfig>(config: T | ((ctx: ClientAuthContext) => T)): (baseURL: string) => T & { baseURL: string } {
   return (baseURL: string) => {
     const ctx: ClientAuthContext = { siteUrl: baseURL }
     const resolved = typeof config === 'function' ? config(ctx) : config
-    return createAuthClient({ ...resolved, baseURL })
+    return { ...resolved, baseURL }
   }
 }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,12 +1,33 @@
 import type { BetterAuthOptions } from 'better-auth'
 
+export interface ClientPluginImport {
+  /** Import path to the plugin file (e.g., 'my-module/runtime/client-plugin') */
+  from: string
+  /** Named export to import (e.g., 'myPlugin'). If not specified, uses default export. */
+  name?: string
+  /** Options to pass to the plugin function */
+  options?: Record<string, unknown>
+}
+
+export interface ClientExtendConfig {
+  /** Plugin imports to add to the client config */
+  plugins?: ClientPluginImport[]
+}
+
 declare module '@nuxt/schema' {
   interface NuxtHooks {
     /**
-     * Extend better-auth config with additional plugins or options.
-     * Called after user's auth.config.ts is loaded.
-     * @param config - Partial config to merge into the auth options
+     * Extend better-auth server config with additional plugins or options.
+     * Called during schema generation for NuxtHub database.
+     * @param config - Partial config to merge into the server auth options
      */
     'better-auth:config:extend': (config: Partial<BetterAuthOptions>) => void | Promise<void>
+
+    /**
+     * Extend better-auth client config with additional plugins.
+     * Called during module setup, affects runtime client.
+     * @param config - Plugin imports to merge into the client auth options
+     */
+    'better-auth:client:extend': (config: ClientExtendConfig) => void | Promise<void>
   }
 }


### PR DESCRIPTION
## Summary
- document `better-auth` as required for adapter imports
- fix schema generation command to use `@better-auth/cli`
- add Nuxt CLI config guidance with `auth.ts` example and `--config` usage

## Tests
- not run (docs-only)

Closes #93
