### PR TITLE
feat(auth): add auth async data helpers

### DIFF
--- a/docs/content/2.core-concepts/2.sessions.md
+++ b/docs/content/2.core-concepts/2.sessions.md
@@ -45,6 +45,21 @@ When enabled, the module skips Better Auth's session refresh manager on those SS
 
 For prerendered or cached pages, the client plugin fetches the session after mount. Use `ready` or `<BetterAuthState>` to avoid flashes in those cases.
 
+## Auth Readiness vs Domain Data Readiness
+
+`ready` and `<BetterAuthState>` guarantee only that auth hydration has finished. They do not guarantee that additional auth-bound domain data (billing state, role membership, entitlements) has loaded.
+
+When rendering UI that depends on both auth and domain data, fetch that domain data SSR-first:
+
+```ts [pages/app.vue]
+const { data: customerState, pending, error } = await useAuthAsyncData(
+  'customer-state',
+  requestFetch => requestFetch<{ activeSubscriptions?: unknown[] }>('/api/auth/customer/state'),
+)
+```
+
+This prevents first-paint UI flips where unauthenticated defaults briefly appear before domain data resolves.
+
 ## Cookie vs Database Sessions
 
 Database sessions (default): stored in DB, revocable, visible in admin

--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -147,6 +147,41 @@ During SSR, `updateUser` only patches local state since no client is available.
 
 :read-more{to="/api/components" title="BetterAuthState component"}
 
+## useAuthRequestFetch
+
+Returns Nuxt's request-scoped fetch function. On SSR it preserves request context (including cookies); on client it behaves like regular fetch.
+
+```ts [pages/app.vue]
+const requestFetch = useAuthRequestFetch()
+const state = await requestFetch('/api/auth/customer/state')
+```
+
+Use this when you need low-level control and want to build your own data loader pattern.
+
+## useAuthAsyncData
+
+SSR-safe helper for auth-bound data loading.
+
+```ts [pages/app.vue]
+const { data: customerState, pending, error } = await useAuthAsyncData(
+  'customer-state',
+  requestFetch => requestFetch<{ activeSubscriptions?: unknown[] }>('/api/auth/customer/state'),
+)
+```
+
+By default:
+- `requireAuth` is `true` (unauthenticated users resolve to `null` without calling the endpoint).
+- `data` defaults to `null`.
+- errors are exposed through `error`.
+
+```ts [pages/app.vue]
+const { data } = await useAuthAsyncData(
+  'public-profile',
+  requestFetch => requestFetch('/api/profile/public'),
+  { requireAuth: false },
+)
+```
+
 ## useAction
 
 Creates a reusable async action handle with normalized error state.

--- a/src/runtime/app/composables/useAuthAsyncData.ts
+++ b/src/runtime/app/composables/useAuthAsyncData.ts
@@ -1,0 +1,28 @@
+import type { AsyncDataOptions } from '#app'
+import { useAsyncData } from '#imports'
+import { useAuthRequestFetch } from './useAuthRequestFetch'
+import { useUserSession } from './useUserSession'
+
+export interface UseAuthAsyncDataOptions<T> extends Omit<AsyncDataOptions<T | null>, 'default'> {
+  requireAuth?: boolean
+}
+
+export function useAuthAsyncData<T>(
+  key: string,
+  fetcher: (requestFetch: ReturnType<typeof useAuthRequestFetch>) => Promise<T>,
+  options: UseAuthAsyncDataOptions<T> = {},
+) {
+  const requestFetch = useAuthRequestFetch()
+  const { loggedIn } = useUserSession()
+  const { requireAuth = true, ...asyncDataOptions } = options
+
+  return useAsyncData<T | null>(key, async () => {
+    if (requireAuth && !loggedIn.value)
+      return null
+
+    return await fetcher(requestFetch)
+  }, {
+    default: () => null,
+    ...asyncDataOptions,
+  })
+}

--- a/src/runtime/app/composables/useAuthRequestFetch.ts
+++ b/src/runtime/app/composables/useAuthRequestFetch.ts
@@ -1,0 +1,5 @@
+import { useRequestFetch } from '#imports'
+
+export function useAuthRequestFetch() {
+  return useRequestFetch()
+}


### PR DESCRIPTION
## Summary
- add `useAuthRequestFetch()` composable for request-scoped auth-bound fetches
- add `useAuthAsyncData()` composable to reduce SSR boilerplate for auth-bound async data
- document auth readiness vs domain-data readiness and new composables usage

## Tests
- `pnpm lint`
- `pnpm typecheck`
