### PR TITLE
feat(auth): simplify social signin DX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This changelog is incomplete for alpha releases. Use the GitHub Releases page fo
 - Renamed `getAppSession()` to `getRequestSession()`.
 - Renamed memoized request context key from `event.context.appSession` to `event.context.requestSession`.
 - Removed `errorMessage` from `useSignIn()` and `useSignUp()` action handles. Use `error.value?.message`.
-- `useSignIn('social')` is no longer a valid keyed call. Use provider aliases such as `useSignIn('github')`.
+- Removed OAuth provider aliases such as `useSignIn('github')`. Use `useSignIn('social')` and pass the provider in `execute()`.
 
   Migration:
 
@@ -29,6 +29,12 @@ This changelog is incomplete for alpha releases. Use the GitHub Releases page fo
   const memoized = event.context.requestSession
 
   // before
+  await useSignIn('github').execute({ callbackURL: '/app' })
+
+  // after
+  await useSignIn('social').execute({ provider: 'github', callbackURL: '/app' })
+
+  // before
   const message = errorMessage.value ?? 'Please try again.'
 
   // after
@@ -37,7 +43,8 @@ This changelog is incomplete for alpha releases. Use the GitHub Releases page fo
 
 ### Added
 
-- Added typed provider aliases for `useSignIn()` based on configured `socialProviders` keys (for example, `useSignIn('github')`).
+- Added strict provider typing for `useSignIn('social').execute()` from configured `socialProviders` keys.
+- Added social `callbackURL` auto-fill when omitted: safe `?redirect=` first, then `auth.redirects.authenticated`.
 
 ### Fixed
 

--- a/docs/content/3.guides/2.oauth-providers.md
+++ b/docs/content/3.guides/2.oauth-providers.md
@@ -54,7 +54,7 @@ const { signIn } = useUserSession()
 <template>
   <button
     type="button"
-    @click="signIn.social({ provider: 'google', callbackURL: '/dashboard' })"
+    @click="signIn.social({ provider: 'google' })"
   >
     Continue with Google
   </button>
@@ -64,6 +64,7 @@ const { signIn } = useUserSession()
 ::tip
 For OAuth flows (`signIn.social`), Better Auth handles the browser redirect to the provider.
 No manual `fetchSession`/`waitForSession` step is needed before that redirect.
+`callbackURL` is optional. When your app configures `auth.redirects.authenticated` (or has a safe `?redirect=` query), the module can use that as the fallback callback URL.
 ::
 
 ::important

--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -167,13 +167,17 @@ if (status.value === 'error') {
 }
 ```
 
-For OAuth sign-in with `useSignIn`, pass a configured provider id directly:
+For OAuth sign-in, use the `social` key and pass the provider in the payload:
 
 ```ts [pages/login.vue]
