### PR TITLE
fix(auth): handle prerender hydration auth state

### DIFF
--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -85,6 +85,14 @@ export function useUserSession(): UseUserSessionReturn {
   const hydrationReconcileQueued = useState('auth:hydration-reconcile-queued', () => false)
   const ready = computed(() => authReady.value)
   const loggedIn = computed(() => Boolean(session.value && user.value))
+  const isPrerenderedPayload = computed(() => Boolean(nuxtApp.payload.prerenderedAt || nuxtApp.payload.isCached))
+  const isPrerenderHydrationEmptySnapshot = computed(() => {
+    if (!runtimeFlags.client)
+      return false
+    if (!nuxtApp.isHydrating || !nuxtApp.payload.serverRendered || !isPrerenderedPayload.value)
+      return false
+    return !session.value && !user.value
+  })
 
   const skipHydratedSsrGetSession = computed(() => {
     const authConfig = runtimeConfig.public.auth as { session?: { skipHydratedSsrGetSession?: boolean } } | undefined
@@ -98,11 +106,14 @@ export function useUserSession(): UseUserSessionReturn {
     if (!nuxtApp.payload.serverRendered)
       return false
     // Don't skip for prerendered/cached payloads; we want a real session check after mount.
-    if (nuxtApp.payload.prerenderedAt || nuxtApp.payload.isCached)
+    if (isPrerenderedPayload.value)
       return false
     // SSR already hydrated state: avoid duplicate /api/auth/get-session on first paint.
     return Boolean(session.value && user.value)
   })
+
+  if (isPrerenderHydrationEmptySnapshot.value && authReady.value)
+    authReady.value = false
 
   if (shouldSkipInitialClientSessionFetch.value && !authReady.value)
     authReady.value = true
@@ -151,6 +162,14 @@ export function useUserSession(): UseUserSessionReturn {
     watch(
       () => clientSession.value,
       (newSession) => {
+        const shouldWaitForPrerenderResolution
+          = isPrerenderHydrationEmptySnapshot.value
+            && !newSession?.data?.session
+            && !newSession?.data?.user
+
+        if (shouldWaitForPrerenderResolution)
+          return
+
         if (newSession?.data?.session && newSession?.data?.user) {
           // Filter out sensitive token field
           const { token: _, ...safeSession } = newSession.data.session as AuthSession & { token?: string }

--- a/src/runtime/app/middleware/auth.global.ts
+++ b/src/runtime/app/middleware/auth.global.ts
@@ -1,6 +1,6 @@
 import type { AuthRuntimeConfig } from '../../config'
 import type { AuthMeta, AuthMode, AuthRouteRules } from '../../types'
-import { createError, defineNuxtRouteMiddleware, getRouteRules, navigateTo, useNuxtApp, useRequestHeaders, useRuntimeConfig, useUserSession } from '#imports'
+import { createError, defineNuxtRouteMiddleware, getRouteRules, navigateTo, useRequestHeaders, useRuntimeConfig, useUserSession } from '#imports'
 import { matchesUser } from '../../utils/match-user'
 
 declare module '#app' {
@@ -16,16 +16,6 @@ declare module 'vue-router' {
 }
 
 export default defineNuxtRouteMiddleware(async (to) => {
-  const nuxtApp = useNuxtApp()
-
-  // Skip auth check during initial hydration of prerendered/cached pages
-  // The client plugin will handle session fetch after mount
-  if (import.meta.client) {
-    const isPrerendered = nuxtApp.payload.prerenderedAt || nuxtApp.payload.isCached
-    if (isPrerendered && nuxtApp.isHydrating)
-      return
-  }
-
   // Runtime fallback: resolve auth from route rules if not set at build-time
   // This handles dynamic catch-all routes where build-time can't match specific paths
   if (to.meta.auth === undefined) {

--- a/test/auth-global-middleware.test.ts
+++ b/test/auth-global-middleware.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+const payload = {
+  prerenderedAt: undefined as unknown,
+  isCached: false,
+}
+
+const nuxtApp = {
+  payload,
+  isHydrating: false,
+}
+
+const runtimeConfig = {
+  public: {
+    auth: {
+      redirects: {
+        login: '/login',
+        guest: '/app',
+      },
+      preserveRedirect: true,
+      redirectQueryKey: 'redirect',
+    },
+  },
+}
+
+const getRouteRules = vi.fn(async () => ({}))
+const navigateTo = vi.fn(async (to: unknown) => to)
+const fetchSession = vi.fn(async () => {})
+const loggedIn = ref(false)
+const user = ref<null | { id: string }>(null)
+
+vi.mock('#imports', () => ({
+  createError: (error: unknown) => error,
+  defineNuxtRouteMiddleware: (middleware: unknown) => middleware,
+  getRouteRules,
+  navigateTo,
+  useRequestHeaders: () => ({ cookie: 'session=test' }),
+  useRuntimeConfig: () => runtimeConfig,
+  useUserSession: () => ({
+    fetchSession,
+    user,
+    loggedIn,
+  }),
+}))
+
+async function loadMiddleware() {
+  vi.resetModules()
+  const mod = await import('../src/runtime/app/middleware/auth.global')
+  return mod.default
+}
+
+describe('auth.global middleware', () => {
+  beforeEach(() => {
+    payload.prerenderedAt = undefined
+    payload.isCached = false
+    nuxtApp.isHydrating = false
+    getRouteRules.mockReset()
+    navigateTo.mockReset()
+    fetchSession.mockReset()
+    loggedIn.value = false
+    user.value = null
+    runtimeConfig.public.auth.redirects.login = '/login'
+    runtimeConfig.public.auth.redirects.guest = '/app'
+  })
+
+  it('keeps public routes unaffected when no auth rule is resolved', async () => {
+    payload.prerenderedAt = Date.now()
+    nuxtApp.isHydrating = true
+    getRouteRules.mockResolvedValueOnce({})
+
+    const middleware = await loadMiddleware()
+    await middleware({
+      path: '/public',
+      fullPath: '/public',
+      meta: {},
+    })
+
+    expect(fetchSession).not.toHaveBeenCalled()
+    expect(navigateTo).not.toHaveBeenCalled()
+  })
+
+  it('redirects authenticated users from guest routes resolved via route rules', async () => {
+    payload.prerenderedAt = Date.now()
+    nuxtApp.isHydrating = true
+    loggedIn.value = true
+    getRouteRules.mockResolvedValueOnce({ auth: { only: 'guest' } })
+
+    const middleware = await loadMiddleware()
+    await middleware({
+      path: '/login',
+      fullPath: '/login',
+      meta: {},
+    })
+
+    expect(navigateTo).toHaveBeenCalledWith('/app')
+  })
+
+  it('checks protected routes and attempts redirect when unauthenticated', async () => {
+    getRouteRules.mockResolvedValueOnce({ auth: 'user' })
+
+    const middleware = await loadMiddleware()
+    await middleware({
+      path: '/app',
+      fullPath: '/app',
+      meta: {},
+    })
+
+    expect(fetchSession).toHaveBeenCalledTimes(1)
+    expect(navigateTo).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/use-user-session.test.ts
+++ b/test/use-user-session.test.ts
@@ -217,6 +217,40 @@ describe('useUserSession hydration bootstrap', () => {
     expect(mockClient.useSession).toHaveBeenCalledOnce()
   })
 
+  it('keeps ready false during prerender hydration when SSR snapshot is empty', async () => {
+    payload.serverRendered = true
+    payload.prerenderedAt = Date.now()
+    nuxtApp.isHydrating = true
+    state.set('auth:ready', ref(true))
+
+    const useUserSession = await loadUseUserSession()
+    const auth = useUserSession()
+    await flushPromises()
+
+    expect(mockClient.useSession).toHaveBeenCalledOnce()
+    expect(auth.ready.value).toBe(false)
+  })
+
+  it('marks ready after first client session resolution on prerender hydration', async () => {
+    payload.serverRendered = true
+    payload.prerenderedAt = Date.now()
+    nuxtApp.isHydrating = true
+    state.set('auth:ready', ref(true))
+    mockClient.getSession.mockResolvedValueOnce({ data: null })
+
+    const useUserSession = await loadUseUserSession()
+    const auth = useUserSession()
+    await flushPromises()
+
+    expect(auth.ready.value).toBe(false)
+
+    nuxtApp.isHydrating = false
+    await auth.fetchSession()
+
+    expect(mockClient.getSession).toHaveBeenCalledTimes(1)
+    expect(auth.ready.value).toBe(true)
+  })
+
   it('bootstraps client session on CSR navigation', async () => {
     payload.serverRendered = false
     runtimeConfig.public.auth.session.skipHydratedSsrGetSession = true


### PR DESCRIPTION
## Summary
- remove middleware hydration bypass for auth-protected routes so guest/user checks still run
- keep public routes unaffected when no auth rule is resolved
- keep \ false during prerender hydration when SSR auth snapshot is empty
- add focused regression tests for middleware route-rule auth handling and prerender readiness timing

## Tests
- \
 RUN  v4.0.15 /Users/maxi/nuxt/better-auth

 ✓ |unit| test/auth-global-middleware.test.ts (3 tests) 17ms
 ✓ |unit| test/use-user-session.test.ts (36 tests) 5049ms
     ✓ signUp does not auto-navigate to authenticated redirect when session is unresolved  5002ms

 Test Files  2 passed (2)
      Tests  39 passed (39)
   Start at  17:53:40
   Duration  5.22s (transform 103ms, setup 0ms, import 167ms, tests 5.07s, environment 0ms)
- \
> @onmax/nuxt-better-auth@0.0.2-alpha.29 lint /Users/maxi/nuxt/better-auth
> eslint .
- \
> @onmax/nuxt-better-auth@0.0.2-alpha.29 typecheck /Users/maxi/nuxt/better-auth
> vue-tsc --noEmit
