### PR TITLE
feat(auth): add redirects.logout

### DIFF
--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -13,6 +13,7 @@ export default defineNuxtConfig({
     redirects: {
       login: '/login',
       guest: '/',
+      // logout: '/goodbye', // optional
     },
     preserveRedirect: true,
     redirectQueryKey: 'redirect',
@@ -50,12 +51,13 @@ export default defineNuxtConfig({
     Path to the client auth config file, relative to the project root.
   ::
 
-  ::field{name="redirects" type="{ login?: string, guest?: string }"}
+  ::field{name="redirects" type="{ login?: string, guest?: string, logout?: string }"}
     Default: `{ login: '/login', guest: '/' }`
 
     Global redirect fallbacks:
     - `login`: where to redirect unauthenticated users
     - `guest`: where to redirect authenticated users trying to access guest-only routes
+    - `logout`: where to navigate after logout (no default)
 
     Per-route `redirectTo` takes precedence when set.
   ::

--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -77,6 +77,8 @@ Signs the user out and clears the local session state.
 await signOut()
 ```
 
+If `auth.redirects.logout` is configured, `signOut()` will navigate there automatically (client-side), unless you provide `onSuccess`.
+
 **Options**
 
 ```ts

--- a/src/module/runtime.ts
+++ b/src/module/runtime.ts
@@ -40,7 +40,11 @@ export function setupRuntimeConfig(input: SetupRuntimeConfigInput): { secondaryS
     nuxt.options.runtimeConfig.public.siteUrl = process.env.NUXT_PUBLIC_SITE_URL
 
   nuxt.options.runtimeConfig.public.auth = defu(nuxt.options.runtimeConfig.public.auth as Record<string, unknown>, {
-    redirects: { login: options.redirects?.login ?? '/login', guest: options.redirects?.guest ?? '/' },
+    redirects: {
+      login: options.redirects?.login ?? '/login',
+      guest: options.redirects?.guest ?? '/',
+      logout: options.redirects?.logout,
+    },
     preserveRedirect: options.preserveRedirect ?? true,
     redirectQueryKey: options.redirectQueryKey ?? 'redirect',
     useDatabase: databaseProvider !== 'none',

--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -1,7 +1,7 @@
 import type { AppAuthClient, AuthSession, AuthUser } from '#nuxt-better-auth'
 import type { ComputedRef, Ref } from 'vue'
 import createAppAuthClient from '#auth/client'
-import { computed, nextTick, useNuxtApp, useRequestHeaders, useRequestURL, useRuntimeConfig, useState, watch } from '#imports'
+import { computed, navigateTo, nextTick, useNuxtApp, useRequestHeaders, useRequestURL, useRuntimeConfig, useState, watch } from '#imports'
 import { normalizeAuthActionError } from '../internal/auth-action-error'
 
 export interface SignOutOptions { onSuccess?: () => void | Promise<void> }
@@ -311,8 +311,15 @@ export function useUserSession(): UseUserSessionReturn {
       throw new Error('signOut can only be called on client-side')
     await client.signOut()
     clearSession()
-    if (options?.onSuccess)
+    if (options?.onSuccess) {
       await options.onSuccess()
+      return
+    }
+
+    const authConfig = runtimeConfig.public.auth as { redirects?: { logout?: string } } | undefined
+    const logoutRedirect = authConfig?.redirects?.logout
+    if (logoutRedirect)
+      await navigateTo(logoutRedirect)
   }
 
   return {

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -34,6 +34,8 @@ export interface BetterAuthModuleOptions {
     login?: string
     /** Where to redirect authenticated users on guest-only routes. Default: '/' */
     guest?: string
+    /** Where to navigate after logout. Default: no automatic navigation */
+    logout?: string
   }
   /**
    * When redirecting unauthenticated users to the login route, append a query param
@@ -71,7 +73,7 @@ export interface BetterAuthModuleOptions {
 
 // Runtime config type for public.auth
 export interface AuthRuntimeConfig {
-  redirects: { login: string, guest: string }
+  redirects: { login: string, guest: string, logout?: string }
   preserveRedirect: boolean
   redirectQueryKey: string
   useDatabase: boolean

--- a/src/runtime/server/api/_better-auth/config.get.ts
+++ b/src/runtime/server/api/_better-auth/config.get.ts
@@ -9,7 +9,7 @@ export default defineEventHandler(async (event) => {
     const authContext = await ((auth as { $context?: Promise<{ trustedOrigins?: string[] }> | { trustedOrigins?: string[] } }).$context)
     const runtimeConfig = useRuntimeConfig()
     const publicAuth = runtimeConfig.public?.auth as {
-      redirects?: { login?: string, guest?: string }
+      redirects?: { login?: string, guest?: string, logout?: string }
       preserveRedirect?: boolean
       redirectQueryKey?: string
       useDatabase?: boolean
@@ -28,7 +28,11 @@ export default defineEventHandler(async (event) => {
       config: {
         // Module config (nuxt.config.ts)
         module: {
-          redirects: { login: publicAuth?.redirects?.login ?? '/login', guest: publicAuth?.redirects?.guest ?? '/' },
+          redirects: {
+            login: publicAuth?.redirects?.login ?? '/login',
+            guest: publicAuth?.redirects?.guest ?? '/',
+            logout: publicAuth?.redirects?.logout,
+          },
           preserveRedirect: publicAuth?.preserveRedirect ?? true,
           redirectQueryKey: publicAuth?.redirectQueryKey ?? 'redirect',
           secondaryStorage: privateAuth?.secondaryStorage ?? false,


### PR DESCRIPTION
## Summary
- Add optional `auth.redirects.logout`.
- When configured, `useUserSession().signOut()` navigates there by default (unless `onSuccess` is provided).
- Expose the value in the DevTools config endpoint.

## Tests
- pnpm lint
- pnpm typecheck
- pnpm test
