### PR TITLE
fix(auth): keep pending for nested redirect responses

### DIFF
--- a/src/runtime/app/internal/auth-action-handles.ts
+++ b/src/runtime/app/internal/auth-action-handles.ts
@@ -38,6 +38,20 @@ function isRedirectResult(value: unknown): value is { redirect: true, url: strin
   return value.redirect === true && typeof value.url === 'string' && value.url.length > 0
 }
 
+function getRedirectResult(value: unknown): { redirect: true, url: string } | null {
+  if (isRedirectResult(value))
+    return value
+
+  if (!isRecord(value))
+    return null
+
+  const nested = value.data
+  if (isRedirectResult(nested))
+    return nested
+
+  return null
+}
+
 const REDIRECT_PENDING_FALLBACK_MS = 10_000
 
 function createActionHandle<TArgs extends unknown[], TResult>(
@@ -68,7 +82,8 @@ function createActionHandle<TArgs extends unknown[], TResult>(
       }
 
       if (callId === latestCallId) {
-        if (isRedirectResult(result as unknown)) {
+        const redirectResult = getRedirectResult(result as unknown)
+        if (redirectResult) {
           // Keep pending while the browser performs the external redirect.
           // If navigation does not happen, settle eventually to avoid a stuck UI.
           status.value = 'pending'

--- a/test/use-signin.test.ts
+++ b/test/use-signin.test.ts
@@ -241,6 +241,31 @@ describe('useSignIn', () => {
     vi.useRealTimers()
   })
 
+  it('keeps pending for nested redirect responses until fallback timeout', async () => {
+    vi.useFakeTimers()
+    sessionMock = {
+      signIn: {
+        social: vi.fn(async () => ({
+          data: {
+            url: 'https://github.com/login/oauth/authorize',
+            redirect: true,
+          },
+          error: null,
+        })),
+      },
+    }
+
+    const useSignIn = await loadUseSignIn()
+    const signInSocial = useSignIn('social')
+
+    await signInSocial.execute({ provider: 'github' } as any)
+    expect(signInSocial.status.value).toBe('pending')
+
+    vi.advanceTimersByTime(10_000)
+    expect(signInSocial.status.value).toBe('success')
+    vi.useRealTimers()
+  })
+
   it('keeps social and non-social handles independent', async () => {
     const socialDeferred = deferred<{ ok: true }>()
     sessionMock = {


### PR DESCRIPTION
## Summary
- fix redirect-pending detection in auth action handles to support both response shapes:
  - top-level `{ redirect: true, url }`
  - nested `{ data: { redirect: true, url }, error }`
- keep `pending` active while browser redirect is in-flight, with the existing 10s fallback
- add a regression test for the nested redirect response shape in `useSignIn`

## Root Cause
`createActionHandle()` only treated top-level redirect payloads as redirect responses. Better Auth client responses can also come nested under `data`, causing `pending` to resolve to `success` too early before navigation.

## Tests
- `pnpm -C /Users/maxi/nuxt/better-auth exec vitest run test/use-signin.test.ts`
- `pnpm -C /Users/maxi/nuxt/better-auth exec vitest run test/use-user-session.test.ts`
