### PR TITLE
feat(nuxt-better-auth): auth schema drift diagnostics

### DIFF
--- a/docs/content/4.integrations/1.nuxthub.md
+++ b/docs/content/4.integrations/1.nuxthub.md
@@ -201,6 +201,43 @@ npx nuxt db migrate   # Apply (automatic in dev)
 Restart dev server after adding schemas in `server/db/` for NuxtHub to discover them.
 ::
 
+## Schema Drift Diagnostics (CI / scripts)
+
+Use the built-in diagnostics helpers to catch mixed migration states before deploy.
+
+```ts [scripts/check-auth-schema-drift.ts]
+import { db } from '@nuxthub/db'
+import { sql } from 'drizzle-orm'
+import {
+  assertNoAuthSchemaDrift,
+  checkAuthSchemaDrift,
+  createSqliteSchemaIntrospector,
+  formatAuthSchemaDriftReport,
+} from '@onmax/nuxt-better-auth'
+
+const introspector = createSqliteSchemaIntrospector(async (query) => {
+  const rows = await db.execute(sql.raw(query))
+  return rows as unknown[]
+})
+
+const report = await checkAuthSchemaDrift(introspector)
+console.log(formatAuthSchemaDriftReport(report))
+assertNoAuthSchemaDrift(report)
+```
+
+Run it in CI:
+
+```yaml
+- name: Check auth schema drift
+  run: pnpm exec tsx scripts/check-auth-schema-drift.ts
+```
+
+The diagnostics include:
+
+- Missing core auth tables/columns (`user`, `account`, `session`)
+- Compatibility columns (`banned`, `banReason`, `banExpires`, `impersonatedBy`)
+- Invitation email width mismatch (`255`)
+
 ### Adding Columns to Auth Tables
 
 To add fields to existing auth tables (e.g., `role` on `user`), use Better Auth's `additionalFields` instead of custom schemas.

--- a/docs/content/6.troubleshooting/1.faq.md
+++ b/docs/content/6.troubleshooting/1.faq.md
@@ -134,6 +134,30 @@ hub: { db: { dialect: 'sqlite' } }
 
 Restart dev server after changing Better Auth plugins.
 
+## How do I detect auth schema drift during upgrades?
+
+Run diagnostics in a script/CI step before deployment:
+
+```ts [scripts/check-auth-schema-drift.ts]
+import { db } from '@nuxthub/db'
+import { sql } from 'drizzle-orm'
+import {
+  checkAuthSchemaDrift,
+  createSqliteSchemaIntrospector,
+  formatAuthSchemaDriftReport,
+} from '@onmax/nuxt-better-auth'
+
+const report = await checkAuthSchemaDrift(createSqliteSchemaIntrospector(async (query) => {
+  return await db.execute(sql.raw(query)) as unknown[]
+}))
+
+console.log(formatAuthSchemaDriftReport(report))
+if (!report.ok)
+  process.exit(1)
+```
+
+This catches common mixed-state upgrades (missing compat columns, invitation email width mismatch, missing core auth tables/columns) before runtime incidents.
+
 ## `routeRules` changes don't apply
 
 `routeRules` are synced to page meta during `pages:extend`.

--- a/src/module.ts
+++ b/src/module.ts
@@ -227,3 +227,12 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
 
 export { defineClientAuth, defineServerAuth } from './runtime/config'
 export type { Auth, AuthMeta, AuthMode, AuthRouteRules, AuthSession, AuthUser, InferSession, InferUser, RequireSessionOptions, ServerAuthContext, UserMatch } from './runtime/types'
+export {
+  analyzeAuthSchemaDrift,
+  assertNoAuthSchemaDrift,
+  checkAuthSchemaDrift,
+  createMySqlSchemaIntrospector,
+  createPostgresSchemaIntrospector,
+  createSqliteSchemaIntrospector,
+  formatAuthSchemaDriftReport,
+} from './schema-diagnostics'

