### PR TITLE
fix(auth): defer prerender ready reset after hydration

### DIFF
--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -82,6 +82,7 @@ export function useUserSession(): UseUserSessionReturn {
   const session = useState<AuthSession | null>('auth:session', () => null)
   const user = useState<AuthUser | null>('auth:user', () => null)
   const authReady = useState('auth:ready', () => false)
+  const prerenderReadyResetQueued = useState('auth:prerender-ready-reset-queued', () => false)
   const hydrationReconcileQueued = useState('auth:hydration-reconcile-queued', () => false)
   const ready = computed(() => authReady.value)
   const loggedIn = computed(() => Boolean(session.value && user.value))
@@ -112,8 +113,18 @@ export function useUserSession(): UseUserSessionReturn {
     return Boolean(session.value && user.value)
   })
 
-  if (isPrerenderHydrationEmptySnapshot.value && authReady.value)
-    authReady.value = false
+  if (isPrerenderHydrationEmptySnapshot.value && authReady.value && !prerenderReadyResetQueued.value) {
+    prerenderReadyResetQueued.value = true
+    nuxtApp.hook('app:suspense:resolve', () => {
+      try {
+        if (!session.value && !user.value && authReady.value)
+          authReady.value = false
+      }
+      finally {
+        prerenderReadyResetQueued.value = false
+      }
+    })
+  }
 
   if (shouldSkipInitialClientSessionFetch.value && !authReady.value)
     authReady.value = true

--- a/test/use-user-session.test.ts
+++ b/test/use-user-session.test.ts
@@ -217,7 +217,7 @@ describe('useUserSession hydration bootstrap', () => {
     expect(mockClient.useSession).toHaveBeenCalledOnce()
   })
 
-  it('keeps ready false during prerender hydration when SSR snapshot is empty', async () => {
+  it('defers ready reset until suspense resolves during prerender hydration empty snapshot', async () => {
     payload.serverRendered = true
     payload.prerenderedAt = Date.now()
     nuxtApp.isHydrating = true
@@ -228,6 +228,12 @@ describe('useUserSession hydration bootstrap', () => {
     await flushPromises()
 
     expect(mockClient.useSession).toHaveBeenCalledOnce()
+    expect((nuxtHooks.get('app:suspense:resolve') || [])).toHaveLength(1)
+    expect(auth.ready.value).toBe(true)
+
+    await triggerNuxtHook('app:suspense:resolve')
+    await flushPromises()
+
     expect(auth.ready.value).toBe(false)
   })
 
@@ -242,6 +248,9 @@ describe('useUserSession hydration bootstrap', () => {
     const auth = useUserSession()
     await flushPromises()
 
+    await triggerNuxtHook('app:suspense:resolve')
+    await flushPromises()
+
     expect(auth.ready.value).toBe(false)
 
     nuxtApp.isHydrating = false
@@ -249,6 +258,20 @@ describe('useUserSession hydration bootstrap', () => {
 
     expect(mockClient.getSession).toHaveBeenCalledTimes(1)
     expect(auth.ready.value).toBe(true)
+  })
+
+  it('queues prerender ready reset once across composable calls', async () => {
+    payload.serverRendered = true
+    payload.prerenderedAt = Date.now()
+    nuxtApp.isHydrating = true
+    state.set('auth:ready', ref(true))
+
+    const useUserSession = await loadUseUserSession()
+    useUserSession()
+    useUserSession()
+    await flushPromises()
+
+    expect((nuxtHooks.get('app:suspense:resolve') || [])).toHaveLength(1)
   })
 
   it('bootstraps client session on CSR navigation', async () => {


### PR DESCRIPTION
## Summary
- defer prerender empty-snapshot `authReady` reset from synchronous hydration time to `app:suspense:resolve`
- guard reset hook registration with a dedicated `useState` flag to avoid duplicate queueing across multiple composable calls
- keep existing skip/bootstrap and `fetchSession` behavior unchanged
- add regression tests for deferred reset timing and one-shot queueing

## Why
On prerendered/cached pages, synchronously flipping `ready` from `true` to `false` during hydration can mismatch SSR output and leave orphaned DOM, causing duplicated `<BetterAuthState>` slot content after hydration.

Deferring the reset until suspense resolution keeps the initial client render aligned with SSR while preserving the pending phase before client session reconciliation finishes.

## Tests
- `pnpm vitest run test/use-user-session.test.ts test/auth-global-middleware.test.ts`
- `pnpm lint`
- `pnpm typecheck`

Closes #190
