### PR TITLE
fix: cache serverAuth per-host instead of singleton

### DIFF
--- a/test/cases/base-url-inference/.nuxtrc
+++ b/test/cases/base-url-inference/.nuxtrc
@@ -1,0 +1,1 @@
+setups.@onmax/nuxt-better-auth="0.0.2-alpha.21"

--- a/test/cases/base-url-inference/app/app.vue
+++ b/test/cases/base-url-inference/app/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <NuxtPage />
+</template>

--- a/test/cases/base-url-inference/app/auth.config.ts
+++ b/test/cases/base-url-inference/app/auth.config.ts
@@ -1,0 +1,3 @@
+import { defineClientAuth } from '../../../../src/runtime/config'
+
+export default defineClientAuth({})

--- a/test/cases/base-url-inference/nuxt.config.ts
+++ b/test/cases/base-url-inference/nuxt.config.ts
@@ -1,0 +1,6 @@
+export default defineNuxtConfig({
+  modules: ['../../../src/module'],
+  runtimeConfig: {
+    betterAuthSecret: 'test-secret-for-testing-only-32chars!',
+  },
+})

--- a/test/cases/base-url-inference/server/api/test/base-url.get.ts
+++ b/test/cases/base-url-inference/server/api/test/base-url.get.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler((event) => {
+  const auth = serverAuth(event) as { options?: { baseURL?: string } }
+  return { baseURL: auth.options?.baseURL }
+})

--- a/test/cases/base-url-inference/server/auth.config.ts
+++ b/test/cases/base-url-inference/server/auth.config.ts
@@ -1,0 +1,11 @@
+import { defineServerAuth } from '../../../../src/runtime/config'
+
+export default defineServerAuth(({ runtimeConfig }) => ({
+  appName: 'Base URL inference test app',
+  socialProviders: {
+    github: {
+      clientId: runtimeConfig.github?.clientId || 'test',
+      clientSecret: runtimeConfig.github?.clientSecret || 'test',
+    },
+  },
+}))

--- a/test/server-auth-base-url-cache.test.ts
+++ b/test/server-auth-base-url-cache.test.ts
@@ -1,0 +1,32 @@
+import { fileURLToPath } from 'node:url'
+import { setup, url } from '@nuxt/test-utils/e2e'
+import { describe, expect, it } from 'vitest'
+
+describe('serverAuth baseURL inference', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('./cases/base-url-inference', import.meta.url)),
+  })
+
+  it('derives baseURL from each request host when siteUrl is unset', async () => {
+    const firstResponse = await fetch(url('/api/test/base-url'), {
+      headers: {
+        'x-forwarded-host': 'first.example.com',
+        'x-forwarded-proto': 'https',
+      },
+    })
+    expect(firstResponse.status).toBe(200)
+    const firstBody = await firstResponse.json() as { baseURL: string | undefined }
+
+    const secondResponse = await fetch(url('/api/test/base-url'), {
+      headers: {
+        'x-forwarded-host': 'second.example.com',
+        'x-forwarded-proto': 'https',
+      },
+    })
+    expect(secondResponse.status).toBe(200)
+    const secondBody = await secondResponse.json() as { baseURL: string | undefined }
+
+    expect(firstBody.baseURL).toBe('https://first.example.com')
+    expect(secondBody.baseURL).toBe('https://second.example.com')
+  })
+})


### PR DESCRIPTION
`serverAuth()` cached a single instance with the baseURL from the first request. Subsequent requests from different hosts got the wrong baseURL. Now caches per resolved host. When `siteUrl` is explicitly set, uses a single cached instance.

Closes #121