### PR TITLE
refactor(api): rename auth helper composables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,27 @@ This changelog is incomplete for alpha releases. Use the GitHub Releases page fo
 
 ### Breaking Changes
 
-- Removed `errorMessage` from `useUserSignIn()` and `useUserSignUp()` action handles. Use `error.value?.message`.
+- Renamed `useUserSignIn()` to `useSignIn()`.
+- Renamed `useUserSignUp()` to `useSignUp()`.
+- Renamed `getAppSession()` to `getRequestSession()`.
+- Renamed memoized request context key from `event.context.appSession` to `event.context.requestSession`.
+- Removed `errorMessage` from `useSignIn()` and `useSignUp()` action handles. Use `error.value?.message`.
 
   Migration:
 
   ```ts
+  // before
+  const signInEmail = useUserSignIn('email')
+  const signUpEmail = useUserSignUp('email')
+  const appSession = await getAppSession(event)
+  const memoized = event.context.appSession
+
+  // after
+  const signInEmail = useSignIn('email')
+  const signUpEmail = useSignUp('email')
+  const requestSession = await getRequestSession(event)
+  const memoized = event.context.requestSession
+
   // before
   const message = errorMessage.value ?? 'Please try again.'
 

--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -174,7 +174,7 @@ export default defineServerAuth((ctx) => ({
 
 ### Session Enrichment
 
-You can enrich session payloads with Better Auth's `custom-session` plugin through `plugins` in `defineServerAuth`. This module does not provide a separate `appSession.enrich` option.
+You can enrich session payloads with Better Auth's `custom-session` plugin through `plugins` in `defineServerAuth`. This module does not provide a separate `requestSession.enrich` option.
 
 See the full recipe in [Server Utilities](/api/server-utils#session-enrichment-with-custom-session).
 

--- a/docs/content/2.core-concepts/1.server-auth.md
+++ b/docs/content/2.core-concepts/1.server-auth.md
@@ -9,7 +9,7 @@ description: When to reach for the full Better Auth server instance.
 
 | Task | Use | Example |
 |------|-----|---------|
-| Get request-cached session context | `getAppSession(event)` | Cache once per request with context-backed storage when available |
+| Get request-cached session context | `getRequestSession(event)` | Cache once per request with context-backed storage when available |
 | Get current session | `getUserSession(event)` | Check if user is logged in |
 | Require authentication | `requireUserSession(event)` | Protect an API route |
 | Access Better Auth API | `serverAuth(event)` | Call `auth.api.listSessions()` |

--- a/docs/content/2.core-concepts/4.auto-imports-aliases.md
+++ b/docs/content/2.core-concepts/4.auto-imports-aliases.md
@@ -8,11 +8,13 @@ description: What the module registers for you.
 **Client**
 
 - `useUserSession()`
+- `useSignIn()`
+- `useSignUp()`
 
 **Server**
 
 - `serverAuth(event?)`
-- `getAppSession(event)`
+- `getRequestSession(event)`
 - `getUserSession(event)`
 - `requireUserSession(event, options?)`
 
@@ -27,13 +29,13 @@ description: What the module registers for you.
 ```ts [server/api/profile.ts]
 export default defineEventHandler(async (event) => {
   // These are auto-imported, no import statement needed
-  const appSession = await getAppSession(event)
+  const requestSession = await getRequestSession(event)
   const session = await getUserSession(event)
   const auth = serverAuth(event)
 })
 ```
 
-Use `getAppSession(event)` when multiple handlers or middleware in the same request need session data. The helper should be preferred over repeated `getUserSession(event)` calls in the same request chain.
+Use `getRequestSession(event)` when multiple handlers or middleware in the same request need session data. The helper should be preferred over repeated `getUserSession(event)` calls in the same request chain.
 `getUserSession(event)` does not memoize by itself.
 
 ### Client Composables (auto-imported in Vue components)

--- a/docs/content/4.integrations/3.i18n.md
+++ b/docs/content/4.integrations/3.i18n.md
@@ -66,7 +66,7 @@ Better Auth errors include a `code` property that you can translate using `useI1
 const {
   execute: signInWithEmail,
   error,
-} = useUserSignIn('email')
+} = useSignIn('email')
 const { t, te } = useI18n()
 
 async function handleLogin(email: string, password: string) {

--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -147,12 +147,12 @@ During SSR, `updateUser` only patches local state since no client is available.
 
 :read-more{to="/api/components" title="BetterAuthState component"}
 
-## useUserSignIn
+## useSignIn
 
 Returns a keyed action handle for `useUserSession().signIn.*`. Each method handle exposes template-friendly async state, similar to composables like `useFetch`.
 
 ```ts [pages/login.vue]
-const { execute, data, status, error } = useUserSignIn('email')
+const { execute, data, status, error } = useSignIn('email')
 
 await execute(
   { email, password, rememberMe },
@@ -174,13 +174,13 @@ const {
   execute: loginWithEmail,
   status: statusEmail,
   error: errorEmail,
-} = useUserSignIn('email')
+} = useSignIn('email')
 
 const {
   execute: loginWithPasskey,
   status: statusPasskey,
   error: errorPasskey,
-} = useUserSignIn('passkey')
+} = useSignIn('passkey')
 ```
 
 Each method returns an action handle:
@@ -215,7 +215,7 @@ Better Auth methods can signal failure by throwing or by resolving to a `{ error
 #### Recommended flow (`execute`)
 
 ```ts [pages/login.vue]
-const { execute, data, status, error } = useUserSignIn('email')
+const { execute, data, status, error } = useSignIn('email')
 
 await execute({ email, password })
 
@@ -229,7 +229,8 @@ if (status.value === 'success') {
 ```
 
 ::warning
-`useUserSignIn` and `useUserSignUp` switched from map-style access (`useUserSignIn().email`) to keyed access (`useUserSignIn('email')`) in alpha.
+`useUserSignIn` and `useUserSignUp` were renamed to `useSignIn` and `useSignUp` in alpha.
+The API switched from map-style access (`useUserSignIn().email`) to keyed access (`useSignIn('email')`) in alpha.
 `error` changed from `unknown | null` to `AuthActionError | null` in alpha.
 The message alias field was removed in alpha. Use `error.value?.message`.
 `execute()` changed twice in alpha:
@@ -240,12 +241,12 @@ The message alias field was removed in alpha. Use `error.value?.message`.
 If you relied on raw payloads, use `error.raw`.
 ::
 
-## useUserSignUp
+## useSignUp
 
-Same API as `useUserSignIn`, but wraps `useUserSession().signUp.*`.
+Same API as `useSignIn`, but wraps `useUserSession().signUp.*`.
 
 ```ts [pages/signup.vue]
-const { execute, data, status, error } = useUserSignUp('email')
+const { execute, data, status, error } = useSignUp('email')
 
 await execute(
   { email, password, name },

--- a/docs/content/5.api/2.server-utils.md
+++ b/docs/content/5.api/2.server-utils.md
@@ -51,32 +51,32 @@ export default defineEventHandler(async (event) => {
 })
 ```
 
-`getUserSession` does not memoize by itself. Use `getAppSession(event)` when you need request-lifetime caching across middleware/handlers.
+`getUserSession` does not memoize by itself. Use `getRequestSession(event)` when you need request-lifetime caching across middleware/handlers.
 
 **Returns:**
 - `{ user: AuthUser, session: AuthSession }` if authenticated.
 - `null` if unauthenticated.
 
-## getAppSession
+## getRequestSession
 
-Retrieves the current session and memoizes it for the lifetime of the current request. In Nuxt and Nitro handlers, the helper stores the memoized value on `event.context.appSession`.
+Retrieves the current session and memoizes it for the lifetime of the current request. In Nuxt and Nitro handlers, the helper stores the memoized value on `event.context.requestSession`.
 
 ```ts [server/api/example.ts]
 export default defineEventHandler(async (event) => {
-  const appSession = await getAppSession(event)
-  const sameRequestSession = await getAppSession(event) // cached
+  const requestSession = await getRequestSession(event)
+  const sameRequestSession = await getRequestSession(event) // cached
 })
 ```
 
 Use this helper when multiple handlers/middleware in the same request need session access without repeating `auth.api.getSession()` calls.
 
 ::note
-`getAppSession` stays type-compatible in projects that use narrowed `h3` typings where `H3Event` does not explicitly declare `context`.
+`getRequestSession` stays type-compatible in projects that use narrowed `h3` typings where `H3Event` does not explicitly declare `context`.
 ::
 
 ## Session Enrichment with `custom-session`
 
-Use Better Auth's `custom-session` plugin when your app needs computed fields in the session payload returned by server helpers. Define the enrichment in `server/auth.config.ts`, and `getUserSession` or `getAppSession` will return the enriched shape.
+Use Better Auth's `custom-session` plugin when your app needs computed fields in the session payload returned by server helpers. Define the enrichment in `server/auth.config.ts`, and `getUserSession` or `getRequestSession` will return the enriched shape.
 
 ```ts [server/auth.config.ts]
 import { customSession } from 'better-auth/plugins'

--- a/playground/app/pages/login.vue
+++ b/playground/app/pages/login.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 definePageMeta({ layout: 'auth' })
 
-const signInEmail = useUserSignIn('email')
-const signInSocial = useUserSignIn('social')
-const signInPasskey = useUserSignIn('passkey')
+const signInEmail = useSignIn('email')
+const signInSocial = useSignIn('social')
+const signInPasskey = useSignIn('passkey')
 const { resolvePostAuthRedirect } = usePostAuthRedirect()
 
 const { t } = useI18n()

--- a/playground/app/pages/register.vue
+++ b/playground/app/pages/register.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 definePageMeta({ layout: 'auth' })
 
-const signUpEmail = useUserSignUp('email')
+const signUpEmail = useSignUp('email')
 const { resolvePostAuthRedirect } = usePostAuthRedirect()
 const { t } = useI18n()
 const toast = useToast()

--- a/src/module/runtime.ts
+++ b/src/module/runtime.ts
@@ -61,7 +61,7 @@ export function setupRuntimeConfig(input: SetupRuntimeConfigInput): { useHubKV: 
     const siteUrl = nuxt.options.runtimeConfig.public.siteUrl as string | undefined
     if (!siteUrl)
       consola.warn('clientOnly mode: set runtimeConfig.public.siteUrl (or NUXT_PUBLIC_SITE_URL) to your frontend URL')
-    consola.info('clientOnly mode enabled - server utilities (serverAuth, getAppSession, getUserSession, requireUserSession) are not available')
+    consola.info('clientOnly mode enabled - server utilities (serverAuth, getRequestSession, getUserSession, requireUserSession) are not available')
     return { useHubKV, secondaryStorageEnabled }
   }
 

--- a/src/module/type-templates.ts
+++ b/src/module/type-templates.ts
@@ -150,7 +150,7 @@ export * from '${input.runtimeTypesAugmentPath}'
 export type { AuthMeta, AuthMode, AuthRouteRules, Auth, InferUser, InferSession } from '${input.runtimeTypesPath}'
 declare module 'h3' {
   interface H3EventContext {
-    appSession?: AppSession | null
+    requestSession?: AppSession | null
   }
 }
 `,

--- a/src/runtime/app/composables/useSignIn.ts
+++ b/src/runtime/app/composables/useSignIn.ts
@@ -5,9 +5,9 @@ import { createActionHandles } from '../internal/auth-action-handles'
 
 type SignIn = NonNullable<AppAuthClient>['signIn']
 
-export function useUserSignIn<MethodKey extends keyof SignIn>(method: MethodKey): ActionHandleFor<SignIn[MethodKey]> {
+export function useSignIn<MethodKey extends keyof SignIn>(method: MethodKey): ActionHandleFor<SignIn[MethodKey]> {
   if (method === undefined || method === null)
-    throw new TypeError('useUserSignIn(method) requires a sign-in method key')
+    throw new TypeError('useSignIn(method) requires a sign-in method key')
 
   const handles = createActionHandles(() => useUserSession().signIn, 'signIn') as ActionHandleMap<SignIn>
   return handles[method] as ActionHandleFor<SignIn[MethodKey]>

--- a/src/runtime/app/composables/useSignUp.ts
+++ b/src/runtime/app/composables/useSignUp.ts
@@ -5,9 +5,9 @@ import { createActionHandles } from '../internal/auth-action-handles'
 
 type SignUp = NonNullable<AppAuthClient>['signUp']
 
-export function useUserSignUp<MethodKey extends keyof SignUp>(method: MethodKey): ActionHandleFor<SignUp[MethodKey]> {
+export function useSignUp<MethodKey extends keyof SignUp>(method: MethodKey): ActionHandleFor<SignUp[MethodKey]> {
   if (method === undefined || method === null)
-    throw new TypeError('useUserSignUp(method) requires a sign-up method key')
+    throw new TypeError('useSignUp(method) requires a sign-up method key')
 
   const handles = createActionHandles(() => useUserSession().signUp, 'signUp') as ActionHandleMap<SignUp>
   return handles[method] as ActionHandleFor<SignUp[MethodKey]>

--- a/test/use-signin.test.ts
+++ b/test/use-signin.test.ts
@@ -27,13 +27,13 @@ vi.mock('#imports', async () => {
   }
 })
 
-async function loadUseUserSignIn() {
+async function loadUseSignIn() {
   vi.resetModules()
-  const mod = await import('../src/runtime/app/composables/useUserSignIn')
-  return mod.useUserSignIn
+  const mod = await import('../src/runtime/app/composables/useSignIn')
+  return mod.useSignIn
 }
 
-describe('useUserSignIn', () => {
+describe('useSignIn', () => {
   it('sets success state, data and clears error on success', async () => {
     const d = deferred<{ ok: true }>()
     sessionMock = {
@@ -42,8 +42,8 @@ describe('useUserSignIn', () => {
       },
     }
 
-    const useUserSignIn = await loadUseUserSignIn()
-    const signInEmail = useUserSignIn('email')
+    const useSignIn = await loadUseSignIn()
+    const signInEmail = useSignIn('email')
 
     const p = signInEmail.execute({} as any)
     expect(signInEmail.status.value).toBe('pending')
@@ -71,8 +71,8 @@ describe('useUserSignIn', () => {
       },
     }
 
-    const useUserSignIn = await loadUseUserSignIn()
-    const signInEmail = useUserSignIn('email')
+    const useSignIn = await loadUseSignIn()
+    const signInEmail = useSignIn('email')
 
     const p1 = signInEmail.execute({} as any)
     d1.resolve({ ok: true })
@@ -98,8 +98,8 @@ describe('useUserSignIn', () => {
       },
     }
 
-    const useUserSignIn = await loadUseUserSignIn()
-    const signInEmail = useUserSignIn('email')
+    const useSignIn = await loadUseSignIn()
+    const signInEmail = useSignIn('email')
 
     await expect(signInEmail.execute({} as any)).resolves.toBeUndefined()
     expect(signInEmail.status.value).toBe('error')
@@ -117,8 +117,8 @@ describe('useUserSignIn', () => {
       },
     }
 
-    const useUserSignIn = await loadUseUserSignIn()
-    const signInEmail = useUserSignIn('email')
+    const useSignIn = await loadUseSignIn()
+    const signInEmail = useSignIn('email')
 
     await expect(signInEmail.execute({} as any)).resolves.toBeUndefined()
     expect(signInEmail.status.value).toBe('error')
@@ -145,8 +145,8 @@ describe('useUserSignIn', () => {
       },
     }
 
-    const useUserSignIn = await loadUseUserSignIn()
-    const signInEmail = useUserSignIn('email')
+    const useSignIn = await loadUseSignIn()
+    const signInEmail = useSignIn('email')
 
     const p1 = signInEmail.execute({} as any)
     const p2 = signInEmail.execute({} as any)
@@ -173,8 +173,8 @@ describe('useUserSignIn', () => {
       }),
     }
 
-    const useUserSignIn = await loadUseUserSignIn()
-    const signInEmail = useUserSignIn('email')
+    const useSignIn = await loadUseSignIn()
+    const signInEmail = useSignIn('email')
 
     expect(signInEmail.status.value).toBe('idle')
     await expect(signInEmail.execute({} as any)).resolves.toBeUndefined()
@@ -192,8 +192,8 @@ describe('useUserSignIn', () => {
       },
     }
 
-    const useUserSignIn = await loadUseUserSignIn()
-    const signInEmail = useUserSignIn('email')
+    const useSignIn = await loadUseSignIn()
+    const signInEmail = useSignIn('email')
     const isPending = () => signInEmail.status.value === 'pending'
 
     expect(typeof signInEmail.execute).toBe('function')
@@ -206,9 +206,9 @@ describe('useUserSignIn', () => {
 
   it('throws when method key is missing', async () => {
     sessionMock = { signIn: {} }
-    const useUserSignIn = await loadUseUserSignIn()
-    expect(() => useUserSignIn(undefined as any)).toThrowError(TypeError)
-    expect(() => useUserSignIn(undefined as any)).toThrow('requires a sign-in method key')
+    const useSignIn = await loadUseSignIn()
+    expect(() => useSignIn(undefined as any)).toThrowError(TypeError)
+    expect(() => useSignIn(undefined as any)).toThrow('requires a sign-in method key')
   })
 
   it('sets error state for invalid method key', async () => {
@@ -218,8 +218,8 @@ describe('useUserSignIn', () => {
       },
     }
 
-    const useUserSignIn = await loadUseUserSignIn()
-    const invalid = useUserSignIn('invalid' as any)
+    const useSignIn = await loadUseSignIn()
+    const invalid = useSignIn('invalid' as any)
 
     await expect(invalid.execute({} as any)).resolves.toBeUndefined()
     expect(invalid.status.value).toBe('error')

--- a/test/use-signup.test.ts
+++ b/test/use-signup.test.ts
@@ -27,13 +27,13 @@ vi.mock('#imports', async () => {
   }
 })
 
-async function loadUseUserSignUp() {
+async function loadUseSignUp() {
   vi.resetModules()
-  const mod = await import('../src/runtime/app/composables/useUserSignUp')
-  return mod.useUserSignUp
+  const mod = await import('../src/runtime/app/composables/useSignUp')
+  return mod.useSignUp
 }
 
-describe('useUserSignUp', () => {
+describe('useSignUp', () => {
   it('returns a keyed action handle with the expected shape', async () => {
     sessionMock = {
       signUp: {
@@ -41,8 +41,8 @@ describe('useUserSignUp', () => {
       },
     }
 
-    const useUserSignUp = await loadUseUserSignUp()
-    const signUpEmail = useUserSignUp('email')
+    const useSignUp = await loadUseSignUp()
+    const signUpEmail = useSignUp('email')
     const isPending = () => signUpEmail.status.value === 'pending'
 
     expect(typeof signUpEmail.execute).toBe('function')
@@ -61,8 +61,8 @@ describe('useUserSignUp', () => {
       },
     }
 
-    const useUserSignUp = await loadUseUserSignUp()
-    const signUpEmail = useUserSignUp('email')
+    const useSignUp = await loadUseSignUp()
+    const signUpEmail = useSignUp('email')
     const isPending = () => signUpEmail.status.value === 'pending'
 
     const p = signUpEmail.execute({} as any)
@@ -89,8 +89,8 @@ describe('useUserSignUp', () => {
       },
     }
 
-    const useUserSignUp = await loadUseUserSignUp()
-    const signUpEmail = useUserSignUp('email')
+    const useSignUp = await loadUseSignUp()
+    const signUpEmail = useSignUp('email')
 
     await expect(signUpEmail.execute({} as any)).resolves.toBeUndefined()
     expect(signUpEmail.status.value).toBe('error')
@@ -102,8 +102,8 @@ describe('useUserSignUp', () => {
 
   it('throws when method key is missing', async () => {
     sessionMock = { signUp: {} }
-    const useUserSignUp = await loadUseUserSignUp()
-    expect(() => useUserSignUp(undefined as any)).toThrowError(TypeError)
-    expect(() => useUserSignUp(undefined as any)).toThrow('requires a sign-up method key')
+    const useSignUp = await loadUseSignUp()
+    expect(() => useSignUp(undefined as any)).toThrowError(TypeError)
+    expect(() => useSignUp(undefined as any)).toThrow('requires a sign-up method key')
   })
 })


### PR DESCRIPTION
## Summary
- rename `useUserSignIn` to `useSignIn`
- rename `useUserSignUp` to `useSignUp`
- rename `getAppSession` to `getRequestSession`
- rename memoized context key from `event.context.appSession` to `event.context.requestSession`
- update runtime, tests, playground usage, and docs/changelog to match

## Breaking Changes
This PR intentionally introduces a hard alpha rename with no compatibility aliases.

| Before | After |
| --- | --- |
| `useUserSignIn('email')` | `useSignIn('email')` |
| `useUserSignUp('email')` | `useSignUp('email')` |
| `getAppSession(event)` | `getRequestSession(event)` |
| `event.context.appSession` | `event.context.requestSession` |

## Tests
- `pnpm -C /Users/maxi/nuxt/better-auth test test/use-signin.test.ts test/use-signup.test.ts test/get-request-session.test.ts`
- `pnpm -C /Users/maxi/nuxt/better-auth test`

## Related
- [#91](https://github.com/nuxt-modules/better-auth/issues/91)
