### PR TITLE
fix(types): preserve define server auth literals

### DIFF
--- a/src/module/type-templates.ts
+++ b/src/module/type-templates.ts
@@ -86,8 +86,8 @@ declare module '@onmax/nuxt-better-auth/config' {
   type ServerAuthConfig = Omit<BetterAuthOptions, 'secret' | 'baseURL'> & {
     plugins?: readonly BetterAuthPlugin[]
   }
-  export function defineServerAuth<const R extends ServerAuthConfig>(config: R): (ctx: _AugmentedServerAuthContext) => R
-  export function defineServerAuth<const R extends ServerAuthConfig>(config: (ctx: _AugmentedServerAuthContext) => R): (ctx: _AugmentedServerAuthContext) => R
+  export function defineServerAuth<const R>(config: (ctx: _AugmentedServerAuthContext) => R & ServerAuthConfig): (ctx: _AugmentedServerAuthContext) => R
+  export function defineServerAuth<const R>(config: R & ServerAuthConfig): (ctx: _AugmentedServerAuthContext) => R
 }
 `,
   }, { nuxt: true, nitro: true, node: true })

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -70,9 +70,9 @@ export interface AuthPrivateRuntimeConfig {
   secondaryStorage: boolean
 }
 
-export function defineServerAuth<const R extends ServerAuthConfig>(config: R): (ctx: ServerAuthContext) => R
-export function defineServerAuth<const R extends ServerAuthConfig>(config: (ctx: ServerAuthContext) => R): (ctx: ServerAuthContext) => R
-export function defineServerAuth<T extends ServerAuthConfig>(config: T | ((ctx: ServerAuthContext) => T)): (ctx: ServerAuthContext) => T {
+export function defineServerAuth<const R>(config: (ctx: ServerAuthContext) => R & ServerAuthConfig): (ctx: ServerAuthContext) => R
+export function defineServerAuth<const R>(config: R & ServerAuthConfig): (ctx: ServerAuthContext) => R
+export function defineServerAuth(config: ServerAuthConfig | ((ctx: ServerAuthContext) => ServerAuthConfig)): (ctx: ServerAuthContext) => ServerAuthConfig {
   return typeof config === 'function' ? config : () => config
 }
 

--- a/test/cases/define-server-auth-literal-inference/tsconfig.json
+++ b/test/cases/define-server-auth-literal-inference/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "types": [],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "files": [
+    "./typecheck-target.ts"
+  ]
+}

--- a/test/cases/define-server-auth-literal-inference/typecheck-target.ts
+++ b/test/cases/define-server-auth-literal-inference/typecheck-target.ts
@@ -1,0 +1,36 @@
+import { defineServerAuth } from '../../../../src/runtime/config'
+
+const objectConfig = defineServerAuth({
+  advanced: { database: { generateId: 'uuid' } },
+  user: {
+    additionalFields: {
+      address: { type: 'string', required: false, fieldName: 'address' },
+    },
+  },
+})
+
+const callbackConfig = defineServerAuth(() => ({
+  advanced: { database: { generateId: 'uuid' } },
+  user: {
+    additionalFields: {
+      city: { type: 'string', required: false },
+    },
+  },
+}))
+
+void objectConfig
+void callbackConfig
+
+// @ts-expect-error invalid generateId literal
+defineServerAuth({
+  advanced: { database: { generateId: 'invalid-id' } },
+})
+
+// @ts-expect-error invalid additionalFields type literal
+defineServerAuth({
+  user: {
+    additionalFields: {
+      badField: { type: 'invalid-type' },
+    },
+  },
+})

--- a/test/define-server-auth-literal-inference.test.ts
+++ b/test/define-server-auth-literal-inference.test.ts
@@ -1,0 +1,16 @@
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const fixtureDir = fileURLToPath(new URL('./cases/define-server-auth-literal-inference', import.meta.url))
+
+describe('defineServerAuth literal inference regression #134', () => {
+  it('typechecks nested literals without as const and rejects invalid literals', () => {
+    const typecheck = spawnSync('pnpm', ['exec', 'tsc', '--noEmit', '--pretty', 'false', '-p', 'tsconfig.json'], {
+      cwd: fixtureDir,
+      encoding: 'utf8',
+    })
+
+    expect(typecheck.status, `tsc failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- switch `defineServerAuth` overloads to unconstrained literal inference with `ServerAuthConfig` validation intersections
- keep runtime behavior unchanged while preserving nested literals like `generateId: 'uuid'` and `additionalFields.*.type: 'string'` without `as const`
- mirror the overload strategy in generated type template declarations
- add regression coverage with positive and negative compile-time assertions for issue 134

## Tests
- `pnpm lint`
- `pnpm typecheck`
- `pnpm vitest run test/define-server-auth-literal-inference.test.ts test/infer-plugins-types.test.ts`

Closes #134
