### PR TITLE
refactor(auth): drop errorMessage field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ This changelog is incomplete for alpha releases. Use the GitHub Releases page fo
 ### Breaking Changes
 
 - Removed `auth.redirects`. Use `routeRules.auth.redirectTo` (or page meta `auth.redirectTo`) for redirect targets.
+- Removed `errorMessage` from `useUserSignIn()` and `useUserSignUp()` action handles. Use `error.value?.message`.
+
+  Migration:
+
+  ```ts
+  // before
+  const message = errorMessage.value ?? 'Please try again.'
+
+  // after
+  const message = error.value?.message ?? 'Please try again.'
+  ```
 
 ## 0.0.2-alpha.0
 

--- a/docs/content/4.integrations/3.i18n.md
+++ b/docs/content/4.integrations/3.i18n.md
@@ -66,7 +66,6 @@ Better Auth errors include a `code` property that you can translate using `useI1
 const {
   execute: signInWithEmail,
   error,
-  errorMessage,
 } = useUserSignIn('email')
 const { t, te } = useI18n()
 
@@ -82,9 +81,9 @@ async function handleLogin(email: string, password: string) {
 const localizedErrorMessage = computed(() => {
   const code = error.value?.code
   if (!code)
-    return errorMessage.value
+    return error.value?.message
   const key = `auth.errors.${code}`
-  return te(key) ? t(key) : errorMessage.value
+  return te(key) ? t(key) : error.value?.message
 })
 </script>
 
@@ -93,7 +92,7 @@ const localizedErrorMessage = computed(() => {
 </template>
 ```
 
-This pattern uses typed `error.code` for translation and falls back to `errorMessage` when no localized key exists.
+This pattern uses typed `error.code` for translation and falls back to `error.message` when no localized key exists.
 
 ## Server-Side Locale Detection
 

--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -138,7 +138,7 @@ During SSR, `updateUser` only patches local state since no client is available.
 Returns a keyed action handle for `useUserSession().signIn.*`. Each method handle exposes template-friendly async state, similar to composables like `useFetch`.
 
 ```ts [pages/login.vue]
-const { execute, data, status, error, errorMessage } = useUserSignIn('email')
+const { execute, data, status, error } = useUserSignIn('email')
 
 await execute(
   { email, password, rememberMe },
@@ -149,7 +149,7 @@ await execute(
 )
 
 if (status.value === 'error') {
-  console.error(errorMessage.value)
+  console.error(error.value?.message)
 }
 ```
 
@@ -184,9 +184,6 @@ Each method returns an action handle:
   ::field{name="error" type="AuthActionError | null"}
     Normalized error for the latest call (cleared on new `execute()`).
   ::
-  ::field{name="errorMessage" type="string | null"}
-    Convenience computed string from `error?.message`.
-  ::
 ::
 
 ::note
@@ -195,7 +192,7 @@ Each sign-in method has independent state. When you call `execute()` multiple ti
 
 ### Error state and promise behavior
 
-Use `status`, `data`, `error`, and `errorMessage` as your source of truth. The action handle always sets `status='error'` and populates normalized `error` when a sign-in attempt fails.
+Use `status`, `data`, and `error` as your source of truth. The action handle always sets `status='error'` and populates normalized `error` when a sign-in attempt fails.
 
 ::note
 Better Auth methods can signal failure by throwing or by resolving to a `{ error }` result. In both cases, the action handle updates `status` and `error`, and `await execute()` always resolves.
@@ -204,12 +201,12 @@ Better Auth methods can signal failure by throwing or by resolving to a `{ error
 #### Recommended flow (`execute`)
 
 ```ts [pages/login.vue]
