### PR TITLE
feat(auth): remove pending from user auth action handles

### DIFF
--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -138,7 +138,7 @@ During SSR, `updateUser` only patches local state since no client is available.
 Returns per-method action handles for `useUserSession().signIn.*`. Each method exposes template-friendly async state, similar to composables like `useFetch`.
 
 ```ts [pages/login.vue]
-const { execute, pending, data, status, error, errorMessage } = useUserSignIn().email
+const { execute, data, status, error, errorMessage } = useUserSignIn().email
 
 await execute(
   { email, password, rememberMe },
@@ -158,14 +158,12 @@ Use renaming to avoid collisions when you use multiple methods in the same scope
 ```ts [pages/login.vue]
 const {
   execute: loginWithEmail,
-  pending: pendingEmail,
   status: statusEmail,
   error: errorEmail,
 } = useUserSignIn().email
 
 const {
   execute: loginWithPasskey,
-  pending: pendingPasskey,
   status: statusPasskey,
   error: errorPasskey,
 } = useUserSignIn().passkey
@@ -179,9 +177,6 @@ Each method returns an action handle:
   ::
   ::field{name="status" type="'idle' | 'pending' | 'success' | 'error'"}
     Current status of the latest `execute()` call.
-  ::
-  ::field{name="pending" type="boolean"}
-    `true` while the latest `execute()` call is running.
   ::
   ::field{name="data" type="any | null"}
     Last successful result. Cleared on each new `execute()` and on errors.
@@ -237,7 +232,7 @@ If you relied on raw payloads, use `error.raw`.
 Same API as `useUserSignIn`, but wraps `useUserSession().signUp.*`.
 
 ```ts [pages/signup.vue]
-const { execute, pending, data, status, error, errorMessage } = useUserSignUp().email
+const { execute, data, status, error, errorMessage } = useUserSignUp().email
 
 await execute(
   { email, password, name },

--- a/playground/app/pages/login.vue
+++ b/playground/app/pages/login.vue
@@ -81,17 +81,17 @@ async function handlePasskeySignIn() {
 
       <UCheckbox id="remember" v-model="rememberMe" :label="t('login.rememberMe')" />
 
-      <UButton block :loading="signInEmail.pending" @click="handleSignIn">
+      <UButton block :loading="signInEmail.status.value === 'pending'" @click="handleSignIn">
         {{ t('common.login') }}
       </UButton>
 
       <div class="w-full gap-2 flex items-center justify-between flex-col">
-        <UButton variant="outline" block :loading="signInSocial.pending" @click="handleSocialSignIn('github')">
+        <UButton variant="outline" block :loading="signInSocial.status.value === 'pending'" @click="handleSocialSignIn('github')">
           <UIcon name="i-simple-icons-github" />
           <span>Sign in with GitHub</span>
         </UButton>
 
-        <UButton variant="outline" block :loading="signInPasskey.pending" @click="handlePasskeySignIn">
+        <UButton variant="outline" block :loading="signInPasskey.status.value === 'pending'" @click="handlePasskeySignIn">
           <UIcon name="i-lucide-key-round" />
           <span>Sign in with Passkey</span>
         </UButton>

--- a/src/runtime/app/internal/auth-action-handles.ts
+++ b/src/runtime/app/internal/auth-action-handles.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, Ref } from 'vue'
+import type { Ref } from 'vue'
 import type { AuthActionError } from '../../types'
 import { computed, ref } from '#imports'
 import { normalizeAuthActionError } from './auth-action-error'
@@ -8,7 +8,6 @@ export type UserAuthActionStatus = 'idle' | 'pending' | 'success' | 'error'
 export interface UserAuthActionHandle<TArgs extends unknown[], TResult> {
   execute: (...args: TArgs) => Promise<void>
   status: Ref<UserAuthActionStatus>
-  pending: ComputedRef<boolean>
   data: Ref<TResult | null>
   error: Ref<AuthActionError | null>
   errorMessage: ComputedRef<string | null>
@@ -40,7 +39,6 @@ function createActionHandle<TArgs extends unknown[], TResult>(
   const status = ref<UserAuthActionStatus>('idle')
   const data = ref<TResult | null>(null)
   const error = ref<AuthActionError | null>(null)
-  const pending = computed(() => status.value === 'pending')
   const errorMessage = computed(() => error.value?.message ?? null)
 
   let latestCallId = 0
@@ -86,7 +84,6 @@ function createActionHandle<TArgs extends unknown[], TResult>(
   return {
     execute,
     status,
-    pending,
     data,
     error,
     errorMessage,

--- a/test/use-user-signin.test.ts
+++ b/test/use-user-signin.test.ts
@@ -48,14 +48,12 @@ describe('useUserSignIn', () => {
 
     const p = signInEmail.execute({} as any)
     expect(signInEmail.status.value).toBe('pending')
-    expect(signInEmail.pending.value).toBe(true)
     expect(signInEmail.data.value).toBeNull()
 
     d.resolve({ ok: true })
     await expect(p).resolves.toBeUndefined()
 
     expect(signInEmail.status.value).toBe('success')
-    expect(signInEmail.pending.value).toBe(false)
     expect(signInEmail.data.value).toEqual({ ok: true })
     expect(signInEmail.error.value).toBeNull()
     expect(signInEmail.errorMessage.value).toBeNull()


### PR DESCRIPTION
## Summary
- remove deprecated `pending` from user auth action handles in shared internals
- update useUserSignIn/SignUp loading consumers to use status checks
- update sign-in tests and auth composables API docs accordingly

## Changes
- `src/runtime/app/internal/auth-action-handles.ts`
  - drops `pending` from the action handle contract
  - keeps `status` as `idle` | `pending` | `success` | `error`
- `playground/app/pages/login.vue`
  - replace `.pending` usage with `status.value === 'pending'`
- `test/use-user-signin.test.ts`
  - removes assertions on `.pending`
- `docs/content/5.api/1.composables.md`
  - updates examples and field docs to remove `pending`

## Why
Aligns action-handle usage with status-driven async state and avoids exposing a redundant derived boolean.

## Risks
- This is a breaking change for consumers directly using `.pending` on `useUserSignIn()` / `useUserSignUp()` action handles.
