### PR TITLE
fix(auth): avoid hydration session flicker

### DIFF
--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -1,11 +1,12 @@
 import type { AppAuthClient, AuthSession, AuthUser } from '#nuxt-better-auth'
 import type { ComputedRef, Ref } from 'vue'
 import createAppAuthClient from '#auth/client'
-import { computed, navigateTo, nextTick, useNuxtApp, useRequestHeaders, useRequestURL, useRuntimeConfig, useState, watch } from '#imports'
+import { computed, navigateTo, nextTick, useNuxtApp, useRequestFetch, useRequestHeaders, useRequestURL, useRuntimeConfig, useState, watch } from '#imports'
 import { normalizeAuthActionError } from '../internal/auth-action-error'
 
 export interface SignOutOptions { onSuccess?: () => void | Promise<void> }
 interface RuntimeFlags { client: boolean, server: boolean }
+interface SessionResponse { session: AuthSession & { token?: string }, user: AuthUser }
 
 let _sessionSignalListenerBound = false
 
@@ -339,10 +340,28 @@ export function useUserSession(): UseUserSessionReturn {
       })
 
   async function fetchSession(options: { headers?: HeadersInit, force?: boolean } = {}) {
-    // On server, session is already fetched by server middleware - nothing to do
     if (runtimeFlags.server) {
-      if (!authReady.value)
-        authReady.value = true
+      try {
+        const headers = options.headers || useRequestHeaders(['cookie'])
+        const requestFetch = useRequestFetch()
+        const data = await requestFetch<SessionResponse | null>('/api/auth/get-session', { headers })
+
+        if (data?.session && data?.user) {
+          const { token: _, ...safeSession } = data.session
+          session.value = safeSession as AuthSession
+          user.value = data.user
+        }
+        else {
+          clearSession()
+        }
+      }
+      catch {
+        clearSession()
+      }
+      finally {
+        if (!authReady.value)
+          authReady.value = true
+      }
       return
     }
 
@@ -352,7 +371,7 @@ export function useUserSession(): UseUserSessionReturn {
         const fetchOptions = headers ? { headers } : undefined
         const query = options.force ? { disableCookieCache: true } : undefined
         const result = await client.getSession({ query }, fetchOptions)
-        const data = result.data as { session: AuthSession & { token?: string }, user: AuthUser } | null
+        const data = result.data as SessionResponse | null
 
         if (data?.session && data?.user) {
           // Filter out sensitive token field

--- a/test/use-user-session.test.ts
+++ b/test/use-user-session.test.ts
@@ -33,6 +33,7 @@ const requestURL: { origin: string, searchParams: URLSearchParams } = {
 let requestHeaders: HeadersInit | undefined = { cookie: 'session=test' }
 const state = new Map<string, ReturnType<typeof ref>>()
 const navigateTo = vi.fn(async () => {})
+const $fetch = vi.fn(async () => null)
 const nuxtHooks = new Map<string, Array<() => void | Promise<void>>>()
 const nuxtApp = {
   payload,
@@ -74,6 +75,7 @@ vi.mock('#imports', async () => {
     nextTick: vue.nextTick,
     watch: vue.watch,
     useNuxtApp: () => nuxtApp,
+    useRequestFetch: () => $fetch,
     useRequestHeaders: () => requestHeaders,
     useRequestURL: () => requestURL,
     useRuntimeConfig: () => runtimeConfig,
@@ -129,6 +131,8 @@ describe('useUserSession hydration bootstrap', () => {
     runtimeConfig.public.auth.session.skipHydratedSsrGetSession = false
     runtimeConfig.public.auth.redirects = {}
     navigateTo.mockClear()
+    $fetch.mockReset()
+    $fetch.mockResolvedValue(null)
 
     sessionAtom.value = {
       data: null,
@@ -313,6 +317,37 @@ describe('useUserSession hydration bootstrap', () => {
     expect(mockClient.getSession).toHaveBeenCalledOnce()
     expect(auth.session.value).toEqual({ id: 'session-2', ipAddress: '127.0.0.1' })
     expect(auth.user.value).toEqual({ id: 'user-2', email: 'user@example.com' })
+  })
+
+  it('fetchSession fetches and sets SSR session on server', async () => {
+    setRuntimeFlags({ client: false, server: true })
+    $fetch.mockResolvedValueOnce({
+      session: { id: 'session-server', token: 'secret', ipAddress: '127.0.0.1' },
+      user: { id: 'user-server', email: 'server@example.com' },
+    })
+
+    const useUserSession = await loadUseUserSession()
+    const auth = useUserSession()
+    await auth.fetchSession()
+
+    expect($fetch).toHaveBeenCalledWith('/api/auth/get-session', { headers: { cookie: 'session=test' } })
+    expect(auth.session.value).toEqual({ id: 'session-server', ipAddress: '127.0.0.1' })
+    expect(auth.user.value).toEqual({ id: 'user-server', email: 'server@example.com' })
+    expect(auth.ready.value).toBe(true)
+  })
+
+  it('fetchSession clears SSR state on server when no session is returned', async () => {
+    setRuntimeFlags({ client: false, server: true })
+    seedHydratedState()
+    $fetch.mockResolvedValueOnce(null)
+
+    const useUserSession = await loadUseUserSession()
+    const auth = useUserSession()
+    await auth.fetchSession()
+
+    expect(auth.session.value).toBeNull()
+    expect(auth.user.value).toBeNull()
+    expect(auth.ready.value).toBe(true)
   })
 
   it('signIn uses auth.redirects.authenticated when no callback is provided', async () => {


### PR DESCRIPTION
## Summary
- preserve SSR-hydrated auth state during the first client hydration empty snapshot
- queue one post-mount forced session reconciliation
- keep non-hydration session update/clear behavior unchanged

## Tests
- `pnpm -C /Users/maxi/nuxt/better-auth exec vitest run test/use-user-session.test.ts test/wrap-auth-method.test.ts`
- `pnpm -C /Users/maxi/nuxt/better-auth test`