-await useSignIn('github').execute({ callbackURL: '/app' })
+await useSignIn('social').execute({ provider: 'github' })
 ```
 
 Provider keys are inferred from `server/auth.config.ts` `socialProviders` keys.
+When `callbackURL` is omitted, the module auto-fills it using the same safe redirect order as other auth flows:
+- safe query redirect (`auth.redirectQueryKey`)
+- `auth.redirects.authenticated`
+- otherwise no fallback callback URL
 
 Use renaming to avoid collisions when you use multiple methods in the same scope:
 
@@ -239,6 +243,7 @@ if (status.value === 'success') {
 ::warning
 `useUserSignIn` and `useUserSignUp` were renamed to `useSignIn` and `useSignUp` in alpha.
 The API switched from map-style access (`useUserSignIn().email`) to keyed access (`useSignIn('email')`) in alpha.
+OAuth provider aliases (for example `useSignIn('github')`) were removed. Use `useSignIn('social').execute({ provider: 'github' })`.
 `error` changed from `unknown | null` to `AuthActionError | null` in alpha.
 The message alias field was removed in alpha. Use `error.value?.message`.
 `execute()` changed twice in alpha:

--- a/playground/app/pages/login.vue
+++ b/playground/app/pages/login.vue
@@ -2,7 +2,7 @@
 definePageMeta({ layout: 'auth' })
 
 const signInEmail = useSignIn('email')
-const signInGithub = useSignIn('github')
+const signInSocial = useSignIn('social')
 const signInPasskey = useSignIn('passkey')
 const { resolvePostAuthRedirect } = usePostAuthRedirect()
 
@@ -29,12 +29,7 @@ async function handleSignIn() {
 }
 
 async function handleSocialSignIn() {
-  try {
-    await signInGithub.execute({ callbackURL: resolvePostAuthRedirect('/app') })
-  }
-  catch (e: any) {
-    toast.add({ title: 'Error', description: e.message || 'GitHub sign in failed', color: 'error' })
-  }
+  await signInSocial.execute({ provider: 'github' })
 }
 
 async function handlePasskeySignIn() {
@@ -86,7 +81,7 @@ async function handlePasskeySignIn() {
       </UButton>
 
       <div class="w-full gap-2 flex items-center justify-between flex-col">
-        <UButton variant="outline" block :loading="signInGithub.status.value === 'pending'" @click="handleSocialSignIn">
+        <UButton variant="outline" block :loading="signInSocial.status.value === 'pending'" @click="handleSocialSignIn">
           <UIcon name="i-simple-icons-github" />
           <span>Sign in with GitHub</span>
         </UButton>

--- a/src/runtime/app/composables/useSignIn.ts
+++ b/src/runtime/app/composables/useSignIn.ts
@@ -10,7 +10,7 @@ type TypedSocialMethod<Method> = Method extends (data: infer Data, ...rest: infe
   ? (data: Omit<Extract<Data, Record<string, unknown>>, 'provider'> & { provider: AuthSocialProviderId }, ...rest: Rest) => Promise<Result>
   : Method
 
-type SignInWithTypedSocial = Omit<SignIn, 'social'> & (SignIn extends { social: infer SocialMethod } ? { social: TypedSocialMethod<SocialMethod> } : {})
+type SignInWithTypedSocial = Omit<SignIn, 'social'> & (SignIn extends { social: infer SocialMethod } ? { social: TypedSocialMethod<SocialMethod> } : unknown)
 
 export function useSignIn<MethodKey extends keyof SignInWithTypedSocial>(method: MethodKey): ActionHandleFor<SignInWithTypedSocial[MethodKey]> {
   if (method === undefined || method === null)

--- a/src/runtime/app/composables/useSignIn.ts
+++ b/src/runtime/app/composables/useSignIn.ts
@@ -4,48 +4,19 @@ import { useUserSession } from '#imports'
 import { createActionHandles } from '../internal/auth-action-handles'
 
 type SignIn = NonNullable<AppAuthClient>['signIn']
-type SignInMethodKey = Exclude<Extract<keyof SignIn, string>, 'social'>
-type SocialMethod = SignIn extends { social: infer T } ? T : never
-type SocialHandle = ActionHandleFor<SocialMethod>
 type AuthSocialProviderId = AuthSocialProviderRegistry extends { ids: infer T } ? Extract<T, string> : never
-type KnownProviderAliasKey = Exclude<AuthSocialProviderId, SignInMethodKey>
-type ProviderAliasKey = KnownProviderAliasKey
-type NonSocialProvider<Provider> = Provider extends 'social' ? never : Provider
-type SignInWithProviderAliases = SignIn & Record<ProviderAliasKey, SocialMethod>
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === 'object')
-}
+type TypedSocialMethod<Method> = Method extends (data: infer Data, ...rest: infer Rest) => Promise<infer Result>
+  ? (data: Omit<Extract<Data, Record<string, unknown>>, 'provider'> & { provider: AuthSocialProviderId }, ...rest: Rest) => Promise<Result>
+  : Method
 
-export function useSignIn<MethodKey extends SignInMethodKey>(method: MethodKey): ActionHandleFor<SignIn[MethodKey]>
-export function useSignIn<Provider extends ProviderAliasKey>(provider: NonSocialProvider<Provider>): SocialHandle
-export function useSignIn(method: SignInMethodKey | ProviderAliasKey): ActionHandleFor<SignIn[SignInMethodKey]> | SocialHandle {
+type SignInWithTypedSocial = Omit<SignIn, 'social'> & (SignIn extends { social: infer SocialMethod } ? { social: TypedSocialMethod<SocialMethod> } : {})
+
+export function useSignIn<MethodKey extends keyof SignInWithTypedSocial>(method: MethodKey): ActionHandleFor<SignInWithTypedSocial[MethodKey]> {
   if (method === undefined || method === null)
     throw new TypeError('useSignIn(method) requires a sign-in method key')
 
-  const handles = createActionHandles(() => {
-    const signIn = useUserSession().signIn as SignIn & Record<PropertyKey, unknown>
-    return new Proxy(signIn as SignInWithProviderAliases, {
-      get(target, prop, receiver) {
-        const method = Reflect.get(target as Record<PropertyKey, unknown>, prop, receiver)
-        // Prefer concrete method keys when they exist (e.g. "social").
-        if (typeof method === 'function')
-          return method
-        if (typeof prop !== 'string')
-          return method
+  const handles = createActionHandles(() => useUserSession().signIn as SignInWithTypedSocial, 'signIn') as ActionHandleMap<SignInWithTypedSocial>
 
-        const social = Reflect.get(target as Record<PropertyKey, unknown>, 'social')
-        if (typeof social !== 'function')
-          return method
-
-        return (...args: unknown[]) => {
-          const [data, ...rest] = args
-          const payload = isRecord(data) ? { ...data, provider: prop } : { provider: prop }
-          return (social as (...socialArgs: unknown[]) => Promise<unknown>)(payload, ...rest)
-        }
-      },
-    })
-  }, 'signIn') as ActionHandleMap<SignInWithProviderAliases>
-
-  return handles[method as keyof SignInWithProviderAliases] as ActionHandleFor<SignIn[SignInMethodKey]> | SocialHandle
+  return handles[method] as ActionHandleFor<SignInWithTypedSocial[MethodKey]>
 }

--- a/test/cases/signin-provider-alias-type-inference/server/auth.config.ts
+++ b/test/cases/signin-provider-alias-type-inference/server/auth.config.ts
@@ -1,9 +1,11 @@
 import { defineServerAuth } from '../../../../src/runtime/config'
 
+export const socialProviders = {
+  github: { clientId: 'test', clientSecret: 'test' },
+  google: { clientId: 'test', clientSecret: 'test' },
+} as const
+
 export default defineServerAuth({
   emailAndPassword: { enabled: true },
-  socialProviders: {
-    github: { clientId: 'test', clientSecret: 'test' },
-    google: { clientId: 'test', clientSecret: 'test' },
-  },
+  socialProviders,
 })

--- a/test/cases/signin-provider-alias-type-inference/typecheck-target.ts
+++ b/test/cases/signin-provider-alias-type-inference/typecheck-target.ts
@@ -1,4 +1,4 @@
-import { socialProviders } from './server/auth.config'
+import type { socialProviders } from './server/auth.config'
 
 type RawSocialProviderIds = Extract<keyof typeof socialProviders, string>
 

--- a/test/cases/signin-provider-alias-type-inference/typecheck-target.ts
+++ b/test/cases/signin-provider-alias-type-inference/typecheck-target.ts
@@ -1,29 +1,29 @@
-import createServerAuth from './server/auth.config'
+import { socialProviders } from './server/auth.config'
 
-type RawConfig = ReturnType<typeof createServerAuth>
-type RawSocialProviders = RawConfig extends { socialProviders: infer S } ? S : RawConfig extends { socialProviders?: infer S } ? S : {}
-type RawSocialProviderIds = RawSocialProviders extends Record<string, unknown> ? Extract<keyof RawSocialProviders, string> : never
+type RawSocialProviderIds = Extract<keyof typeof socialProviders, string>
 
-type MethodKey = 'email'
-type ProviderAliasKey = RawSocialProviderIds
-type NonSocialProvider<Provider> = Provider extends 'social' ? never : Provider
+interface ActionHandle<Payload> {
+  execute: (payload: Payload) => Promise<void>
+}
 
-declare function useSignIn<Method extends MethodKey>(method: Method): unknown
-declare function useSignIn<Provider extends ProviderAliasKey>(provider: NonSocialProvider<Provider>): unknown
+declare function useSignIn(method: 'email'): ActionHandle<{ email: string, password: string }>
+declare function useSignIn(method: 'social'): ActionHandle<{ provider: RawSocialProviderIds, callbackURL?: string }>
 
 useSignIn('email')
-useSignIn('github')
-useSignIn('google')
+useSignIn('social')
 
 const rawGithub: RawSocialProviderIds = 'github'
 const rawGoogle: RawSocialProviderIds = 'google'
 void rawGithub
 void rawGoogle
 
-// @ts-expect-error social must use provider aliases
-useSignIn('social')
+useSignIn('social').execute({ provider: 'github' })
+useSignIn('social').execute({ provider: 'google', callbackURL: '/app' })
+
+// @ts-expect-error provider not configured in socialProviders
+useSignIn('social').execute({ provider: 'discord' })
 
 // @ts-expect-error invalid provider typo
 useSignIn('emial')
-// @ts-expect-error provider not configured in socialProviders
-useSignIn('discord')
+// @ts-expect-error provider aliases are not valid keyed methods
+useSignIn('github')

--- a/test/use-signin-provider-alias-typing.test.ts
+++ b/test/use-signin-provider-alias-typing.test.ts
@@ -4,12 +4,12 @@ import { describe, expect, it } from 'vitest'
 
 const fixtureDir = fileURLToPath(new URL('./cases/signin-provider-alias-type-inference', import.meta.url))
 
-describe('useSignIn provider alias typing', () => {
-  it('infers provider aliases from configured socialProviders keys', () => {
+describe('useSignIn social provider typing', () => {
+  it('infers social provider ids from configured socialProviders keys', () => {
     const typecheck = spawnSync('npx', ['tsc', '--noEmit', '--pretty', 'false', '-p', 'tsconfig.type-check.json'], {
       cwd: fixtureDir,
       encoding: 'utf8',
     })
     expect(typecheck.status, `tsc failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)
-  })
+  }, 30000)
 })


### PR DESCRIPTION
## Summary
- remove provider alias keying from `useSignIn` (for example `useSignIn('github')`)
- restore a single OAuth entrypoint via `useSignIn('social')` with strict provider typing
- auto-fill missing social `callbackURL` from safe query redirect first, then `auth.redirects.authenticated`
- update playground/docs/changelog and typing/runtime tests to match the breaking API

## Tests
- `pnpm exec vitest run test/use-signin.test.ts test/use-user-session.test.ts test/use-signin-provider-alias-typing.test.ts`
- `pnpm test`

Related: #179
