### PR TITLE
docs(nuxt-better-auth): standardize secondaryStorage guidance

### DIFF
--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -58,10 +58,6 @@ export default defineNuxtConfig({
     Enable KV as secondary storage for sessions. This significantly improves performance by reducing database hits for session validation.
 
     **Requirement**: Requires [NuxtHub Integration](/integrations/nuxthub) with `hub: { kv: true }`.
-
-    **Baseline recommendation**: Keep this disabled first, confirm your app behavior with DB-backed sessions, then enable it when session lookup volume justifies KV acceleration.
-
-    **Operational caveat**: Session invalidation still propagates through cache lifecycle. Plan for a short cache-staleness window around sign-out / permission changes.
   ::
 
   ::field{name="database.provider" type="'none' | 'nuxthub' | 'convex'"}

--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -58,6 +58,10 @@ export default defineNuxtConfig({
     Enable KV as secondary storage for sessions. This significantly improves performance by reducing database hits for session validation.
 
     **Requirement**: Requires [NuxtHub Integration](/integrations/nuxthub) with `hub: { kv: true }`.
+
+    **Baseline recommendation**: Keep this disabled first, confirm your app behavior with DB-backed sessions, then enable it when session lookup volume justifies KV acceleration.
+
+    **Operational caveat**: Session invalidation still propagates through cache lifecycle. Plan for a short cache-staleness window around sign-out / permission changes.
   ::
 
   ::field{name="database.provider" type="'none' | 'nuxthub' | 'convex'"}

--- a/docs/content/4.integrations/1.nuxthub.md
+++ b/docs/content/4.integrations/1.nuxthub.md
@@ -90,76 +90,15 @@ export default defineNuxtConfig({
 
 Sessions are cached in NuxtHub KV, reducing database queries.
 
-## Recommended Session Strategy (DB + KV)
+## Secondary Storage Notes
 
-Use this baseline by default:
+`secondaryStorage` stores session lookups in NuxtHub KV and can reduce repeated database reads on session validation. SSR requests still resolve session state per request, but lookups can hit KV instead of the database.
 
-1. Start with DB-backed sessions only (`secondaryStorage: false`).
-2. Validate auth flows (sign-in, sign-out, role/permission changes, SSR pages, protected APIs).
-3. Enable KV secondary storage only when session read load becomes a bottleneck.
+This setup can introduce a short propagation window after session invalidation events, such as sign-out or permission-sensitive updates. For critical authorization paths, keep server-side checks in place with `requireUserSession`.
 
-DB-default example:
+Enable `secondaryStorage` when `hub.kv` is enabled and session-read traffic is a measurable bottleneck. Keep DB-only sessions when your traffic is moderate or when you prioritize stricter read-after-write consistency.
 
-```ts [nuxt.config.ts]
-export default defineNuxtConfig({
-  hub: {
-    db: 'sqlite',
-    kv: true,
-  },
-  auth: {
-    secondaryStorage: false,
-  },
-})
-```
-
-KV-secondary example:
-
-```ts [nuxt.config.ts]
-export default defineNuxtConfig({
-  hub: {
-    db: 'sqlite',
-    kv: true,
-  },
-  auth: {
-    secondaryStorage: true,
-  },
-})
-```
-
-### Decision Checklist
-
-Enable `secondaryStorage` when most of these are true:
-
-- You already run with `@nuxthub/core` and `hub.kv: true`.
-- Session validation traffic is high enough to pressure DB reads.
-- You can tolerate a short cache-staleness window around invalidation events.
-- You have a rollback path to DB-only sessions.
-
-Keep DB-only sessions when most of these are true:
-
-- Traffic is moderate and DB session reads are not a bottleneck.
-- You prioritize strict consistency over cache-assisted throughput.
-- You are still validating auth behavior during initial rollout.
-
-### SSR and Invalidation Notes
-
-- SSR requests still resolve session state per request; KV secondary storage reduces DB hits during session lookups.
-- Session invalidation (sign-out, revocation, permission-sensitive updates) can have brief propagation windows while cache entries expire/refresh.
-- For critical authorization changes, enforce server-side checks (`requireUserSession`) and avoid assuming immediate cache convergence.
-
-### Rollout / Migration Playbook
-
-1. Deploy with `secondaryStorage: false` and confirm baseline metrics.
-2. Enable `hub.kv: true` and `auth.secondaryStorage: true` in one environment (staging first).
-3. Observe session errors, auth API latency, and sign-out/revocation behavior.
-4. Promote to production after behavior matches expectations.
-
-### Rollback Playbook
-
-1. Set `auth.secondaryStorage: false`.
-2. Deploy and verify session reads continue through DB path.
-3. Keep KV enabled for other app features if needed; session behavior no longer depends on it.
-4. Re-enable only after addressing observed cache or invalidation issues.
+To return to DB-only session reads, set `auth.secondaryStorage` to `false` and deploy.
 
 ## Production Migrations
 

--- a/docs/content/4.integrations/1.nuxthub.md
+++ b/docs/content/4.integrations/1.nuxthub.md
@@ -90,7 +90,7 @@ export default defineNuxtConfig({
 
 Sessions are cached in NuxtHub KV, reducing database queries.
 
-## Secondary Storage Notes
+## Choosing Secondary Storage
 
 `secondaryStorage` stores session lookups in NuxtHub KV and can reduce repeated database reads on session validation. SSR requests still resolve session state per request, but lookups can hit KV instead of the database.
 

--- a/docs/content/4.integrations/1.nuxthub.md
+++ b/docs/content/4.integrations/1.nuxthub.md
@@ -90,6 +90,77 @@ export default defineNuxtConfig({
 
 Sessions are cached in NuxtHub KV, reducing database queries.
 
+## Recommended Session Strategy (DB + KV)
+
+Use this baseline by default:
+
+1. Start with DB-backed sessions only (`secondaryStorage: false`).
+2. Validate auth flows (sign-in, sign-out, role/permission changes, SSR pages, protected APIs).
+3. Enable KV secondary storage only when session read load becomes a bottleneck.
+
+DB-default example:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  hub: {
+    db: 'sqlite',
+    kv: true,
+  },
+  auth: {
+    secondaryStorage: false,
+  },
+})
+```
+
+KV-secondary example:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  hub: {
+    db: 'sqlite',
+    kv: true,
+  },
+  auth: {
+    secondaryStorage: true,
+  },
+})
+```
+
+### Decision Checklist
+
+Enable `secondaryStorage` when most of these are true:
+
+- You already run with `@nuxthub/core` and `hub.kv: true`.
+- Session validation traffic is high enough to pressure DB reads.
+- You can tolerate a short cache-staleness window around invalidation events.
+- You have a rollback path to DB-only sessions.
+
+Keep DB-only sessions when most of these are true:
+
+- Traffic is moderate and DB session reads are not a bottleneck.
+- You prioritize strict consistency over cache-assisted throughput.
+- You are still validating auth behavior during initial rollout.
+
+### SSR and Invalidation Notes
+
+- SSR requests still resolve session state per request; KV secondary storage reduces DB hits during session lookups.
+- Session invalidation (sign-out, revocation, permission-sensitive updates) can have brief propagation windows while cache entries expire/refresh.
+- For critical authorization changes, enforce server-side checks (`requireUserSession`) and avoid assuming immediate cache convergence.
+
+### Rollout / Migration Playbook
+
+1. Deploy with `secondaryStorage: false` and confirm baseline metrics.
+2. Enable `hub.kv: true` and `auth.secondaryStorage: true` in one environment (staging first).
+3. Observe session errors, auth API latency, and sign-out/revocation behavior.
+4. Promote to production after behavior matches expectations.
+
+### Rollback Playbook
+
+1. Set `auth.secondaryStorage: false`.
+2. Deploy and verify session reads continue through DB path.
+3. Keep KV enabled for other app features if needed; session behavior no longer depends on it.
+4. Re-enable only after addressing observed cache or invalidation issues.
+
 ## Production Migrations
 
 NuxtHub handles migrations automatically in most deployments. For manual control:


### PR DESCRIPTION
## Summary
- add an opinionated baseline for NuxtHub session storage strategy
- document clear decision checklist for when to enable `secondaryStorage`
- clarify SSR/session invalidation behavior and consistency caveats
- add rollout and rollback playbooks
- include explicit DB-default and KV-secondary config examples

Closes #137
