### PR TITLE
fix(auth): make ssr session skip opt-in

### DIFF
--- a/docs/content/2.core-concepts/2.sessions.md
+++ b/docs/content/2.core-concepts/2.sessions.md
@@ -18,10 +18,30 @@ const {
 
 ## SSR behavior
 
-During server-side rendering (SSR), the module attempts to fetch the session using the incoming request cookies and populates state before rendering. A client plugin then keeps the state in sync after hydration.
+During server-side rendering (SSR), the module fetches the session using incoming request cookies and populates state before rendering. A client plugin then keeps the state in sync after hydration.
 
-- **Server render:** `user` and `session` are set when a valid session cookie exists, `ready` is `true`
-- **After hydration:** state stays in sync with client-side updates
+- **Server render:** `user` and `session` are set when a valid session cookie exists, and `ready` is `true`.
+- **After hydration:** State stays in sync with client-side updates.
+
+### Optional: Skip Hydrated SSR Session Fetch
+
+By default, SSR pages still bootstrap the client session with an initial `/api/auth/get-session` request. This enables Better Auth's session refresh behavior.
+
+If you want to skip that request when `user` and `session` are already hydrated from SSR, enable the option below:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  betterAuth: {
+    session: {
+      skipHydratedSsrGetSession: true,
+    },
+  },
+})
+```
+
+::warning
+When enabled, the module skips Better Auth's session refresh manager on those SSR pages (focus, polling, broadcast). Session state will still sync after auth actions that trigger a session signal.
+::
 
 For prerendered or cached pages, the client plugin fetches the session after mount. Use `ready` or `<BetterAuthState>` to avoid flashes in those cases.
 

--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -22,7 +22,7 @@ const { loggedIn, user, session, client, signIn, signOut } = useUserSession()
     The current session object.
   ::
   ::field{name="ready" type="ComputedRef<boolean>"}
-    `true` when the initial session fetch is complete.
+    `true` when initial session resolution is complete (from SSR hydration or client fetch).
   ::
   ::field{name="client" type="AuthClient | null"}
     Direct access to the Better Auth client instance.

--- a/src/module/runtime.ts
+++ b/src/module/runtime.ts
@@ -45,6 +45,9 @@ export function setupRuntimeConfig(input: SetupRuntimeConfigInput): { secondaryS
     useDatabase: databaseProvider !== 'none',
     databaseProvider,
     clientOnly,
+    session: {
+      skipHydratedSsrGetSession: options.session?.skipHydratedSsrGetSession ?? false,
+    },
   }) as AuthRuntimeConfig
 
   if (clientOnly) {

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -30,6 +30,16 @@ export interface BetterAuthModuleOptions {
     login?: string // default: '/login'
     guest?: string // default: '/'
   }
+  session?: {
+    /**
+     * When enabled, and session/user are already hydrated from SSR, skip the initial
+     * client `/api/auth/get-session` bootstrap request. This also skips Better Auth's
+     * session refresh manager on those pages.
+     *
+     * Default: false
+     */
+    skipHydratedSsrGetSession?: boolean
+  }
   /** Enable KV secondary storage for sessions. Requires hub.kv: true */
   secondaryStorage?: boolean
   /** Database backend selection and provider-specific options */
@@ -54,6 +64,7 @@ export interface AuthRuntimeConfig {
   useDatabase: boolean
   databaseProvider: DatabaseProvider
   clientOnly: boolean
+  session: { skipHydratedSsrGetSession: boolean }
 }
 
 // Private runtime config (server-only)

--- a/test/use-user-session.test.ts
+++ b/test/use-user-session.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+interface SessionState {
+  data: { session: Record<string, unknown>, user: Record<string, unknown> } | null
+  isPending: boolean
+  isRefetching: boolean
+  error: unknown
+}
+
+const payload = {
+  serverRendered: false,
+  prerenderedAt: undefined as unknown,
+  isCached: false,
+}
+
+const runtimeConfig = {
+  public: {
+    siteUrl: 'http://localhost:3000',
+    auth: {
+      session: {
+        skipHydratedSsrGetSession: false,
+      },
+    },
+  },
+}
+
+const requestURL = { origin: 'http://localhost:3000' }
+let requestHeaders: HeadersInit | undefined = { cookie: 'session=test' }
+const state = new Map<string, ReturnType<typeof ref>>()
+
+const sessionAtom = ref<SessionState>({
+  data: null,
+  isPending: false,
+  isRefetching: false,
+  error: null,
+})
+
+const mockClient = {
+  useSession: vi.fn(() => sessionAtom),
+  getSession: vi.fn(async () => ({ data: null })),
+  $store: {
+    listen: vi.fn(),
+  },
+  signOut: vi.fn(async () => {}),
+  signIn: { social: vi.fn(async () => ({})), email: vi.fn(async () => ({})) },
+  signUp: { email: vi.fn(async () => ({})) },
+}
+
+vi.mock('#auth/client', () => ({
+  default: vi.fn(() => mockClient),
+}))
+
+vi.mock('#imports', async () => {
+  const vue = await import('vue')
+  return {
+    computed: vue.computed,
+    nextTick: vue.nextTick,
+    watch: vue.watch,
+    useNuxtApp: () => ({ payload }),
+    useRequestHeaders: () => requestHeaders,
+    useRequestURL: () => requestURL,
+    useRuntimeConfig: () => runtimeConfig,
+    useState: <T>(key: string, init: () => T) => {
+      if (!state.has(key))
+        state.set(key, vue.ref(init()))
+      return state.get(key) as ReturnType<typeof vue.ref<T>>
+    },
+  }
+})
+
+function setRuntimeFlags(flags: { client: boolean, server: boolean }) {
+  const state = globalThis as { __NUXT_BETTER_AUTH_TEST_FLAGS__?: { client: boolean, server: boolean } }
+  state.__NUXT_BETTER_AUTH_TEST_FLAGS__ = flags
+}
+
+async function loadUseUserSession() {
+  vi.resetModules()
+  const mod = await import('../src/runtime/app/composables/useUserSession')
+  return mod.useUserSession
+}
+
+function seedHydratedState() {
+  state.set('auth:session', ref({ id: 'session-1' }))
+  state.set('auth:user', ref({ id: 'user-1' }))
+  state.set('auth:ready', ref(false))
+}
+
+describe('useUserSession hydration bootstrap', () => {
+  beforeEach(() => {
+    state.clear()
+    payload.serverRendered = false
+    payload.prerenderedAt = undefined
+    payload.isCached = false
+    requestHeaders = { cookie: 'session=test' }
+    requestURL.origin = 'http://localhost:3000'
+    runtimeConfig.public.siteUrl = 'http://localhost:3000'
+    runtimeConfig.public.auth.session.skipHydratedSsrGetSession = false
+
+    sessionAtom.value = {
+      data: null,
+      isPending: false,
+      isRefetching: false,
+      error: null,
+    }
+
+    mockClient.useSession.mockClear()
+    mockClient.getSession.mockClear()
+    mockClient.$store.listen.mockClear()
+    mockClient.signOut.mockClear()
+    mockClient.signIn.social.mockClear()
+    mockClient.signIn.email.mockClear()
+    mockClient.signUp.email.mockClear()
+    mockClient.getSession.mockResolvedValue({ data: null })
+
+    setRuntimeFlags({ client: true, server: false })
+  })
+
+  afterEach(() => {
+    delete (globalThis as { __NUXT_BETTER_AUTH_TEST_FLAGS__?: { client: boolean, server: boolean } }).__NUXT_BETTER_AUTH_TEST_FLAGS__
+  })
+
+  it('bootstraps client session by default even when SSR payload is hydrated', async () => {
+    payload.serverRendered = true
+    seedHydratedState()
+
+    const useUserSession = await loadUseUserSession()
+    const auth = useUserSession()
+
+    expect(auth.ready.value).toBe(true)
+    expect(mockClient.useSession).toHaveBeenCalledOnce()
+  })
+
+  it('skips initial client session bootstrap when option is enabled and SSR payload is hydrated', async () => {
+    payload.serverRendered = true
+    runtimeConfig.public.auth.session.skipHydratedSsrGetSession = true
+    seedHydratedState()
+
+    let _signalCb: (() => void | Promise<void>) | undefined
+    mockClient.$store.listen.mockImplementation((_signal: string, cb: () => void | Promise<void>) => {
+      _signalCb = cb
+      return () => {
+        _signalCb = undefined
+      }
+    })
+
+    const useUserSession = await loadUseUserSession()
+    const auth = useUserSession()
+
+    expect(mockClient.useSession).not.toHaveBeenCalled()
+    expect(auth.ready.value).toBe(true)
+    expect(mockClient.$store.listen).toHaveBeenCalledOnce()
+    expect(_signalCb).toBeDefined()
+  })
+
+  it('bootstraps client session when SSR payload is not hydrated (even with option enabled)', async () => {
+    payload.serverRendered = true
+    runtimeConfig.public.auth.session.skipHydratedSsrGetSession = true
+
+    const useUserSession = await loadUseUserSession()
+    useUserSession()
+
+    expect(mockClient.useSession).toHaveBeenCalledOnce()
+  })
+
+  it('bootstraps client session for prerendered/cached payloads', async () => {
+    payload.serverRendered = true
+    payload.prerenderedAt = Date.now()
+    runtimeConfig.public.auth.session.skipHydratedSsrGetSession = true
+    seedHydratedState()
+
+    const useUserSession = await loadUseUserSession()
+    useUserSession()
+
+    expect(mockClient.useSession).toHaveBeenCalledOnce()
+  })
+
+  it('bootstraps client session on CSR navigation', async () => {
+    payload.serverRendered = false
+    runtimeConfig.public.auth.session.skipHydratedSsrGetSession = true
+    seedHydratedState()
+
+    const useUserSession = await loadUseUserSession()
+    useUserSession()
+
+    expect(mockClient.useSession).toHaveBeenCalledOnce()
+  })
+
+  it('fetchSession still calls getSession and updates state', async () => {
+    mockClient.getSession.mockResolvedValueOnce({
+      data: {
+        session: { id: 'session-2', token: 'secret', ipAddress: '127.0.0.1' },
+        user: { id: 'user-2', email: 'user@example.com' },
+      },
+    })
+
+    const useUserSession = await loadUseUserSession()
+    const auth = useUserSession()
+    await auth.fetchSession()
+
+    expect(mockClient.getSession).toHaveBeenCalledOnce()
+    expect(auth.session.value).toEqual({ id: 'session-2', ipAddress: '127.0.0.1' })
+    expect(auth.user.value).toEqual({ id: 'user-2', email: 'user@example.com' })
+  })
+
+  it('syncs session on $sessionSignal when option is enabled and SSR payload is hydrated', async () => {
+    payload.serverRendered = true
+    runtimeConfig.public.auth.session.skipHydratedSsrGetSession = true
+    seedHydratedState()
+
+    let signalCb: (() => void | Promise<void>) | undefined
+    mockClient.$store.listen.mockImplementation((_signal: string, cb: () => void | Promise<void>) => {
+      signalCb = cb
+      return () => {
+        signalCb = undefined
+      }
+    })
+
+    mockClient.getSession.mockResolvedValueOnce({
+      data: {
+        session: { id: 'session-3', token: 'secret', ipAddress: '127.0.0.1' },
+        user: { id: 'user-3', email: 'user3@example.com' },
+      },
+    })
+
+    const useUserSession = await loadUseUserSession()
+    const auth = useUserSession()
+
+    expect(mockClient.useSession).not.toHaveBeenCalled()
+    expect(auth.ready.value).toBe(true)
+
+    await signalCb?.()
+
+    expect(mockClient.getSession).toHaveBeenCalledOnce()
+    expect(auth.session.value).toEqual({ id: 'session-3', ipAddress: '127.0.0.1' })
+    expect(auth.user.value).toEqual({ id: 'user-3', email: 'user3@example.com' })
+  })
+})


### PR DESCRIPTION
Closes https://github.com/nuxt-modules/better-auth/issues/103

## Description
1. Skip the initial client /api/auth/get-session request when SSR already hydrated user and session.
2. Add focused composable tests and docs clarifications for SSR hydration + ready behavior.