### PR TITLE
fix(nuxthub): use generated schema for drizzle adapter

### DIFF
--- a/src/module/templates.ts
+++ b/src/module/templates.ts
@@ -23,7 +23,8 @@ interface BuildDatabaseCodeInput {
 
 export function buildDatabaseCode(input: BuildDatabaseCodeInput): string {
   if (input.provider === 'nuxthub') {
-    return `import { db, schema } from '@nuxthub/db'
+    return `import { db } from '@nuxthub/db'
+import * as schema from './schema.${input.hubDialect}.mjs'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 const rawDialect = '${input.hubDialect}'
 const dialect = rawDialect === 'postgresql' ? 'pg' : rawDialect

--- a/test/nuxthub-provider-template.test.ts
+++ b/test/nuxthub-provider-template.test.ts
@@ -26,4 +26,3 @@ describe('nuxthub provider database template', () => {
     expect(code).toContain(`const dialect = rawDialect === 'postgresql' ? 'pg' : rawDialect`)
   })
 })
-

--- a/test/nuxthub-provider-template.test.ts
+++ b/test/nuxthub-provider-template.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { buildDatabaseCode } from '../src/module/templates'
+
+describe('nuxthub provider database template', () => {
+  it('imports schema from generated better-auth schema file', () => {
+    const code = buildDatabaseCode({
+      provider: 'nuxthub',
+      hubDialect: 'sqlite',
+      usePlural: false,
+      camelCase: true,
+    })
+
+    expect(code).toContain(`import { db } from '@nuxthub/db'`)
+    expect(code).toContain(`import * as schema from './schema.sqlite.mjs'`)
+    expect(code).not.toContain(`import { db, schema } from '@nuxthub/db'`)
+  })
+
+  it('normalizes postgresql dialect to pg provider', () => {
+    const code = buildDatabaseCode({
+      provider: 'nuxthub',
+      hubDialect: 'postgresql',
+      usePlural: false,
+      camelCase: true,
+    })
+
+    expect(code).toContain(`const dialect = rawDialect === 'postgresql' ? 'pg' : rawDialect`)
+  })
+})
+


### PR DESCRIPTION
Fixes #149

NuxtHub provider now uses the module-generated Better Auth schema (`./schema.<dialect>.mjs`) when wiring `drizzleAdapter()`, while keeping `db` from `@nuxthub/db`.

Tests:
- `pnpm vitest run test/nuxthub-provider-template.test.ts`