### PR TITLE
fix(docs): clarify custom DB CLI + deps

### DIFF
--- a/docs/content/3.guides/3.custom-database.md
+++ b/docs/content/3.guides/3.custom-database.md
@@ -13,6 +13,16 @@ Better Auth supports any database through adapters. Use this guide when you need
 | OAuth-only, no persistence | [Database-less Mode](/guides/database-less-mode) |
 | Existing database, custom setup | **This guide** |
 
+## Install Better Auth
+
+Adapter imports come from the `better-auth` package, so you must install it in your app.
+
+```bash
+pnpm add better-auth
+```
+
+`better-auth` is a peer dependency of `@onmax/nuxt-better-auth`. Keep the major versions aligned to avoid mismatches.
+
 ## Drizzle Adapter
 
 ```ts [server/auth.config.ts]
@@ -66,10 +76,37 @@ export default defineServerAuth({
 You must create the required tables manually. Better Auth provides a CLI to generate schemas:
 
 ```bash
-npx better-auth generate
+npx @better-auth/cli@latest generate
 ```
 
 This generates migration files for your adapter. Apply them with your database tool.
+
+### CLI config (Nuxt)
+
+The CLI reads a Better Auth instance from `auth.ts`, not your `server/auth.config.ts`. Add a dedicated `auth.ts` file for CLI generation.
+
+```ts [auth.ts]
+import { betterAuth } from 'better-auth'
+import { drizzleAdapter } from 'better-auth/adapters/drizzle'
+import { drizzle } from 'drizzle-orm/node-postgres'
+
+const db = drizzle(process.env.DATABASE_URL!)
+
+export const auth = betterAuth({
+  database: drizzleAdapter(db, { provider: 'pg' }),
+  emailAndPassword: { enabled: true },
+})
+```
+
+If you use Prisma or Kysely, swap the adapter section to match your setup.
+
+Use `--config` if you place the file elsewhere:
+
+```bash
+npx @better-auth/cli@latest generate --config server/auth/auth.ts
+```
+
+Keep this config in sync with `server/auth.config.ts` so the generated schema matches your runtime plugins and options.
 
 ::callout{icon="i-lucide-book" to="https://www.better-auth.com/docs/concepts/database"}
 See **Better Auth database docs** for full schema reference and adapter options.


### PR DESCRIPTION
## Summary
- document `better-auth` as required for adapter imports
- fix schema generation command to use `@better-auth/cli`
- add Nuxt CLI config guidance with `auth.ts` example and `--config` usage

## Tests
- not run (docs-only)

Closes #93
