### PR TITLE
fix(auth): avoid false redirect during prerender hydration

### DIFF
--- a/src/runtime/app/middleware/auth.global.ts
+++ b/src/runtime/app/middleware/auth.global.ts
@@ -1,6 +1,6 @@
 import type { AuthRuntimeConfig } from '../../config'
 import type { AuthMeta, AuthMode, AuthRouteRules } from '../../types'
-import { createError, defineNuxtRouteMiddleware, getRouteRules, navigateTo, useRequestHeaders, useRuntimeConfig, useUserSession } from '#imports'
+import { createError, defineNuxtRouteMiddleware, getRouteRules, navigateTo, useNuxtApp, useRequestHeaders, useRuntimeConfig, useUserSession } from '#imports'
 import { matchesUser } from '../../utils/match-user'
 
 declare module '#app' {
@@ -16,6 +16,8 @@ declare module 'vue-router' {
 }
 
 export default defineNuxtRouteMiddleware(async (to) => {
+  const nuxtApp = useNuxtApp()
+
   // Runtime fallback: resolve auth from route rules if not set at build-time
   // This handles dynamic catch-all routes where build-time can't match specific paths
   if (to.meta.auth === undefined) {
@@ -35,7 +37,11 @@ export default defineNuxtRouteMiddleware(async (to) => {
   // Always fetch session if not logged in - state may not have synced yet
   if (!loggedIn.value) {
     const headers = import.meta.server ? useRequestHeaders(['cookie']) : undefined
-    await fetchSession({ headers })
+    const isHydratedPrerenderPayload
+      = (import.meta.client || !import.meta.server)
+        && nuxtApp.isHydrating
+        && Boolean(nuxtApp.payload.prerenderedAt || nuxtApp.payload.isCached)
+    await fetchSession({ headers, ...(isHydratedPrerenderPayload ? { force: true } : {}) })
   }
 
   const mode: AuthMode = typeof auth === 'string' ? auth : auth?.only ?? 'user'

--- a/test/auth-global-middleware.test.ts
+++ b/test/auth-global-middleware.test.ts
@@ -35,6 +35,7 @@ vi.mock('#imports', () => ({
   defineNuxtRouteMiddleware: (middleware: unknown) => middleware,
   getRouteRules,
   navigateTo,
+  useNuxtApp: () => nuxtApp,
   useRequestHeaders: () => ({ cookie: 'session=test' }),
   useRuntimeConfig: () => runtimeConfig,
   useUserSession: () => ({
@@ -107,6 +108,45 @@ describe('auth.global middleware', () => {
     })
 
     expect(fetchSession).toHaveBeenCalledTimes(1)
+    expect(fetchSession).toHaveBeenCalledWith({ headers: undefined })
     expect(navigateTo).toHaveBeenCalledTimes(1)
+  })
+
+  it('forces a fresh session check during prerender hydration for protected routes', async () => {
+    payload.prerenderedAt = Date.now()
+    nuxtApp.isHydrating = true
+    getRouteRules.mockResolvedValueOnce({ auth: 'user' })
+
+    const middleware = await loadMiddleware()
+    await middleware({
+      path: '/app',
+      fullPath: '/app',
+      meta: {},
+    })
+
+    expect(fetchSession).toHaveBeenCalledTimes(1)
+    expect(fetchSession).toHaveBeenCalledWith({ headers: undefined, force: true })
+    expect(navigateTo).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not redirect when prerender hydration session fetch resolves as logged in', async () => {
+    payload.prerenderedAt = Date.now()
+    nuxtApp.isHydrating = true
+    getRouteRules.mockResolvedValueOnce({ auth: 'user' })
+    fetchSession.mockImplementationOnce(async () => {
+      loggedIn.value = true
+      user.value = { id: 'user-1' }
+    })
+
+    const middleware = await loadMiddleware()
+    await middleware({
+      path: '/app',
+      fullPath: '/app',
+      meta: {},
+    })
+
+    expect(fetchSession).toHaveBeenCalledTimes(1)
+    expect(fetchSession).toHaveBeenCalledWith({ headers: undefined, force: true })
+    expect(navigateTo).not.toHaveBeenCalled()
   })
 })

--- a/test/use-user-session.test.ts
+++ b/test/use-user-session.test.ts
@@ -353,6 +353,28 @@ describe('useUserSession hydration bootstrap', () => {
     expect(auth.user.value).toEqual({ id: 'user-2', email: 'user@example.com' })
   })
 
+  it('fetchSession passes disableCookieCache query when force is enabled', async () => {
+    const useUserSession = await loadUseUserSession()
+    const auth = useUserSession()
+    await auth.fetchSession({ force: true })
+
+    expect(mockClient.getSession).toHaveBeenCalledWith(
+      { query: { disableCookieCache: true } },
+      { headers: { cookie: 'session=test' } },
+    )
+  })
+
+  it('fetchSession does not pass disableCookieCache query by default', async () => {
+    const useUserSession = await loadUseUserSession()
+    const auth = useUserSession()
+    await auth.fetchSession()
+
+    expect(mockClient.getSession).toHaveBeenCalledWith(
+      { query: undefined },
+      { headers: { cookie: 'session=test' } },
+    )
+  })
+
   it('fetchSession fetches and sets SSR session on server', async () => {
     setRuntimeFlags({ client: false, server: true })
     $fetch.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- force a fresh session read in `auth.global` before redirect decisions when navigating during prerender/cached hydration
- keep existing auth mode handling and redirect behavior unchanged outside that hydration context
- add middleware regression tests for forced fetch + no-redirect after hydration session resolution
- add `useUserSession.fetchSession` tests covering `force: true` (`disableCookieCache`) and default behavior

## Why
During prerender/cached hydration, stale client session state can briefly appear unauthenticated and trigger an incorrect login redirect on protected routes. Forcing a fresh session read in that specific hydration window prevents false redirects while preserving normal navigation behavior.

## Tests
- `pnpm vitest run test/auth-global-middleware.test.ts test/use-user-session.test.ts`
  - 2 files passed, 43 tests passed
- `pnpm lint`
- `pnpm typecheck`
