### PR TITLE
fix(types): augment requireusersession server types

### DIFF
--- a/docs/content/5.api/2.server-utils.md
+++ b/docs/content/5.api/2.server-utils.md
@@ -63,6 +63,10 @@ Ensures the user is authenticated and optionally matches specific criteria. Thro
 const { user, session } = await requireUserSession(event, options?)
 ```
 
+::note
+`requireUserSession` uses `AuthUser` and `AuthSession` from `#nuxt-better-auth` for both the returned value and option callbacks (`user` match + `rule`).
+::
+
 ### Options
 
 ::field-group

--- a/docs/content/5.api/4.types.md
+++ b/docs/content/5.api/4.types.md
@@ -91,6 +91,7 @@ Used for user matching in `AuthMeta.user` and `RequireSessionOptions.user` (OR l
 ### `RequireSessionOptions`
 
 The options object for `requireUserSession(event, options?)`.
+It is augmentation-aware: `user` matching and `rule` callback context use `AuthUser` / `AuthSession` from `#nuxt-better-auth`.
 
 ### `signOut` options
 

--- a/src/module/type-templates.ts
+++ b/src/module/type-templates.ts
@@ -126,8 +126,14 @@ export function registerSharedTypeTemplates(input: RegisterSharedTypeTemplatesIn
   addTypeTemplate({
     filename: 'types/nuxt-better-auth.d.ts',
     getContents: () => `
+import type { AuthSession, AuthUser } from '${input.runtimeTypesAugmentPath}'
+import type { UserMatch } from '${input.runtimeTypesPath}'
 export * from '${input.runtimeTypesAugmentPath}'
-export type { AuthMeta, AuthMode, AuthRouteRules, UserMatch, RequireSessionOptions, Auth, InferUser, InferSession } from '${input.runtimeTypesPath}'
+export type { AuthMeta, AuthMode, AuthRouteRules, UserMatch, Auth, InferUser, InferSession } from '${input.runtimeTypesPath}'
+export interface RequireSessionOptions {
+  user?: UserMatch<AuthUser>
+  rule?: (ctx: { user: AuthUser, session: AuthSession }) => boolean | Promise<boolean>
+}
 `,
   })
 

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -1,10 +1,15 @@
 import type { H3Event } from 'h3'
-import type { AuthSession, AuthUser, RequireSessionOptions } from '../../types'
+import type { AuthSession, AuthUser } from '#nuxt-better-auth'
+import type { UserMatch } from '../../types'
 import { createError } from 'h3'
 import { matchesUser } from '../../utils/match-user'
 import { serverAuth } from './auth'
 
 interface FullSession { user: AuthUser, session: AuthSession }
+interface RequireUserSessionOptions {
+  user?: UserMatch<AuthUser>
+  rule?: (ctx: { user: AuthUser, session: AuthSession }) => boolean | Promise<boolean>
+}
 
 export async function getUserSession(event: H3Event): Promise<FullSession | null> {
   const auth = serverAuth(event)
@@ -12,7 +17,7 @@ export async function getUserSession(event: H3Event): Promise<FullSession | null
   return session as FullSession | null
 }
 
-export async function requireUserSession(event: H3Event, options?: RequireSessionOptions): Promise<FullSession> {
+export async function requireUserSession(event: H3Event, options?: RequireUserSessionOptions): Promise<FullSession> {
   const session = await getUserSession(event)
 
   if (!session)

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -1,5 +1,5 @@
-import type { H3Event } from 'h3'
 import type { AuthSession, AuthUser } from '#nuxt-better-auth'
+import type { H3Event } from 'h3'
 import type { UserMatch } from '../../types'
 import { createError } from 'h3'
 import { matchesUser } from '../../utils/match-user'

--- a/test/require-user-session-typing.test.ts
+++ b/test/require-user-session-typing.test.ts
@@ -1,0 +1,119 @@
+import { copyFileSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'pathe'
+import { spawnSync } from 'node:child_process'
+import { describe, expect, it } from 'vitest'
+
+describe('requireUserSession typing regression #130', () => {
+  it('uses augmented AuthUser/AuthSession types for return value and options', async () => {
+    const testDir = mkdtempSync(join(tmpdir(), 'nuxt-better-auth-session-types-'))
+    try {
+      const runtimeDir = join(testDir, 'runtime')
+      const serverUtilsDir = join(runtimeDir, 'server', 'utils')
+      const runtimeUtilsDir = join(runtimeDir, 'utils')
+
+      mkdirSync(serverUtilsDir, { recursive: true })
+      mkdirSync(runtimeUtilsDir, { recursive: true })
+
+      copyFileSync(join(import.meta.dirname, '../src/runtime/server/utils/session.ts'), join(serverUtilsDir, 'session.ts'))
+
+      writeFileSync(join(serverUtilsDir, 'auth.ts'), `export function serverAuth(_event?: unknown) {
+  return {
+    api: {
+      getSession: async (_ctx: unknown) => null,
+    },
+  }
+}
+`)
+
+      writeFileSync(join(runtimeUtilsDir, 'match-user.ts'), `export function matchesUser(_user: unknown, _match: unknown): boolean {
+  return true
+}
+`)
+
+      writeFileSync(join(runtimeDir, 'types.ts'), `export interface AuthUser {
+  id: string
+  email?: string
+}
+
+export interface AuthSession {
+  id: string
+}
+
+export type UserMatch<T> = { [K in keyof T]?: T[K] | T[K][] }
+`)
+
+      writeFileSync(join(testDir, 'augment.d.ts'), `declare module '#nuxt-better-auth' {
+  interface AuthUser {
+    id: string
+    email?: string
+    address?: string
+  }
+
+  interface AuthSession {
+    id: string
+  }
+}
+`)
+
+      writeFileSync(join(testDir, 'h3.d.ts'), `declare module 'h3' {
+  export interface H3Event {
+    headers: Headers
+  }
+
+  export function createError(input: { statusCode: number, statusMessage: string }): Error
+}
+`)
+
+      writeFileSync(join(testDir, 'check.ts'), `import type { H3Event } from 'h3'
+import { requireUserSession } from './runtime/server/utils/session'
+
+export async function check(event: H3Event) {
+  const session = await requireUserSession(event, {
+    user: { address: 'NQ12...' },
+    rule: ({ user }) => Boolean(user.address),
+  })
+
+  return session.user.address
+}
+`)
+
+      const tsconfigPath = join(testDir, 'tsconfig.json')
+      writeFileSync(tsconfigPath, `{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": [],
+    "paths": {
+      "h3": ["./h3.d.ts"],
+      "#nuxt-better-auth": ["./augment.d.ts"]
+    }
+  },
+  "files": [
+    "./runtime/server/utils/session.ts",
+    "./runtime/server/utils/auth.ts",
+    "./runtime/utils/match-user.ts",
+    "./runtime/types.ts",
+    "./augment.d.ts",
+    "./check.ts"
+  ]
+}
+`)
+
+      const typecheck = spawnSync('pnpm', ['exec', 'tsc', '--noEmit', '--pretty', 'false', '-p', tsconfigPath], {
+        cwd: import.meta.dirname,
+        encoding: 'utf8',
+      })
+
+      expect(typecheck.status, `tsc failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)
+    }
+    finally {
+      await rm(testDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/test/require-user-session-typing.test.ts
+++ b/test/require-user-session-typing.test.ts
@@ -1,8 +1,8 @@
+import { spawnSync } from 'node:child_process'
 import { copyFileSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'pathe'
-import { spawnSync } from 'node:child_process'
 import { describe, expect, it } from 'vitest'
 
 describe('requireUserSession typing regression #130', () => {


### PR DESCRIPTION
## Summary
- switch server session utility typing to augmentation-aware `AuthUser`/`AuthSession` from `#nuxt-better-auth`
- make `requireUserSession` option types (`user` match + `rule` callback) augmentation-aware as well
- align generated `RequireSessionOptions` from `#nuxt-better-auth` with augmented `AuthUser`/`AuthSession`
- add an isolated regression test that typechecks copied `session.ts` against module augmentation
- document the augmentation-aware behavior in server utils/types API docs

## Why
Server `requireUserSession` previously referenced base `AuthUser`/`AuthSession` types from internal relative paths, so additional fields inferred/augmented for `#nuxt-better-auth` were missing in server handlers.

Fixes #130

## Testing
- `pnpm vitest run test/require-user-session-typing.test.ts` ✅
- `pnpm vitest run test/infer-plugins-types.test.ts` ✅
- `pnpm test` ✅
