### PR TITLE
refactor(types): remove explicit any

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,27 @@
 // @ts-check
 import antfu from '@antfu/eslint-config'
 
-export default antfu({
-  ignores: ['**/*.md', 'dist/**', '.nuxt/**'],
-}, {
-  rules: {
-    'node/prefer-global/process': 'off',
+export default antfu(
+  {
+    ignores: ['**/*.md', 'dist/**', '.nuxt/**'],
   },
-})
+  {
+    rules: {
+      'node/prefer-global/process': 'off',
+    },
+  },
+  // Enforce no explicit `any` in shipped code, but keep .d.ts/tests/playground flexible.
+  {
+    files: ['src/**/*.{ts,tsx,vue,mjs,cjs}'],
+    ignores: ['src/**/*.d.ts'],
+    rules: {
+      'ts/no-explicit-any': 'error',
+    },
+  },
+  {
+    files: ['test/**', 'playground/**'],
+    rules: {
+      'ts/no-explicit-any': 'off',
+    },
+  },
+)

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -1,9 +1,11 @@
-import type { ModuleCustomTab } from '@nuxt/devtools-kit/types'
 import type { Nuxt } from '@nuxt/schema'
 
 export function setupDevTools(nuxt: Nuxt) {
-  nuxt.hook('devtools:customTabs', (tabs: ModuleCustomTab[]) => {
-    tabs.push({
+  // Avoid depending on devtools-kit types in the published build output.
+  type HookableNuxt = Nuxt & { hook: (name: 'devtools:customTabs', cb: (tabs: unknown[]) => void) => void }
+
+  ;(nuxt as HookableNuxt).hook('devtools:customTabs', (tabs) => {
+    ;(tabs as Array<Record<string, unknown>>).push({
       category: 'server',
       name: 'better-auth',
       title: 'Auth',

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -1,8 +1,8 @@
 import type { ModuleCustomTab } from '@nuxt/devtools-kit/types'
-import type { Nuxt } from 'nuxt/schema'
+import type { Nuxt } from '@nuxt/schema'
 
 export function setupDevTools(nuxt: Nuxt) {
-  nuxt.hook('devtools:customTabs' as any, (tabs: ModuleCustomTab[]) => {
+  nuxt.hook('devtools:customTabs', (tabs: ModuleCustomTab[]) => {
     tabs.push({
       category: 'server',
       name: 'better-auth',

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -1,11 +1,19 @@
 import type { Nuxt } from '@nuxt/schema'
 
-export function setupDevTools(nuxt: Nuxt) {
-  // Avoid depending on devtools-kit types in the published build output.
-  type HookableNuxt = Nuxt & { hook: (name: 'devtools:customTabs', cb: (tabs: unknown[]) => void) => void }
+interface DevtoolsCustomTab {
+  category: string
+  name: string
+  title: string
+  icon: string
+  view: { type: 'iframe', src: string }
+}
 
-  ;(nuxt as HookableNuxt).hook('devtools:customTabs', (tabs) => {
-    ;(tabs as Array<Record<string, unknown>>).push({
+export function setupDevTools(nuxt: Nuxt) {
+  type HookableNuxt = Nuxt & { hook: (name: 'devtools:customTabs', cb: (tabs: DevtoolsCustomTab[]) => void) => void }
+
+  const hookable = nuxt as HookableNuxt
+  hookable.hook('devtools:customTabs', (tabs) => {
+    tabs.push({
       category: 'server',
       name: 'better-auth',
       title: 'Auth',

--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -56,7 +56,8 @@ function ensureSessionSignalListener(client: AppAuthClient, onSignal: () => Prom
     return
 
   _sessionSignalListenerBound = true
-  ;(listen as (signal: string, cb: () => void | Promise<void>) => unknown)('$sessionSignal', async () => {
+  const listenFn = listen as (signal: string, cb: () => void | Promise<void>) => unknown
+  listenFn('$sessionSignal', async () => {
     try {
       await onSignal()
     }

--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -26,6 +26,10 @@ export interface UseUserSessionReturn {
 let _client: AppAuthClient | null = null
 interface UpdateUserResponse { error?: unknown }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object')
+}
+
 function getClient(baseURL: string): AppAuthClient {
   if (!_client)
     _client = createAppAuthClient(baseURL)
@@ -43,12 +47,16 @@ function ensureSessionSignalListener(client: AppAuthClient, onSignal: () => Prom
   if (_sessionSignalListenerBound)
     return
 
-  const store = (client as any).$store as { listen?: (signal: string, cb: () => void | Promise<void>) => unknown } | undefined
-  if (!store?.listen)
+  const store = (client as unknown as { $store?: unknown }).$store
+  if (!isRecord(store))
+    return
+
+  const listen = (store as { listen?: unknown }).listen
+  if (typeof listen !== 'function')
     return
 
   _sessionSignalListenerBound = true
-  store.listen('$sessionSignal', async () => {
+  ;(listen as (signal: string, cb: () => void | Promise<void>) => unknown)('$sessionSignal', async () => {
     try {
       await onSignal()
     }
@@ -191,15 +199,34 @@ export function useUserSession(): UseUserSessionReturn {
 
   function wrapAuthMethod<T extends (...args: unknown[]) => Promise<unknown>>(method: T): T {
     return (async (...args: unknown[]) => {
-      const [data, options] = args as [Record<string, any> | undefined, Record<string, any> | undefined]
+      const data = args[0]
+      const options = args[1]
+      const dataRecord = isRecord(data) ? data : undefined
+      const optionsRecord = isRecord(options) ? options : undefined
+
+      type OnSuccess = (ctx: unknown) => void | Promise<void>
+      const fetchOptions = isRecord(dataRecord?.fetchOptions) ? dataRecord.fetchOptions : undefined
+      const nestedOnSuccess = fetchOptions?.onSuccess
+      const topLevelOnSuccess = optionsRecord?.onSuccess
 
       // Passkey pattern: onSuccess in data.fetchOptions
-      if (data?.fetchOptions?.onSuccess) {
-        return method({ ...data, fetchOptions: { ...data.fetchOptions, onSuccess: wrapOnSuccess(data.fetchOptions.onSuccess) } }, options)
+      if (typeof nestedOnSuccess === 'function') {
+        const nextData = {
+          ...dataRecord,
+          fetchOptions: {
+            ...fetchOptions,
+            onSuccess: wrapOnSuccess(nestedOnSuccess as OnSuccess),
+          },
+        }
+        return method(nextData as unknown as Parameters<T>[0], options as unknown as Parameters<T>[1])
       }
       // Email/social pattern: onSuccess in options
-      if (options?.onSuccess) {
-        return method(data, { ...options, onSuccess: wrapOnSuccess(options.onSuccess) })
+      if (typeof topLevelOnSuccess === 'function') {
+        const nextOptions = {
+          ...optionsRecord,
+          onSuccess: wrapOnSuccess(topLevelOnSuccess as OnSuccess),
+        }
+        return method(data as unknown as Parameters<T>[0], nextOptions as unknown as Parameters<T>[1])
       }
       return method(data, options)
     }) as T

--- a/src/runtime/app/composables/useUserSignIn.ts
+++ b/src/runtime/app/composables/useUserSignIn.ts
@@ -4,30 +4,43 @@ import { computed, ref, useUserSession } from '#imports'
 
 type UserAuthActionStatus = 'idle' | 'pending' | 'success' | 'error'
 
-interface UserAuthActionHandle<T extends (...args: any[]) => Promise<any>> {
-  execute: (...args: Parameters<T>) => ReturnType<T>
+interface UserAuthActionHandle<TArgs extends unknown[], TResult> {
+  execute: (...args: TArgs) => Promise<TResult>
   status: Ref<UserAuthActionStatus>
   pending: ComputedRef<boolean>
   error: Ref<unknown | null>
 }
 
-type AnyAsyncFn = (...args: any[]) => Promise<any>
+type AnyAsyncFn = (...args: unknown[]) => Promise<unknown>
+type ActionHandleFor<T> = T extends (...args: infer A) => Promise<infer R>
+  ? UserAuthActionHandle<A, R>
+  : never
 type ActionHandleMap<T> = {
-  [K in keyof T]: T[K] extends AnyAsyncFn ? UserAuthActionHandle<T[K]> : never
+  [K in keyof T]: ActionHandleFor<T[K]>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object')
 }
 
 function isErrorResult(value: unknown): value is { error: unknown } {
-  return Boolean(value && typeof value === 'object' && 'error' in value && (value as any).error)
+  if (!isRecord(value))
+    return false
+  if (!('error' in value))
+    return false
+  return Boolean((value as Record<string, unknown>).error)
 }
 
-function createActionHandle<T extends AnyAsyncFn>(getMethod: () => T): UserAuthActionHandle<T> {
+function createActionHandle<TArgs extends unknown[], TResult>(
+  getMethod: () => (...args: TArgs) => Promise<TResult>,
+): UserAuthActionHandle<TArgs, TResult> {
   const status = ref<UserAuthActionStatus>('idle')
   const error = ref<unknown | null>(null)
   const pending = computed(() => status.value === 'pending')
 
   let latestCallId = 0
 
-  const execute = (async (...args: Parameters<T>) => {
+  const execute = (async (...args: TArgs) => {
     const callId = ++latestCallId
     status.value = 'pending'
     error.value = null
@@ -36,17 +49,17 @@ function createActionHandle<T extends AnyAsyncFn>(getMethod: () => T): UserAuthA
       const result = await getMethod()(...args)
 
       if (callId !== latestCallId)
-        return result as ReturnType<T>
+        return result
 
-      if (isErrorResult(result)) {
+      if (isErrorResult(result as unknown)) {
         status.value = 'error'
-        error.value = (result as any).error
-        return result as ReturnType<T>
+        error.value = (result as unknown as { error: unknown }).error
+        return result
       }
 
       status.value = 'success'
       error.value = null
-      return result as ReturnType<T>
+      return result
     }
     catch (err) {
       if (callId === latestCallId) {
@@ -55,13 +68,13 @@ function createActionHandle<T extends AnyAsyncFn>(getMethod: () => T): UserAuthA
       }
       throw err
     }
-  }) as UserAuthActionHandle<T>['execute']
+  }) as UserAuthActionHandle<TArgs, TResult>['execute']
 
   return { execute, status, pending, error }
 }
 
 export function useUserSignIn(): ActionHandleMap<NonNullable<AppAuthClient>['signIn']> {
-  const handles = new Map<PropertyKey, UserAuthActionHandle<AnyAsyncFn>>()
+  const handles = new Map<PropertyKey, UserAuthActionHandle<unknown[], unknown>>()
 
   return new Proxy({} as ActionHandleMap<NonNullable<AppAuthClient>['signIn']>, {
     get(_target, prop) {
@@ -74,11 +87,15 @@ export function useUserSignIn(): ActionHandleMap<NonNullable<AppAuthClient>['sig
 
       const handle = createActionHandle(() => {
         const { signIn } = useUserSession()
-        return (signIn as any)[prop] as AnyAsyncFn
+        const record = signIn as unknown as Record<PropertyKey, unknown>
+        const method = record[prop]
+        if (typeof method !== 'function')
+          throw new TypeError(`signIn.${String(prop)}() is not a function`)
+        return method as AnyAsyncFn
       })
 
       handles.set(prop, handle)
-      return handle
+      return handle as unknown as ActionHandleMap<NonNullable<AppAuthClient>['signIn']>[keyof NonNullable<AppAuthClient>['signIn']]
     },
   })
 }

--- a/src/runtime/app/composables/useUserSignUp.ts
+++ b/src/runtime/app/composables/useUserSignUp.ts
@@ -4,30 +4,43 @@ import { computed, ref, useUserSession } from '#imports'
 
 type UserAuthActionStatus = 'idle' | 'pending' | 'success' | 'error'
 
-interface UserAuthActionHandle<T extends (...args: any[]) => Promise<any>> {
-  execute: (...args: Parameters<T>) => ReturnType<T>
+interface UserAuthActionHandle<TArgs extends unknown[], TResult> {
+  execute: (...args: TArgs) => Promise<TResult>
   status: Ref<UserAuthActionStatus>
   pending: ComputedRef<boolean>
   error: Ref<unknown | null>
 }
 
-type AnyAsyncFn = (...args: any[]) => Promise<any>
+type AnyAsyncFn = (...args: unknown[]) => Promise<unknown>
+type ActionHandleFor<T> = T extends (...args: infer A) => Promise<infer R>
+  ? UserAuthActionHandle<A, R>
+  : never
 type ActionHandleMap<T> = {
-  [K in keyof T]: T[K] extends AnyAsyncFn ? UserAuthActionHandle<T[K]> : never
+  [K in keyof T]: ActionHandleFor<T[K]>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object')
 }
 
 function isErrorResult(value: unknown): value is { error: unknown } {
-  return Boolean(value && typeof value === 'object' && 'error' in value && (value as any).error)
+  if (!isRecord(value))
+    return false
+  if (!('error' in value))
+    return false
+  return Boolean((value as Record<string, unknown>).error)
 }
 
-function createActionHandle<T extends AnyAsyncFn>(getMethod: () => T): UserAuthActionHandle<T> {
+function createActionHandle<TArgs extends unknown[], TResult>(
+  getMethod: () => (...args: TArgs) => Promise<TResult>,
+): UserAuthActionHandle<TArgs, TResult> {
   const status = ref<UserAuthActionStatus>('idle')
   const error = ref<unknown | null>(null)
   const pending = computed(() => status.value === 'pending')
 
   let latestCallId = 0
 
-  const execute = (async (...args: Parameters<T>) => {
+  const execute = (async (...args: TArgs) => {
     const callId = ++latestCallId
     status.value = 'pending'
     error.value = null
@@ -36,17 +49,17 @@ function createActionHandle<T extends AnyAsyncFn>(getMethod: () => T): UserAuthA
       const result = await getMethod()(...args)
 
       if (callId !== latestCallId)
-        return result as ReturnType<T>
+        return result
 
-      if (isErrorResult(result)) {
+      if (isErrorResult(result as unknown)) {
         status.value = 'error'
-        error.value = (result as any).error
-        return result as ReturnType<T>
+        error.value = (result as unknown as { error: unknown }).error
+        return result
       }
 
       status.value = 'success'
       error.value = null
-      return result as ReturnType<T>
+      return result
     }
     catch (err) {
       if (callId === latestCallId) {
@@ -55,13 +68,13 @@ function createActionHandle<T extends AnyAsyncFn>(getMethod: () => T): UserAuthA
       }
       throw err
     }
-  }) as UserAuthActionHandle<T>['execute']
+  }) as UserAuthActionHandle<TArgs, TResult>['execute']
 
   return { execute, status, pending, error }
 }
 
 export function useUserSignUp(): ActionHandleMap<NonNullable<AppAuthClient>['signUp']> {
-  const handles = new Map<PropertyKey, UserAuthActionHandle<AnyAsyncFn>>()
+  const handles = new Map<PropertyKey, UserAuthActionHandle<unknown[], unknown>>()
 
   return new Proxy({} as ActionHandleMap<NonNullable<AppAuthClient>['signUp']>, {
     get(_target, prop) {
@@ -73,11 +86,15 @@ export function useUserSignUp(): ActionHandleMap<NonNullable<AppAuthClient>['sig
 
       const handle = createActionHandle(() => {
         const { signUp } = useUserSession()
-        return (signUp as any)[prop] as AnyAsyncFn
+        const record = signUp as unknown as Record<PropertyKey, unknown>
+        const method = record[prop]
+        if (typeof method !== 'function')
+          throw new TypeError(`signUp.${String(prop)}() is not a function`)
+        return method as AnyAsyncFn
       })
 
       handles.set(prop, handle)
-      return handle
+      return handle as unknown as ActionHandleMap<NonNullable<AppAuthClient>['signUp']>[keyof NonNullable<AppAuthClient>['signUp']]
     },
   })
 }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,3 +1,4 @@
+import type { ModuleCustomTab } from '@nuxt/devtools-kit/types'
 import type { Nuxt } from '@nuxt/schema'
 import type { BetterAuthOptions } from 'better-auth'
 import type { DbDialect } from '../module/hub'
@@ -28,6 +29,8 @@ export interface BetterAuthDatabaseProviderDefinition {
 
 declare module '@nuxt/schema' {
   interface NuxtHooks {
+    'devtools:customTabs': (tabs: ModuleCustomTab[]) => void
+
     /**
      * Extend better-auth config with additional plugins or options.
      * Called after user's auth.config.ts is loaded.

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,4 +1,3 @@
-import type { ModuleCustomTab } from '@nuxt/devtools-kit/types'
 import type { Nuxt } from '@nuxt/schema'
 import type { BetterAuthOptions } from 'better-auth'
 import type { DbDialect } from '../module/hub'
@@ -29,8 +28,6 @@ export interface BetterAuthDatabaseProviderDefinition {
 
 declare module '@nuxt/schema' {
   interface NuxtHooks {
-    'devtools:customTabs': (tabs: ModuleCustomTab[]) => void
-
     /**
      * Extend better-auth config with additional plugins or options.
      * Called after user's auth.config.ts is loaded.


### PR DESCRIPTION
## Summary
- Scope ts/no-explicit-any to shipped src/ code (excluding src/**/*.d.ts).
- Replace remaining explicit any usage in client composables and devtools hook wiring.

## Tests
- pnpm lint