--- a/src/schema-diagnostics.ts
+++ b/src/schema-diagnostics.ts
@@ -1,0 +1,345 @@
+export type AuthSchemaDriftLevel = 'error' | 'warning'
+
+export interface AuthSchemaColumn {
+  name: string
+  dataType?: string | null
+  maxLength?: number | null
+}
+
+export interface AuthSchemaTable {
+  name: string
+  columns: AuthSchemaColumn[]
+}
+
+export interface AuthSchemaSnapshot {
+  tables: Record<string, AuthSchemaTable>
+}
+
+export interface AuthSchemaDriftIssue {
+  level: AuthSchemaDriftLevel
+  code: string
+  message: string
+  table?: string
+  column?: string
+}
+
+export interface AuthSchemaDriftReport {
+  ok: boolean
+  issues: AuthSchemaDriftIssue[]
+}
+
+export interface AuthSchemaDriftOptions {
+  expectSessionTable?: boolean
+  tableNames?: {
+    user?: string
+    account?: string
+    session?: string
+    invitation?: string | string[]
+  }
+}
+
+export interface AuthSchemaIntrospector {
+  listTables: () => Promise<string[]>
+  listColumns: (tableName: string) => Promise<AuthSchemaColumn[]>
+}
+
+export type SqlQuery = (query: string) => Promise<unknown[]>
+
+interface ResolvedTableNames {
+  user: string
+  account: string
+  session: string
+  invitationCandidates: string[]
+}
+
+function resolveTableNames(options: AuthSchemaDriftOptions = {}): ResolvedTableNames {
+  const invitation = options.tableNames?.invitation
+  const invitationCandidates = Array.isArray(invitation)
+    ? invitation
+    : invitation
+      ? [invitation]
+      : ['invitation', 'invitations']
+
+  return {
+    user: options.tableNames?.user || 'user',
+    account: options.tableNames?.account || 'account',
+    session: options.tableNames?.session || 'session',
+    invitationCandidates,
+  }
+}
+
+function normalizeName(name: string): string {
+  return name.trim().toLowerCase()
+}
+
+function toColumnMap(columns: AuthSchemaColumn[]): Record<string, AuthSchemaColumn> {
+  return Object.fromEntries(columns.map(column => [normalizeName(column.name), column]))
+}
+
+function addIssue(issues: AuthSchemaDriftIssue[], issue: AuthSchemaDriftIssue): void {
+  issues.push(issue)
+}
+
+function parseLengthFromSqlType(dataType: string | null | undefined): number | null {
+  if (!dataType)
+    return null
+  const match = dataType.match(/\((\d+)\)/)
+  if (!match)
+    return null
+  const parsed = Number.parseInt(match[1], 10)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function parseNumber(value: unknown): number | null {
+  if (value == null)
+    return null
+  if (typeof value === 'number')
+    return Number.isFinite(value) ? value : null
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+function escapeSqlLiteral(value: string): string {
+  return value.replaceAll('\'', '\'\'')
+}
+
+export function analyzeAuthSchemaDrift(snapshot: AuthSchemaSnapshot, options: AuthSchemaDriftOptions = {}): AuthSchemaDriftReport {
+  const issues: AuthSchemaDriftIssue[] = []
+  const tableNames = resolveTableNames(options)
+  const expectSessionTable = options.expectSessionTable ?? true
+
+  const tablesByName = Object.fromEntries(
+    Object.values(snapshot.tables).map(table => [normalizeName(table.name), table]),
+  )
+
+  const requiredTables = [tableNames.user, tableNames.account, ...(expectSessionTable ? [tableNames.session] : [])]
+  for (const tableName of requiredTables) {
+    if (!tablesByName[normalizeName(tableName)]) {
+      addIssue(issues, {
+        level: 'error',
+        code: 'missing_table',
+        table: tableName,
+        message: `Missing required auth table "${tableName}"`,
+      })
+    }
+  }
+
+  const userTable = tablesByName[normalizeName(tableNames.user)]
+  const accountTable = tablesByName[normalizeName(tableNames.account)]
+  const sessionTable = tablesByName[normalizeName(tableNames.session)]
+
+  if (userTable) {
+    const columns = toColumnMap(userTable.columns)
+    for (const columnName of ['id']) {
+      if (!columns[normalizeName(columnName)]) {
+        addIssue(issues, {
+          level: 'error',
+          code: 'missing_required_column',
+          table: userTable.name,
+          column: columnName,
+          message: `Missing required column "${columnName}" on "${userTable.name}"`,
+        })
+      }
+    }
+
+    for (const columnName of ['banned', 'banReason', 'banExpires']) {
+      if (!columns[normalizeName(columnName)]) {
+        addIssue(issues, {
+          level: 'warning',
+          code: 'missing_compat_column',
+          table: userTable.name,
+          column: columnName,
+          message: `Compatibility column "${columnName}" is missing on "${userTable.name}"`,
+        })
+      }
+    }
+  }
+
+  if (accountTable) {
+    const columns = toColumnMap(accountTable.columns)
+    for (const columnName of ['id', 'userId']) {
+      if (!columns[normalizeName(columnName)]) {
+        addIssue(issues, {
+          level: 'error',
+          code: 'missing_required_column',
+          table: accountTable.name,
+          column: columnName,
+          message: `Missing required column "${columnName}" on "${accountTable.name}"`,
+        })
+      }
+    }
+  }
+
+  if (expectSessionTable && sessionTable) {
+    const columns = toColumnMap(sessionTable.columns)
+    for (const columnName of ['id', 'userId']) {
+      if (!columns[normalizeName(columnName)]) {
+        addIssue(issues, {
+          level: 'error',
+          code: 'missing_required_column',
+          table: sessionTable.name,
+          column: columnName,
+          message: `Missing required column "${columnName}" on "${sessionTable.name}"`,
+        })
+      }
+    }
+
+    if (!columns[normalizeName('impersonatedBy')]) {
+      addIssue(issues, {
+        level: 'warning',
+        code: 'missing_compat_column',
+        table: sessionTable.name,
+        column: 'impersonatedBy',
+        message: `Compatibility column "impersonatedBy" is missing on "${sessionTable.name}"`,
+      })
+    }
+  }
+
+  const invitationTable = tableNames.invitationCandidates
+    .map(name => tablesByName[normalizeName(name)])
+    .find(Boolean)
+
+  if (invitationTable) {
+    const columns = toColumnMap(invitationTable.columns)
+    const emailColumn = columns[normalizeName('email')]
+    if (!emailColumn) {
+      addIssue(issues, {
+        level: 'warning',
+        code: 'missing_compat_column',
+        table: invitationTable.name,
+        column: 'email',
+        message: `Compatibility column "email" is missing on "${invitationTable.name}"`,
+      })
+    }
+    else if (emailColumn.maxLength != null && emailColumn.maxLength !== 255) {
+      addIssue(issues, {
+        level: 'warning',
+        code: 'invitation_email_length_mismatch',
+        table: invitationTable.name,
+        column: 'email',
+        message: `Expected "${invitationTable.name}.email" length 255 but found ${emailColumn.maxLength}`,
+      })
+    }
+  }
+
+  return {
+    ok: !issues.some(issue => issue.level === 'error'),
+    issues,
+  }
+}
+
+export async function checkAuthSchemaDrift(
+  introspector: AuthSchemaIntrospector,
+  options: AuthSchemaDriftOptions = {},
+): Promise<AuthSchemaDriftReport> {
+  const tableNames = await introspector.listTables()
+  const tables: Record<string, AuthSchemaTable> = {}
+
+  await Promise.all(tableNames.map(async (tableName) => {
+    const columns = await introspector.listColumns(tableName)
+    tables[tableName] = { name: tableName, columns }
+  }))
+
+  return analyzeAuthSchemaDrift({ tables }, options)
+}
+
+export function formatAuthSchemaDriftReport(report: AuthSchemaDriftReport): string {
+  if (!report.issues.length)
+    return '[nuxt-better-auth] No auth schema drift detected.'
+
+  const rows = report.issues.map((issue) => {
+    const location = [issue.table, issue.column].filter(Boolean).join('.')
+    const prefix = issue.level === 'error' ? 'ERROR' : 'WARN'
+    return `- [${prefix}] ${issue.code}${location ? ` (${location})` : ''}: ${issue.message}`
+  })
+
+  return ['[nuxt-better-auth] Auth schema drift report:', ...rows].join('\n')
+}
+
+export function assertNoAuthSchemaDrift(report: AuthSchemaDriftReport): void {
+  if (report.ok)
+    return
+  throw new Error(formatAuthSchemaDriftReport(report))
+}
+
+export function createSqliteSchemaIntrospector(query: SqlQuery): AuthSchemaIntrospector {
+  return {
+    async listTables() {
+      const rows = await query(`SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`)
+      return rows
+        .map((row) => (row as Record<string, unknown>).name)
+        .filter((name): name is string => typeof name === 'string')
+    },
+    async listColumns(tableName: string) {
+      const rows = await query(`PRAGMA table_info('${escapeSqlLiteral(tableName)}')`)
+      return rows.map((row) => {
+        const record = row as Record<string, unknown>
+        const dataType = typeof record.type === 'string' ? record.type : null
+        return {
+          name: String(record.name || ''),
+          dataType,
+          maxLength: parseLengthFromSqlType(dataType),
+        } satisfies AuthSchemaColumn
+      })
+    },
+  }
+}
+
+export function createPostgresSchemaIntrospector(query: SqlQuery, schema = 'public'): AuthSchemaIntrospector {
+  const escapedSchema = escapeSqlLiteral(schema)
+  return {
+    async listTables() {
+      const rows = await query(`SELECT table_name FROM information_schema.tables WHERE table_schema = '${escapedSchema}'`)
+      return rows
+        .map((row) => (row as Record<string, unknown>).table_name)
+        .filter((name): name is string => typeof name === 'string')
+    },
+    async listColumns(tableName: string) {
+      const rows = await query(`
+SELECT column_name, data_type, character_maximum_length
+FROM information_schema.columns
+WHERE table_schema = '${escapedSchema}'
+  AND table_name = '${escapeSqlLiteral(tableName)}'
+`)
+      return rows.map((row) => {
+        const record = row as Record<string, unknown>
+        return {
+          name: String(record.column_name || ''),
+          dataType: typeof record.data_type === 'string' ? record.data_type : null,
+          maxLength: parseNumber(record.character_maximum_length),
+        } satisfies AuthSchemaColumn
+      })
+    },
+  }
+}
+
+export function createMySqlSchemaIntrospector(query: SqlQuery, schemaName?: string): AuthSchemaIntrospector {
+  const schemaExpr = schemaName ? `'${escapeSqlLiteral(schemaName)}'` : 'DATABASE()'
+  return {
+    async listTables() {
+      const rows = await query(`SELECT table_name FROM information_schema.tables WHERE table_schema = ${schemaExpr}`)
+      return rows
+        .map((row) => (row as Record<string, unknown>).table_name)
+        .filter((name): name is string => typeof name === 'string')
+    },
+    async listColumns(tableName: string) {
+      const rows = await query(`
+SELECT column_name, data_type, character_maximum_length
+FROM information_schema.columns
+WHERE table_schema = ${schemaExpr}
+  AND table_name = '${escapeSqlLiteral(tableName)}'
+`)
+      return rows.map((row) => {
+        const record = row as Record<string, unknown>
+        return {
+          name: String(record.column_name || ''),
+          dataType: typeof record.data_type === 'string' ? record.data_type : null,
+          maxLength: parseNumber(record.character_maximum_length),
+        } satisfies AuthSchemaColumn
+      })
+    },
+  }
+}

--- a/test/exports/module.yaml
+++ b/test/exports/module.yaml
@@ -2,6 +2,13 @@
   default: function
   defineClientAuth: function
   defineServerAuth: function
+  analyzeAuthSchemaDrift: function
+  assertNoAuthSchemaDrift: function
+  checkAuthSchemaDrift: function
+  createMySqlSchemaIntrospector: function
+  createPostgresSchemaIntrospector: function
+  createSqliteSchemaIntrospector: function
+  formatAuthSchemaDriftReport: function
 ./config:
   defineClientAuth: function
   defineServerAuth: function

--- a/test/schema-diagnostics.test.ts
+++ b/test/schema-diagnostics.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import {
+  analyzeAuthSchemaDrift,
+  assertNoAuthSchemaDrift,
+  checkAuthSchemaDrift,
+  createSqliteSchemaIntrospector,
+  formatAuthSchemaDriftReport,
+} from '../src/schema-diagnostics'
+
+describe('analyzeAuthSchemaDrift', () => {
+  it('reports missing required tables as errors', () => {
+    const report = analyzeAuthSchemaDrift({
+      tables: {
+        user: { name: 'user', columns: [{ name: 'id' }] },
+      },
+    })
+
+    expect(report.ok).toBe(false)
+    expect(report.issues.some(issue => issue.code === 'missing_table' && issue.table === 'account')).toBe(true)
+  })
+
+  it('reports compatibility warnings for known drift columns', () => {
+    const report = analyzeAuthSchemaDrift({
+      tables: {
+        user: { name: 'user', columns: [{ name: 'id' }] },
+        account: { name: 'account', columns: [{ name: 'id' }, { name: 'userId' }] },
+        session: { name: 'session', columns: [{ name: 'id' }, { name: 'userId' }] },
+      },
+    })
+
+    expect(report.ok).toBe(true)
+    expect(report.issues.some(issue => issue.column === 'banned')).toBe(true)
+    expect(report.issues.some(issue => issue.column === 'impersonatedBy')).toBe(true)
+  })
+
+  it('checks invitation email width when invitation table exists', () => {
+    const report = analyzeAuthSchemaDrift({
+      tables: {
+        user: { name: 'user', columns: [{ name: 'id' }, { name: 'banned' }, { name: 'banReason' }, { name: 'banExpires' }] },
+        account: { name: 'account', columns: [{ name: 'id' }, { name: 'userId' }] },
+        session: { name: 'session', columns: [{ name: 'id' }, { name: 'userId' }, { name: 'impersonatedBy' }] },
+        invitations: { name: 'invitations', columns: [{ name: 'email', maxLength: 128 }] },
+      },
+    })
+
+    expect(report.issues.some(issue => issue.code === 'invitation_email_length_mismatch')).toBe(true)
+  })
+})
+
+describe('checkAuthSchemaDrift', () => {
+  it('builds snapshot from introspector and formats report', async () => {
+    const report = await checkAuthSchemaDrift({
+      listTables: async () => ['user', 'account', 'session'],
+      listColumns: async tableName => ({
+        user: [{ name: 'id' }],
+        account: [{ name: 'id' }, { name: 'userId' }],
+        session: [{ name: 'id' }, { name: 'userId' }],
+      }[tableName] || []),
+    })
+
+    expect(formatAuthSchemaDriftReport(report)).toContain('Auth schema drift report')
+  })
+
+  it('throws when report contains errors', async () => {
+    const report = await checkAuthSchemaDrift({
+      listTables: async () => ['user'],
+      listColumns: async () => [{ name: 'id' }],
+    })
+
+    expect(() => assertNoAuthSchemaDrift(report)).toThrow('Auth schema drift report')
+  })
+})
+
+describe('createSqliteSchemaIntrospector', () => {
+  it('maps sqlite table and pragma rows', async () => {
+    const introspector = createSqliteSchemaIntrospector(async (query) => {
+      if (query.includes('sqlite_master'))
+        return [{ name: 'user' }]
+      return [{ name: 'email', type: 'varchar(255)' }]
+    })
+
+    const tables = await introspector.listTables()
+    const columns = await introspector.listColumns('user')
+
+    expect(tables).toEqual(['user'])
+    expect(columns[0]).toEqual({
+      name: 'email',
+      dataType: 'varchar(255)',
+      maxLength: 255,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add script-oriented auth schema drift diagnostics utilities
- include dialect introspector helpers for sqlite/postgresql/mysql query adapters
- check required auth tables/columns and known compatibility mismatch cases
- expose report formatting and assertion helpers for CI workflows
- document usage recipes in NuxtHub integration and troubleshooting docs
- add unit coverage for analyzer and introspector helpers

Closes #139
