### PR TITLE
fix(module): restore auth.redirects and fix routeRules typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ This changelog is incomplete for alpha releases. Use the GitHub Releases page fo
 
 ### Breaking Changes
 
-- Removed `auth.redirects`. Use `routeRules.auth.redirectTo` (or page meta `auth.redirectTo`) for redirect targets.
 - Removed `errorMessage` from `useUserSignIn()` and `useUserSignUp()` action handles. Use `error.value?.message`.
 
   Migration:
@@ -18,6 +17,10 @@ This changelog is incomplete for alpha releases. Use the GitHub Releases page fo
   // after
   const message = error.value?.message ?? 'Please try again.'
   ```
+
+### Fixed
+
+- Restored `auth.redirects` as global redirect fallbacks (route-level `redirectTo` still takes precedence).
 
 ## 0.0.2-alpha.0
 

--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -10,6 +10,10 @@ navigation.icon: i-lucide-settings
 export default defineNuxtConfig({
   modules: ['@onmax/nuxt-better-auth'],
   auth: {
+    redirects: {
+      login: '/login',
+      guest: '/',
+    },
     preserveRedirect: true,
     redirectQueryKey: 'redirect',
   },
@@ -44,6 +48,16 @@ export default defineNuxtConfig({
     Default: `'app/auth.config'`
 
     Path to the client auth config file, relative to the project root.
+  ::
+
+  ::field{name="redirects" type="{ login?: string, guest?: string }"}
+    Default: `{ login: '/login', guest: '/' }`
+
+    Global redirect fallbacks:
+    - `login`: where to redirect unauthenticated users
+    - `guest`: where to redirect authenticated users trying to access guest-only routes
+
+    Per-route `redirectTo` takes precedence when set.
   ::
 
   ::field{name="preserveRedirect" type="boolean"}
@@ -83,7 +97,7 @@ export default defineNuxtConfig({
 
 ## Redirect Targets (RouteRules-First)
 
-`auth.redirects` has been removed. Redirect paths now belong to route-level auth config:
+Prefer redirect paths on route-level auth config:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
@@ -97,6 +111,8 @@ export default defineNuxtConfig({
 If `redirectTo` is omitted, shorthand fallbacks apply:
 - `auth: 'user'` falls back to `/login`
 - `auth: 'guest'` falls back to `/`
+
+If you want global defaults for those fallbacks, use `auth.redirects`.
 
 ## Server Configuration
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -73,6 +73,7 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
     clientOnly: false,
     serverConfig: 'server/auth.config',
     clientConfig: 'app/auth.config',
+    redirects: { login: '/login', guest: '/' },
     preserveRedirect: true,
     redirectQueryKey: 'redirect',
     secondaryStorage: false,

--- a/src/module/runtime.ts
+++ b/src/module/runtime.ts
@@ -40,6 +40,7 @@ export function setupRuntimeConfig(input: SetupRuntimeConfigInput): { secondaryS
     nuxt.options.runtimeConfig.public.siteUrl = process.env.NUXT_PUBLIC_SITE_URL
 
   nuxt.options.runtimeConfig.public.auth = defu(nuxt.options.runtimeConfig.public.auth as Record<string, unknown>, {
+    redirects: { login: options.redirects?.login ?? '/login', guest: options.redirects?.guest ?? '/' },
     preserveRedirect: options.preserveRedirect ?? true,
     redirectQueryKey: options.redirectQueryKey ?? 'redirect',
     useDatabase: databaseProvider !== 'none',

--- a/src/runtime/app/middleware/auth.global.ts
+++ b/src/runtime/app/middleware/auth.global.ts
@@ -53,14 +53,14 @@ export default defineNuxtRouteMiddleware(async (to) => {
 
   if (mode === 'guest') {
     if (loggedIn.value)
-      return navigateTo(redirectTo ?? '/')
+      return navigateTo(redirectTo ?? config?.redirects?.guest ?? '/')
     return
   }
 
   if (!loggedIn.value) {
     const resolved = resolveLoginRedirect({
       route: to,
-      loginTarget: redirectTo ?? '/login',
+      loginTarget: redirectTo ?? config?.redirects?.login ?? '/login',
       config,
     })
     return resolved.external ? navigateTo(resolved.to, { external: true }) : navigateTo(resolved.to)

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -29,6 +29,12 @@ export interface BetterAuthModuleOptions {
   serverConfig?: string
   /** Client config path relative to rootDir. Default: 'app/auth.config' */
   clientConfig?: string
+  redirects?: {
+    /** Where to redirect unauthenticated users. Default: '/login' */
+    login?: string
+    /** Where to redirect authenticated users on guest-only routes. Default: '/' */
+    guest?: string
+  }
   /**
    * When redirecting unauthenticated users to the login route, append a query param
    * containing the originally requested path (for safe "return-to" redirects).
@@ -65,6 +71,7 @@ export interface BetterAuthModuleOptions {
 
 // Runtime config type for public.auth
 export interface AuthRuntimeConfig {
+  redirects: { login: string, guest: string }
   preserveRedirect: boolean
   redirectQueryKey: string
   useDatabase: boolean

--- a/src/runtime/server/api/_better-auth/config.get.ts
+++ b/src/runtime/server/api/_better-auth/config.get.ts
@@ -9,6 +9,7 @@ export default defineEventHandler(async (event) => {
     const authContext = await ((auth as { $context?: Promise<{ trustedOrigins?: string[] }> | { trustedOrigins?: string[] } }).$context)
     const runtimeConfig = useRuntimeConfig()
     const publicAuth = runtimeConfig.public?.auth as {
+      redirects?: { login?: string, guest?: string }
       preserveRedirect?: boolean
       redirectQueryKey?: string
       useDatabase?: boolean
@@ -27,6 +28,7 @@ export default defineEventHandler(async (event) => {
       config: {
         // Module config (nuxt.config.ts)
         module: {
+          redirects: { login: publicAuth?.redirects?.login ?? '/login', guest: publicAuth?.redirects?.guest ?? '/' },
           preserveRedirect: publicAuth?.preserveRedirect ?? true,
           redirectQueryKey: publicAuth?.redirectQueryKey ?? 'redirect',
           secondaryStorage: privateAuth?.secondaryStorage ?? false,

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,5 +1,5 @@
+import type { AuthUser, UserMatch } from '#nuxt-better-auth'
 import type { NitroRouteRules } from 'nitropack/types'
-import type { AuthUser, UserMatch } from './types/augment'
 
 // Re-export augmentable types
 export type { AppSession, AuthSession, AuthUser, RequireSessionOptions, ServerAuthContext, UserMatch, UserSessionComposable } from './types/augment'

--- a/test/cases/core-auth-redirects/nuxt.config.ts
+++ b/test/cases/core-auth-redirects/nuxt.config.ts
@@ -1,0 +1,12 @@
+export default defineNuxtConfig({
+  extends: ['../core-auth'],
+
+  auth: {
+    serverConfig: '../core-auth/server/auth.config',
+    clientConfig: '../core-auth/app/auth.config',
+    redirects: {
+      login: '/custom-login',
+      guest: '/protected',
+    },
+  },
+})

--- a/test/cases/plugins-type-inference/tsconfig.type-check.json
+++ b/test/cases/plugins-type-inference/tsconfig.type-check.json
@@ -20,6 +20,7 @@
   },
   "files": [
     "./.nuxt/types/nuxt-better-auth-infer.d.ts",
+    "./.nuxt/types/nuxt-better-auth-nitro.d.ts",
     "./typecheck-target.ts"
   ]
 }

--- a/test/cases/plugins-type-inference/typecheck-target.ts
+++ b/test/cases/plugins-type-inference/typecheck-target.ts
@@ -1,4 +1,11 @@
 import type { AuthUser } from '#nuxt-better-auth'
+import type { NitroRouteRules } from 'nitropack/types'
+
+declare module '#nuxt-better-auth' {
+  interface AuthUser {
+    foo: string
+  }
+}
 
 const user: AuthUser = {
   id: '1',
@@ -9,6 +16,14 @@ const user: AuthUser = {
   name: 'n',
   role: 'admin',
   internalCode: 'x',
+  foo: 'bar',
+}
+
+const rules: NitroRouteRules = {
+  auth: {
+    user: { role: 'admin', internalCode: 'x', foo: 'bar' },
+  },
 }
 
 void user
+void rules

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,9 +1,19 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import { getPackageExportsManifest } from 'vitest-package-exports'
 import yaml from 'yaml'
 
 describe('exports-snapshot', async () => {
   it('module exports', async () => {
+    if (!existsSync('dist/module.mjs') || !existsSync('dist/runtime/config.js')) {
+      const build = spawnSync('pnpm', ['exec', 'nuxt-module-build', 'build'], {
+        encoding: 'utf8',
+        env: process.env,
+      })
+      expect(build.status, `nuxt-module-build failed:\n${build.stdout}\n${build.stderr}`).toBe(0)
+    }
+
     const manifest = await getPackageExportsManifest({ importMode: 'dist' })
     await expect(yaml.stringify(manifest.exports)).toMatchFileSnapshot('./exports/module.yaml')
   })

--- a/test/redirects-option.test.ts
+++ b/test/redirects-option.test.ts
@@ -1,0 +1,31 @@
+import { fileURLToPath } from 'node:url'
+import { setup, url } from '@nuxt/test-utils/e2e'
+import { describe, expect, it } from 'vitest'
+
+describe('auth.redirects option', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('./cases/core-auth-redirects', import.meta.url)),
+  })
+
+  it('redirects unauthenticated users to redirects.login and preserves requested url by default', async () => {
+    const response = await fetch(url('/protected?foo=1'), { redirect: 'manual' })
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toContain('/custom-login?redirect=%2Fprotected%3Ffoo%3D1')
+  })
+
+  it('redirects authenticated users on guest routes to redirects.guest', async () => {
+    const testUser = { email: `test-${Date.now()}@example.com`, password: 'testpass123', name: 'Test User' }
+
+    const signupRes = await fetch(url('/api/auth/sign-up/email'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(testUser),
+    })
+    expect(signupRes.status).toBe(200)
+    const cookies = signupRes.headers.get('set-cookie') || ''
+
+    const res = await fetch(url('/login'), { redirect: 'manual', headers: { cookie: cookies } })
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toContain('/protected')
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,12 @@
 {
   "compilerOptions": {
     "target": "ESNext",
+    "baseUrl": ".",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "paths": {
+      "#nuxt-better-auth": ["./src/runtime/types/augment"]
+    },
     "resolveJsonModule": true,
     "types": ["node"],
     "strict": true,


### PR DESCRIPTION
Fixes #164

- Restore `auth.redirects` (login/guest) as global redirect fallbacks
- Fix RouteRules typing so `auth.user` uses the same `AuthUser` identity as `#nuxt-better-auth` augmentations/inference
- Add runtime test fixture for redirects + type regression for Nitro RouteRules
- Update docs + changelog