### PR TITLE
fix: align nuxt min-version to >=4.0.0

### DIFF
--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -6,7 +6,7 @@ navigation.icon: i-lucide-download
 
 ## Prerequisites
 
-- Nuxt v3.10+
+- Nuxt v4.0+
 
 ## Add to project
 

--- a/docs/content/6.troubleshooting/1.faq.md
+++ b/docs/content/6.troubleshooting/1.faq.md
@@ -21,7 +21,7 @@ Yes, using [database-less mode](/guides/database-less-mode). Sessions are stored
 
 ### Does this work with Nuxt 2?
 
-No. This module requires Nuxt 3.10 or later.
+No. This module requires Nuxt 4 or later.
 
 ### What's the difference from nuxt-auth-utils?
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -68,7 +68,7 @@ export default defineClientAuth({})
 export type { BetterAuthModuleOptions } from './runtime/config'
 
 export default defineNuxtModule<BetterAuthModuleOptions>({
-  meta: { name: '@onmax/nuxt-better-auth', version, configKey: 'auth', compatibility: { nuxt: '>=3.0.0' } },
+  meta: { name: '@onmax/nuxt-better-auth', version, configKey: 'auth', compatibility: { nuxt: '>=4.0.0' } },
   defaults: {
     clientOnly: false,
     serverConfig: 'server/auth.config',


### PR DESCRIPTION
Module declared `>=3.0.0` (boilerplate from module starter) but always required Nuxt 4 (`@nuxt/kit ^4.2.2`). Docs said 3.10+. Aligns all references to `>=4.0.0`. Closes #122.