### PR TITLE
docs(nuxthub): otp schema troubleshooting

### DIFF
--- a/docs/content/6.troubleshooting/2.nuxthub-otp-schema.md
+++ b/docs/content/6.troubleshooting/2.nuxthub-otp-schema.md
@@ -1,0 +1,64 @@
+---
+title: NuxtHub OTP 500s (Schema Mismatch)
+description: Fix email OTP 500 errors caused by missing Better Auth tables in the NuxtHub schema wiring.
+---
+
+This page helps you fix 500 errors from the Email OTP endpoint when you use NuxtHub DB.
+
+If you see a 500 when you call:
+
+- `POST /api/auth/email-otp/send-verification-otp`
+
+and the logs include an error like:
+
+```txt
+BetterAuthError: [# Drizzle Adapter]: The model "verification" was not found in the schema object.
+```
+
+## Why this happens
+
+Email OTP flows require the Better Auth `verification` table.
+
+When `hub.db` is enabled, this module generates a Better Auth Drizzle schema during build:
+
+- `.nuxt/better-auth/schema.<dialect>.mjs`
+- `.nuxt/better-auth/schema.<dialect>.ts`
+
+The NuxtHub database provider uses that generated schema when creating the Drizzle adapter.
+
+## Checklist
+
+- The generated schema file exists in `.nuxt/better-auth/` for your dialect (`sqlite`, `postgresql`, `mysql`).
+- Your database has the Better Auth tables (including `verification`).
+- You have the `emailOTP` plugin enabled and configured with `sendVerificationOTP`.
+
+## Workaround (older versions / debugging)
+
+If you are on an older version or want to debug provider wiring, you can override the NuxtHub provider template to import the generated schema file explicitly:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  hooks: {
+    'better-auth:database:providers': (providers) => {
+      const provider = providers?.nuxthub
+      if (!provider)
+        return
+
+      provider.buildDatabaseCode = ({ hubDialect, usePlural, camelCase }) => `import { db } from '@nuxthub/db'
+import * as schema from './schema.${hubDialect}.mjs'
+import { drizzleAdapter } from 'better-auth/adapters/drizzle'
+const rawDialect = '${hubDialect}'
+const dialect = rawDialect === 'postgresql' ? 'pg' : rawDialect
+export function createDatabase() { return drizzleAdapter(db, { provider: dialect, schema, usePlural: ${usePlural}, camelCase: ${camelCase} }) }
+export { db }`
+    },
+  },
+})
+```
+
+## Notes for Email OTP
+
+The Email OTP endpoint requires the Better Auth `emailOTP` plugin to be enabled and configured with a `sendVerificationOTP` implementation.
+
+See: [Better Auth Email OTP plugin](https://better-auth.com/docs/plugins/email-otp)
+


### PR DESCRIPTION
## Summary
- Document NuxtHub OTP 500s caused by schema mismatch and how the generated schema is wired.
- Provide a provider override snippet for older versions/debugging.