-const { execute, data, status, errorMessage } = useUserSignIn('email')
+const { execute, data, status, error } = useUserSignIn('email')
 
 await execute({ email, password })
 
 if (status.value === 'error') {
-  console.error(errorMessage.value)
+  console.error(error.value?.message)
 }
 
 if (status.value === 'success') {
@@ -220,6 +217,7 @@ if (status.value === 'success') {
 ::warning
 `useUserSignIn` and `useUserSignUp` switched from map-style access (`useUserSignIn().email`) to keyed access (`useUserSignIn('email')`) in alpha.
 `error` changed from `unknown | null` to `AuthActionError | null` in alpha.
+The message alias field was removed in alpha. Use `error.value?.message`.
 `execute()` changed twice in alpha:
 - old: `await execute()` could reject
 - previous alpha: `await execute()` resolved `{ ok: true, data } | { ok: false, error }`
@@ -233,7 +231,7 @@ If you relied on raw payloads, use `error.raw`.
 Same API as `useUserSignIn`, but wraps `useUserSession().signUp.*`.
 
 ```ts [pages/signup.vue]
-const { execute, data, status, error, errorMessage } = useUserSignUp('email')
+const { execute, data, status, error } = useUserSignUp('email')
 
 await execute(
   { email, password, name },

--- a/src/runtime/app/internal/auth-action-handles.ts
+++ b/src/runtime/app/internal/auth-action-handles.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import type { AuthActionError } from '../../types'
-import { computed, ref } from '#imports'
+import { ref } from '#imports'
 import { normalizeAuthActionError } from './auth-action-error'
 
 export type UserAuthActionStatus = 'idle' | 'pending' | 'success' | 'error'
@@ -10,7 +10,6 @@ export interface UserAuthActionHandle<TArgs extends unknown[], TResult> {
   status: Ref<UserAuthActionStatus>
   data: Ref<TResult | null>
   error: Ref<AuthActionError | null>
-  errorMessage: ComputedRef<string | null>
 }
 
 type AnyAsyncFn = (...args: unknown[]) => Promise<unknown>
@@ -39,7 +38,6 @@ function createActionHandle<TArgs extends unknown[], TResult>(
   const status = ref<UserAuthActionStatus>('idle')
   const data = ref<TResult | null>(null)
   const error = ref<AuthActionError | null>(null)
-  const errorMessage = computed(() => error.value?.message ?? null)
 
   let latestCallId = 0
 
@@ -86,7 +84,6 @@ function createActionHandle<TArgs extends unknown[], TResult>(
     status,
     data,
     error,
-    errorMessage,
   }
 }
 

--- a/test/use-user-signin.test.ts
+++ b/test/use-user-signin.test.ts
@@ -55,7 +55,7 @@ describe('useUserSignIn', () => {
     expect(signInEmail.status.value).toBe('success')
     expect(signInEmail.data.value).toEqual({ ok: true })
     expect(signInEmail.error.value).toBeNull()
-    expect(signInEmail.errorMessage.value).toBeNull()
+    expect(signInEmail.error.value?.message).toBeUndefined()
   })
 
   it('clears previous data when a new execute starts', async () => {
@@ -106,7 +106,7 @@ describe('useUserSignIn', () => {
     expect(signInEmail.data.value).toBeNull()
     expect(signInEmail.error.value).toMatchObject({ message: 'boom' })
     expect(signInEmail.error.value!.raw).toBeInstanceOf(Error)
-    expect(signInEmail.errorMessage.value).toBe('boom')
+    expect(signInEmail.error.value?.message).toBe('boom')
   })
 
   it('does not throw and sets error state for { error } responses', async () => {
@@ -128,7 +128,7 @@ describe('useUserSignIn', () => {
       code: 'INVALID_EMAIL_OR_PASSWORD',
       status: 401,
     })
-    expect(signInEmail.errorMessage.value).toBe('invalid credentials')
+    expect(signInEmail.error.value?.message).toBe('invalid credentials')
   })
 
   it('is race-safe (only latest call updates state)', async () => {
@@ -194,13 +194,14 @@ describe('useUserSignIn', () => {
 
     const useUserSignIn = await loadUseUserSignIn()
     const signInEmail = useUserSignIn('email')
+    const isPending = () => signInEmail.status.value === 'pending'
 
     expect(typeof signInEmail.execute).toBe('function')
     expect(signInEmail.status.value).toBe('idle')
-    expect(signInEmail.pending.value).toBe(false)
+    expect(isPending()).toBe(false)
     expect(signInEmail.data.value).toBeNull()
     expect(signInEmail.error.value).toBeNull()
-    expect(signInEmail.errorMessage.value).toBeNull()
+    expect(signInEmail.error.value?.message).toBeUndefined()
   })
 
   it('throws when method key is missing', async () => {
@@ -223,6 +224,6 @@ describe('useUserSignIn', () => {
     await expect(invalid.execute({} as any)).resolves.toBeUndefined()
     expect(invalid.status.value).toBe('error')
     expect(invalid.error.value?.raw).toBeInstanceOf(TypeError)
-    expect(invalid.errorMessage.value).toBe('signIn.invalid() is not a function')
+    expect(invalid.error.value?.message).toBe('signIn.invalid() is not a function')
   })
 })

--- a/test/use-user-signup.test.ts
+++ b/test/use-user-signup.test.ts
@@ -43,13 +43,14 @@ describe('useUserSignUp', () => {
 
     const useUserSignUp = await loadUseUserSignUp()
     const signUpEmail = useUserSignUp('email')
+    const isPending = () => signUpEmail.status.value === 'pending'
 
     expect(typeof signUpEmail.execute).toBe('function')
     expect(signUpEmail.status.value).toBe('idle')
-    expect(signUpEmail.pending.value).toBe(false)
+    expect(isPending()).toBe(false)
     expect(signUpEmail.data.value).toBeNull()
     expect(signUpEmail.error.value).toBeNull()
-    expect(signUpEmail.errorMessage.value).toBeNull()
+    expect(signUpEmail.error.value?.message).toBeUndefined()
   })
 
   it('sets success state, data and clears error on success', async () => {
@@ -62,20 +63,21 @@ describe('useUserSignUp', () => {
 
     const useUserSignUp = await loadUseUserSignUp()
     const signUpEmail = useUserSignUp('email')
+    const isPending = () => signUpEmail.status.value === 'pending'
 
     const p = signUpEmail.execute({} as any)
     expect(signUpEmail.status.value).toBe('pending')
-    expect(signUpEmail.pending.value).toBe(true)
+    expect(isPending()).toBe(true)
     expect(signUpEmail.data.value).toBeNull()
 
     d.resolve({ ok: true })
     await expect(p).resolves.toBeUndefined()
 
     expect(signUpEmail.status.value).toBe('success')
-    expect(signUpEmail.pending.value).toBe(false)
+    expect(isPending()).toBe(false)
     expect(signUpEmail.data.value).toEqual({ ok: true })
     expect(signUpEmail.error.value).toBeNull()
-    expect(signUpEmail.errorMessage.value).toBeNull()
+    expect(signUpEmail.error.value?.message).toBeUndefined()
   })
 
   it('does not throw and sets error state for thrown method errors', async () => {
@@ -95,7 +97,7 @@ describe('useUserSignUp', () => {
     expect(signUpEmail.data.value).toBeNull()
     expect(signUpEmail.error.value).toMatchObject({ message: 'boom' })
     expect(signUpEmail.error.value!.raw).toBeInstanceOf(Error)
-    expect(signUpEmail.errorMessage.value).toBe('boom')
+    expect(signUpEmail.error.value?.message).toBe('boom')
   })
 
   it('throws when method key is missing', async () => {


### PR DESCRIPTION
## Summary
- remove the redundant `errorMessage` field from user auth action handles
- standardize all usage/docs on `error.value?.message`
- update sign-in/sign-up tests to assert message via `error`
- document this as a breaking alpha change with migration snippet

## Breaking change
- `useUserSignIn()` and `useUserSignUp()` action handles no longer expose `errorMessage`
- migration: replace `errorMessage.value` with `error.value?.message`

## Validation
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
