### PR TITLE
chore: update docs url to better-auth.nuxt.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ## Documentation
 
-**[nuxt-better-auth.onmax.me](https://nuxt-better-auth.onmax.me/)**
+**[better-auth.nuxt.dev](https://better-auth.nuxt.dev/)**
 
 ## License
 

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -12,7 +12,7 @@ export default defineNuxtConfig({
 
   // Used by useSiteConfig() and for absolute OG URLs.
   site: {
-    url: 'https://nuxt-better-auth.onmax.me',
+    url: 'https://better-auth.nuxt.dev',
     name: 'Nuxt Better Auth',
     description: 'Nuxt module for Better Auth with auto schema generation, route protection, and session management.',
     defaultLocale: 'en',
@@ -23,8 +23,8 @@ export default defineNuxtConfig({
       link: [{ rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' }],
       meta: [
         { name: 'twitter:card', content: 'summary_large_image' },
-        { property: 'og:image', content: 'https://nuxt-better-auth.onmax.me/og.png' },
-        { name: 'twitter:image', content: 'https://nuxt-better-auth.onmax.me/og.png' },
+        { property: 'og:image', content: 'https://better-auth.nuxt.dev/og.png' },
+        { name: 'twitter:image', content: 'https://better-auth.nuxt.dev/og.png' },
         { property: 'og:image:width', content: '1200' },
         { property: 'og:image:height', content: '630' },
       ],

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "description": "Nuxt module for Better Auth integration with NuxtHub, route protection, session management, and role-based access",
   "author": "onmax",
   "license": "MIT",
+  "homepage": "https://better-auth.nuxt.dev",
   "repository": {
     "type": "git",
     "url": "https://github.com/nuxt-modules/better-auth"

--- a/playground/app/pages/forget-password.vue
+++ b/playground/app/pages/forget-password.vue
@@ -67,7 +67,7 @@ async function handleRequestReset() {
       <div class="flex justify-center w-full border-t pt-4">
         <p class="text-center text-xs text-neutral-500">
           built with
-          <a href="https://nuxt-better-auth.onmax.me/" class="underline" target="_blank">
+          <a href="https://better-auth.nuxt.dev/" class="underline" target="_blank">
             <span class="dark:text-white/70 cursor-pointer">nuxt-better-auth.</span>
           </a>
         </p>

--- a/playground/app/pages/index.vue
+++ b/playground/app/pages/index.vue
@@ -23,7 +23,7 @@ const { loggedIn } = useUserSession()
           Official demo to showcase
           <a href="https://better-auth.com" target="_blank" class="italic underline">better-auth.</a>
           features using
-          <a href="https://nuxt-better-auth.onmax.me" target="_blank" class="italic underline">nuxt-better-auth.</a>
+          <a href="https://better-auth.nuxt.dev" target="_blank" class="italic underline">nuxt-better-auth.</a>
         </p>
       </div>
       <div class="md:w-10/12 w-full flex flex-col gap-4">

--- a/playground/app/pages/login.vue
+++ b/playground/app/pages/login.vue
@@ -104,7 +104,7 @@ async function handlePasskeySignIn() {
       <div class="flex justify-center w-full border-t pt-4">
         <p class="text-center text-xs text-neutral-500">
           built with
-          <a href="https://nuxt-better-auth.onmax.me/" class="underline" target="_blank">
+          <a href="https://better-auth.nuxt.dev/" class="underline" target="_blank">
             <span class="dark:text-white/70 cursor-pointer">nuxt-better-auth.</span>
           </a>
         </p>

--- a/playground/app/pages/register.vue
+++ b/playground/app/pages/register.vue
@@ -127,7 +127,7 @@ async function handleSignUp() {
       <div class="flex justify-center w-full border-t pt-4">
         <p class="text-center text-xs text-neutral-500">
           built with
-          <a href="https://nuxt-better-auth.onmax.me/" class="underline" target="_blank">
+          <a href="https://better-auth.nuxt.dev/" class="underline" target="_blank">
             <span class="dark:text-white/70 cursor-pointer">nuxt-better-auth.</span>
           </a>
         </p>

--- a/playground/app/pages/reset-password.vue
+++ b/playground/app/pages/reset-password.vue
@@ -86,7 +86,7 @@ async function handleResetPassword() {
       <div class="flex justify-center w-full border-t pt-4">
         <p class="text-center text-xs text-neutral-500">
           built with
-          <a href="https://nuxt-better-auth.onmax.me/" class="underline" target="_blank">
+          <a href="https://better-auth.nuxt.dev/" class="underline" target="_blank">
             <span class="dark:text-white/70 cursor-pointer">nuxt-better-auth.</span>
           </a>
         </p>


### PR DESCRIPTION
Docs moved from `nuxt-better-auth.onmax.me` → `better-auth.nuxt.dev`. Updates all references (demo URLs unchanged).