### PR TITLE
fix(devtools): gate db mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@
 
 **[nuxt-better-auth.onmax.me](https://nuxt-better-auth.onmax.me/)**
 
+## Alpha Migration Notes
+
+- `auth.database.*` module options are removed. This now fails fast during module setup.
+- Configure Better Auth's `database` directly in `server/auth.config.ts`, or use a module that registers `better-auth:database:providers`.
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
   "devDependencies": {
     "@antfu/eslint-config": "^4.12.0",
     "@libsql/client": "^0.15.15",
-    "@libsql/linux-x64-gnu": "0.5.22",
     "@nuxt/devtools": "^3.1.1",
     "@nuxt/devtools-kit": "^3.1.1",
     "@nuxt/module-builder": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,9 +50,6 @@ importers:
       '@libsql/client':
         specifier: ^0.15.15
         version: 0.15.15
-      '@libsql/linux-x64-gnu':
-        specifier: 0.5.22
-        version: 0.5.22
       '@nuxt/devtools':
         specifier: ^3.1.1
         version: 3.1.1(vite@7.2.7(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))
@@ -10397,7 +10394,8 @@ snapshots:
   '@libsql/linux-arm64-musl@0.5.22':
     optional: true
 
-  '@libsql/linux-x64-gnu@0.5.22': {}
+  '@libsql/linux-x64-gnu@0.5.22':
+    optional: true
 
   '@libsql/linux-x64-musl@0.5.22':
     optional: true

--- a/src/runtime/server/api/_better-auth/accounts.get.ts
+++ b/src/runtime/server/api/_better-auth/accounts.get.ts
@@ -1,8 +1,20 @@
 import { defineEventHandler, getQuery } from 'h3'
+import { isDevtoolsDatabaseEligible } from '../../../utils/devtools-database'
+import { getDatabaseProvider, getDatabaseSource } from '../../utils/auth'
 import { paginationQuerySchema, sanitizeSearchPattern } from './_schema'
 
 export default defineEventHandler(async (event) => {
   try {
+    const databaseProvider = getDatabaseProvider()
+    const databaseSource = getDatabaseSource()
+    if (!isDevtoolsDatabaseEligible({ databaseProvider, databaseSource })) {
+      return {
+        accounts: [],
+        total: 0,
+        error: 'DevTools DB routes are only available for module-managed nuxthub database mode.',
+      }
+    }
+
     const { db, schema } = await import('@nuxthub/db')
     if (!schema.account)
       return { accounts: [], total: 0, error: 'Account table not found' }

--- a/src/runtime/server/api/_better-auth/sessions.get.ts
+++ b/src/runtime/server/api/_better-auth/sessions.get.ts
@@ -1,8 +1,20 @@
 import { defineEventHandler, getQuery } from 'h3'
+import { isDevtoolsDatabaseEligible } from '../../../utils/devtools-database'
+import { getDatabaseProvider, getDatabaseSource } from '../../utils/auth'
 import { paginationQuerySchema, sanitizeSearchPattern } from './_schema'
 
 export default defineEventHandler(async (event) => {
   try {
+    const databaseProvider = getDatabaseProvider()
+    const databaseSource = getDatabaseSource()
+    if (!isDevtoolsDatabaseEligible({ databaseProvider, databaseSource })) {
+      return {
+        sessions: [],
+        total: 0,
+        error: 'DevTools DB routes are only available for module-managed nuxthub database mode.',
+      }
+    }
+
     const { db, schema } = await import('@nuxthub/db')
     if (!schema.session)
       return { sessions: [], total: 0, error: 'Session table not found' }

--- a/src/runtime/server/api/_better-auth/users.get.ts
+++ b/src/runtime/server/api/_better-auth/users.get.ts
@@ -1,8 +1,20 @@
 import { defineEventHandler, getQuery } from 'h3'
+import { isDevtoolsDatabaseEligible } from '../../../utils/devtools-database'
+import { getDatabaseProvider, getDatabaseSource } from '../../utils/auth'
 import { paginationQuerySchema, sanitizeSearchPattern } from './_schema'
 
 export default defineEventHandler(async (event) => {
   try {
+    const databaseProvider = getDatabaseProvider()
+    const databaseSource = getDatabaseSource()
+    if (!isDevtoolsDatabaseEligible({ databaseProvider, databaseSource })) {
+      return {
+        users: [],
+        total: 0,
+        error: 'DevTools DB routes are only available for module-managed nuxthub database mode.',
+      }
+    }
+
     const { db, schema } = await import('@nuxthub/db')
     if (!schema.user)
       return { users: [], total: 0, error: 'User table not found' }

--- a/src/runtime/utils/devtools-database.ts
+++ b/src/runtime/utils/devtools-database.ts
@@ -1,0 +1,14 @@
+export interface DevtoolsDatabaseEligibilityInput {
+  databaseProvider?: string | null
+  databaseSource?: string | null
+  fallbackModuleProvider?: string | null
+}
+
+export function isDevtoolsDatabaseEligible(input: DevtoolsDatabaseEligibilityInput): boolean {
+  const { databaseProvider, databaseSource, fallbackModuleProvider } = input
+
+  if (typeof databaseProvider === 'string')
+    return databaseProvider === 'nuxthub' && databaseSource === 'module'
+
+  return fallbackModuleProvider === 'nuxthub'
+}

--- a/test/devtools-database-eligibility.test.ts
+++ b/test/devtools-database-eligibility.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { isDevtoolsDatabaseEligible } from '../src/runtime/utils/devtools-database'
+
+describe('isDevtoolsDatabaseEligible', () => {
+  it('returns true for nuxthub + module', () => {
+    expect(isDevtoolsDatabaseEligible({
+      databaseProvider: 'nuxthub',
+      databaseSource: 'module',
+    })).toBe(true)
+  })
+
+  it('returns false for nuxthub + user', () => {
+    expect(isDevtoolsDatabaseEligible({
+      databaseProvider: 'nuxthub',
+      databaseSource: 'user',
+    })).toBe(false)
+  })
+
+  it('returns false for custom provider + module', () => {
+    expect(isDevtoolsDatabaseEligible({
+      databaseProvider: 'custom-db',
+      databaseSource: 'module',
+    })).toBe(false)
+  })
+
+  it('returns false for none provider', () => {
+    expect(isDevtoolsDatabaseEligible({
+      databaseProvider: 'none',
+      databaseSource: 'module',
+    })).toBe(false)
+  })
+
+  it('returns true from fallback nuxthub provider when config is unavailable', () => {
+    expect(isDevtoolsDatabaseEligible({
+      fallbackModuleProvider: 'nuxthub',
+    })).toBe(true)
+  })
+
+  it('returns false from fallback none/custom provider', () => {
+    expect(isDevtoolsDatabaseEligible({
+      fallbackModuleProvider: 'none',
+    })).toBe(false)
+
+    expect(isDevtoolsDatabaseEligible({
+      fallbackModuleProvider: 'custom-db',
+    })).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- gate devtools DB tabs/fetches to module-managed nuxthub mode only
- add server-side guards for devtools DB endpoints to avoid cross-provider access
- remove temporary @libsql/linux-x64-gnu root pin and related note

## Tests
- pnpm vitest run test/devtools-database-eligibility.test.ts
- pnpm lint
- pnpm typecheck