### PR TITLE
test(vitest): serialize integration files

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,34 @@
+import { configDefaults, defineConfig } from 'vitest/config'
+
+const integrationTests = [
+  'test/module.test.ts',
+  'test/no-db.test.ts',
+  'test/no-hub.test.ts',
+  'test/dev-trusted-origins.test.ts',
+  'test/server-auth-base-url-cache.test.ts',
+]
+
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        test: {
+          name: 'unit',
+          include: ['test/**/*.test.ts'],
+          exclude: [...configDefaults.exclude, ...integrationTests],
+        },
+      },
+      {
+        test: {
+          name: 'integration',
+          include: integrationTests,
+          fileParallelism: false,
+          hookTimeout: 180_000,
+          sequence: {
+            groupOrder: 1,
+          },
+        },
+      },
+    ],
+  },
+})


### PR DESCRIPTION
## Summary
- add a dedicated `vitest.config.ts` with separate `unit` and `integration` projects
- run Nuxt integration files (`test/module.test.ts`, `test/no-db.test.ts`, `test/no-hub.test.ts`, `test/dev-trusted-origins.test.ts`, `test/server-auth-base-url-cache.test.ts`) with `fileParallelism: false`
- increase integration hook timeout to `180_000` and set `sequence.groupOrder` so integration runs after unit tests
- keep unit tests parallel

## Why
- reduces flaky integration behavior in CI caused by multiple Nuxt integration environments competing for shared runtime resources (port/timeouts and transient output resolution)

## Tests
- `pnpm lint`
- `pnpm test`
- `pnpm test` repeated 3x (all passing)
