### PR TITLE
fix(auth): persist updateUser to server

### DIFF
--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -117,11 +117,15 @@ await fetchSession({
 
 #### `updateUser`
 
-Optimistically updates the local user object.
+Updates the user on the server and optimistically patches local state. Local state reverts if the server call fails.
 
 ```ts
-updateUser({ name: 'New Name' })
+await updateUser({ name: 'New Name' })
 ```
+
+::note
+During SSR, `updateUser` only patches local state since no client is available.
+::
 
 ::tip
 **Reactivity**: `user` and `session` are global states using `useState`. Changes in one component are instantly reflected everywhere.

--- a/src/runtime/types/augment.ts
+++ b/src/runtime/types/augment.ts
@@ -44,5 +44,5 @@ export interface UserSessionComposable {
   fetchSession: (options?: { headers?: HeadersInit, force?: boolean }) => Promise<void>
   waitForSession: () => Promise<void>
   signOut: (options?: { onSuccess?: () => void | Promise<void> }) => Promise<void>
-  updateUser: (updates: Partial<AuthUser>) => void
+  updateUser: (updates: Partial<AuthUser>) => Promise<void>
 }

--- a/test/cases/plugins-type-inference/server/auth.config.ts
+++ b/test/cases/plugins-type-inference/server/auth.config.ts
@@ -25,7 +25,7 @@ function customAdminLikePlugin() {
 
 export default defineServerAuth({
   emailAndPassword: { enabled: true },
-  plugins: [customAdminLikePlugin()],
+  plugins: [customAdminLikePlugin()] as const,
   user: {
     additionalFields: {
       internalCode: {


### PR DESCRIPTION
Closes #108

## Problem
`updateUser()` only patched local reactive state, so changes were lost on session refresh because nothing was persisted to the server.

## Behavior
- On client: `updateUser()` persists with `client.updateUser(updates)`.
- Local state is patched optimistically first.
- If the server call fails (throw or error payload), local user state is rolled back.
- On SSR (no client available), `updateUser()` only patches local state.

## Repros
- Bug: [`nuxt-better-auth-108`](https://github.com/onmax/repros/tree/repro/nuxt-better-auth-108/nuxt-better-auth-108)
- Fix: [`nuxt-better-auth-108-fix`](https://github.com/onmax/repros/tree/repro/nuxt-better-auth-108/nuxt-better-auth-108-fix)
