### PR TITLE
feat(types): autocomplete auth usefetch paths

### DIFF
--- a/docs/content/2.core-concepts/2.sessions.md
+++ b/docs/content/2.core-concepts/2.sessions.md
@@ -52,6 +52,13 @@ For prerendered or cached pages, the client plugin fetches the session after mou
 When rendering UI that depends on both auth and domain data, fetch that domain data SSR-first:
 
 ```ts [pages/app.vue]
+const { data: customerState } = await useFetch('/api/auth/customer/state')
+const { data: customerById } = await useFetch('/api/auth/customer/123/state')
+```
+
+Endpoint payloads are inferred from your Better Auth config (core + plugins), including dynamic auth paths.
+
+```ts [pages/app.vue]
 const { data: customerState, pending, error } = await useAuthAsyncData(
   'customer-state',
   requestFetch => requestFetch('/api/auth/customer/state'),

--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -151,6 +151,18 @@ During SSR, `updateUser` only patches local state since no client is available.
 
 Returns Nuxt's request-scoped fetch function. On SSR it preserves request context (including cookies); on client it behaves like regular fetch.
 
+When endpoint typing is enabled, `useFetch('/api/auth/...')` and `useLazyFetch('/api/auth/...')` infer payloads directly from your Better Auth config:
+
+```ts [pages/app.vue]
+const { data: customerState } = await useFetch('/api/auth/customer/state')
+customerState.value?.activeSubscriptions[0]?.toUpperCase()
+
+const { data: customerById } = await useLazyFetch('/api/auth/customer/123/state')
+customerById.value?.customerId.toUpperCase()
+```
+
+Global `$fetch` keeps Nitro `InternalApi` response inference, but path autocomplete is best on `useFetch`/`useLazyFetch` and `useAuthRequestFetch`.
+
 ```ts [pages/app.vue]
 const requestFetch = useAuthRequestFetch()
 const state = await requestFetch('/api/auth/customer/state')

--- a/src/module/type-templates.ts
+++ b/src/module/type-templates.ts
@@ -135,6 +135,7 @@ import type createServerAuth from '${serverConfigPath}'
 import type { BetterAuthOptions } from 'better-auth'
 import type { getEndpoints } from 'better-auth/api'
 import type { Serialize, Simplify } from 'nitropack/types'
+import type { FetchError } from 'ofetch'
 
 type _RawConfig = ReturnType<typeof createServerAuth>
 type _RawPlugins = _RawConfig extends { plugins: infer P } ? P : _RawConfig extends { plugins?: infer P } ? P : []
@@ -183,14 +184,124 @@ type _PluginEndpointMaps<Plugins> = Plugins extends readonly (infer Plugin)[]
 type _PluginAuthInternalApi = _UnionToIntersection<_PluginEndpointMaps<_RawPlugins>>
 type _GeneratedAuthInternalApi = _CoreAuthInternalApi & _PluginAuthInternalApi
 
+type _RoutePathToRequestPath<Path extends string> = Path extends \`\${infer Prefix}:\${string}/\${infer Rest}\`
+  ? \`\${Prefix}\${string}/\${_RoutePathToRequestPath<Rest>}\`
+  : Path extends \`\${infer Prefix}:\${string}\`
+      ? \`\${Prefix}\${string}\`
+      : Path
+type _AuthApiPatternPath = Extract<keyof _GeneratedAuthInternalApi, string>
+type _AuthApiRequestPath = _RoutePathToRequestPath<_AuthApiPatternPath>
+type _AuthPatternFromRequestPath<Path extends string> = {
+  [Pattern in _AuthApiPatternPath]: Path extends _RoutePathToRequestPath<Pattern> ? Pattern : never
+}[_AuthApiPatternPath]
+type _AuthEndpointMethod<Path extends _AuthApiRequestPath> = Extract<keyof _GeneratedAuthInternalApi[_AuthPatternFromRequestPath<Path>], string>
+
+type _AuthFetchExplicitMethod<Path extends _AuthApiRequestPath> = Exclude<_AuthEndpointMethod<Path>, 'default'>
+type _AuthFetchMethod<Path extends _AuthApiRequestPath> = _AuthFetchExplicitMethod<Path> extends never
+  ? 'get'
+  : _AuthFetchExplicitMethod<Path> | Uppercase<_AuthFetchExplicitMethod<Path>>
+type _AuthFetchDefaultMethod<Path extends _AuthApiRequestPath> = 'get' extends _AuthFetchMethod<Path>
+  ? 'get'
+  : _AuthFetchMethod<Path>
+type _AuthFetchResolvedMethod<Path extends _AuthApiRequestPath, Method extends string> = Lowercase<Method> extends _AuthEndpointMethod<Path>
+  ? Lowercase<Method>
+  : 'default'
+type _AuthExtractedRouteMethod<Options> = Options extends undefined
+  ? 'get'
+  : Lowercase<Exclude<Options extends { method?: infer M } ? M : never, undefined>> extends infer Method extends string
+      ? Method
+      : 'get'
+type _AuthFetchResult<Path extends _AuthApiRequestPath, Method extends string> = _GeneratedAuthInternalApi[_AuthPatternFromRequestPath<Path>][_AuthFetchResolvedMethod<Path, Method>]
+
 declare module '#nuxt-better-auth' {
   export type AuthApiInternalRoutes = _GeneratedAuthInternalApi
-  export type AuthApiEndpointPath = Extract<keyof AuthApiInternalRoutes, string>
-  export type AuthApiEndpointMethod<Path extends AuthApiEndpointPath> = Extract<keyof AuthApiInternalRoutes[Path], string>
+  export type AuthApiEndpointPatternPath = _AuthApiPatternPath
+  export type AuthApiEndpointPath = _AuthApiRequestPath
+  export type AuthApiEndpointMethod<Path extends AuthApiEndpointPath> = _AuthEndpointMethod<Path>
   export type AuthApiEndpointResponse<
     Path extends AuthApiEndpointPath,
     Method extends AuthApiEndpointMethod<Path> = AuthApiEndpointMethod<Path>,
-  > = AuthApiInternalRoutes[Path][Method]
+  > = AuthApiInternalRoutes[_AuthPatternFromRequestPath<Path>][Method]
+}
+
+declare module 'nuxt/dist/app/composables/fetch' {
+  export function useFetch<
+    ErrorT = FetchError,
+    Path extends import('#nuxt-better-auth').AuthApiEndpointPath = import('#nuxt-better-auth').AuthApiEndpointPath,
+    Method extends _AuthFetchMethod<Path> = _AuthFetchDefaultMethod<Path>,
+    _ResT = _AuthFetchResult<Path, Method>,
+    DataT = _ResT,
+    PickKeys extends import('nuxt/dist/app/composables/asyncData').KeysOf<DataT> = import('nuxt/dist/app/composables/asyncData').KeysOf<DataT>,
+    DefaultT = undefined,
+  >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: import('nuxt/dist/app/composables/fetch').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>): import('nuxt/dist/app/composables/asyncData').AsyncData<import('nuxt/dist/app/composables/asyncData').PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
+  export function useFetch<
+    ErrorT = FetchError,
+    Path extends import('#nuxt-better-auth').AuthApiEndpointPath = import('#nuxt-better-auth').AuthApiEndpointPath,
+    Method extends _AuthFetchMethod<Path> = _AuthFetchDefaultMethod<Path>,
+    _ResT = _AuthFetchResult<Path, Method>,
+    DataT = _ResT,
+    PickKeys extends import('nuxt/dist/app/composables/asyncData').KeysOf<DataT> = import('nuxt/dist/app/composables/asyncData').KeysOf<DataT>,
+    DefaultT = DataT,
+  >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: import('nuxt/dist/app/composables/fetch').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>): import('nuxt/dist/app/composables/asyncData').AsyncData<import('nuxt/dist/app/composables/asyncData').PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
+
+  export function useLazyFetch<
+    ErrorT = FetchError,
+    Path extends import('#nuxt-better-auth').AuthApiEndpointPath = import('#nuxt-better-auth').AuthApiEndpointPath,
+    Method extends _AuthFetchMethod<Path> = _AuthFetchDefaultMethod<Path>,
+    _ResT = _AuthFetchResult<Path, Method>,
+    DataT = _ResT,
+    PickKeys extends import('nuxt/dist/app/composables/asyncData').KeysOf<DataT> = import('nuxt/dist/app/composables/asyncData').KeysOf<DataT>,
+    DefaultT = undefined,
+  >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: Omit<import('nuxt/dist/app/composables/fetch').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>, 'lazy'>): import('nuxt/dist/app/composables/asyncData').AsyncData<import('nuxt/dist/app/composables/asyncData').PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
+  export function useLazyFetch<
+    ErrorT = FetchError,
+    Path extends import('#nuxt-better-auth').AuthApiEndpointPath = import('#nuxt-better-auth').AuthApiEndpointPath,
+    Method extends _AuthFetchMethod<Path> = _AuthFetchDefaultMethod<Path>,
+    _ResT = _AuthFetchResult<Path, Method>,
+    DataT = _ResT,
+    PickKeys extends import('nuxt/dist/app/composables/asyncData').KeysOf<DataT> = import('nuxt/dist/app/composables/asyncData').KeysOf<DataT>,
+    DefaultT = DataT,
+  >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: Omit<import('nuxt/dist/app/composables/fetch').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>, 'lazy'>): import('nuxt/dist/app/composables/asyncData').AsyncData<import('nuxt/dist/app/composables/asyncData').PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
+}
+
+declare module 'nuxt/app' {
+  export function useFetch<
+    ErrorT = FetchError,
+    Path extends import('#nuxt-better-auth').AuthApiEndpointPath = import('#nuxt-better-auth').AuthApiEndpointPath,
+    Method extends _AuthFetchMethod<Path> = _AuthFetchDefaultMethod<Path>,
+    _ResT = _AuthFetchResult<Path, Method>,
+    DataT = _ResT,
+    PickKeys extends import('nuxt/dist/app/composables/asyncData').KeysOf<DataT> = import('nuxt/dist/app/composables/asyncData').KeysOf<DataT>,
+    DefaultT = undefined,
+  >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: import('nuxt/dist/app/composables/fetch').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>): import('nuxt/dist/app/composables/asyncData').AsyncData<import('nuxt/dist/app/composables/asyncData').PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
+  export function useFetch<
+    ErrorT = FetchError,
+    Path extends import('#nuxt-better-auth').AuthApiEndpointPath = import('#nuxt-better-auth').AuthApiEndpointPath,
+    Method extends _AuthFetchMethod<Path> = _AuthFetchDefaultMethod<Path>,
+    _ResT = _AuthFetchResult<Path, Method>,
+    DataT = _ResT,
+    PickKeys extends import('nuxt/dist/app/composables/asyncData').KeysOf<DataT> = import('nuxt/dist/app/composables/asyncData').KeysOf<DataT>,
+    DefaultT = DataT,
+  >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: import('nuxt/dist/app/composables/fetch').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>): import('nuxt/dist/app/composables/asyncData').AsyncData<import('nuxt/dist/app/composables/asyncData').PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
+
+  export function useLazyFetch<
+    ErrorT = FetchError,
+    Path extends import('#nuxt-better-auth').AuthApiEndpointPath = import('#nuxt-better-auth').AuthApiEndpointPath,
+    Method extends _AuthFetchMethod<Path> = _AuthFetchDefaultMethod<Path>,
+    _ResT = _AuthFetchResult<Path, Method>,
+    DataT = _ResT,
+    PickKeys extends import('nuxt/dist/app/composables/asyncData').KeysOf<DataT> = import('nuxt/dist/app/composables/asyncData').KeysOf<DataT>,
+    DefaultT = undefined,
+  >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: Omit<import('nuxt/dist/app/composables/fetch').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>, 'lazy'>): import('nuxt/dist/app/composables/asyncData').AsyncData<import('nuxt/dist/app/composables/asyncData').PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
+  export function useLazyFetch<
+    ErrorT = FetchError,
+    Path extends import('#nuxt-better-auth').AuthApiEndpointPath = import('#nuxt-better-auth').AuthApiEndpointPath,
+    Method extends _AuthFetchMethod<Path> = _AuthFetchDefaultMethod<Path>,
+    _ResT = _AuthFetchResult<Path, Method>,
+    DataT = _ResT,
+    PickKeys extends import('nuxt/dist/app/composables/asyncData').KeysOf<DataT> = import('nuxt/dist/app/composables/asyncData').KeysOf<DataT>,
+    DefaultT = DataT,
+  >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: Omit<import('nuxt/dist/app/composables/fetch').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>, 'lazy'>): import('nuxt/dist/app/composables/asyncData').AsyncData<import('nuxt/dist/app/composables/asyncData').PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
 }
 
 declare module 'nitropack' {

--- a/src/runtime/app/composables/useAuthRequestFetch.ts
+++ b/src/runtime/app/composables/useAuthRequestFetch.ts
@@ -1,5 +1,29 @@
+import type { AuthApiEndpointMethod, AuthApiEndpointPath, AuthApiEndpointResponse } from '#nuxt-better-auth'
+import type { NitroFetchOptions } from 'nitropack/types'
 import { useRequestFetch } from '#imports'
 
+type AuthRequestFetchExtractedMethod<Options> = Options extends undefined
+  ? 'get'
+  : Lowercase<Extract<Exclude<Options extends { method?: infer Method } ? Method : never, undefined>, string>> extends infer NormalizedMethod extends string
+    ? NormalizedMethod
+    : 'get'
+
+type AuthRequestFetchMethodFromOptions<Path extends AuthApiEndpointPath, Options> = NitroFetchOptions<Path> extends Options
+  ? 'get'
+  : AuthRequestFetchExtractedMethod<Options>
+
+type AuthRequestFetchResolvedMethod<Path extends AuthApiEndpointPath, Options> = Extract<AuthRequestFetchMethodFromOptions<Path, Options>, AuthApiEndpointMethod<Path>> extends infer Method extends string
+  ? Method extends never ? 'default' : Method
+  : 'default'
+
+type AuthRequestFetch = <
+  Path extends AuthApiEndpointPath,
+  Options extends NitroFetchOptions<Path> = NitroFetchOptions<Path>,
+>(
+  request: Path,
+  opts?: Options,
+) => Promise<AuthApiEndpointResponse<Path, Extract<AuthRequestFetchResolvedMethod<Path, Options>, AuthApiEndpointMethod<Path>>>>
+
 export function useAuthRequestFetch() {
-  return useRequestFetch()
+  return useRequestFetch() as AuthRequestFetch & ReturnType<typeof useRequestFetch>
 }

--- a/test/cases/use-fetch-endpoints-type-inference/.nuxtrc
+++ b/test/cases/use-fetch-endpoints-type-inference/.nuxtrc
@@ -1,0 +1,1 @@
+setups.@onmax/nuxt-better-auth="0.0.2-alpha.29"

--- a/test/cases/use-fetch-endpoints-type-inference/auth.config.ts
+++ b/test/cases/use-fetch-endpoints-type-inference/auth.config.ts
@@ -1,0 +1,3 @@
+import { defineClientAuth } from '@onmax/nuxt-better-auth/config'
+
+export default defineClientAuth({})

--- a/test/cases/use-fetch-endpoints-type-inference/imports-shim.d.ts
+++ b/test/cases/use-fetch-endpoints-type-inference/imports-shim.d.ts
@@ -1,0 +1,3 @@
+declare module '#imports' {
+  export function useRequestFetch(): import('nitropack/types').H3Event$Fetch | typeof global.$fetch
+}

--- a/test/cases/use-fetch-endpoints-type-inference/nuxt.config.ts
+++ b/test/cases/use-fetch-endpoints-type-inference/nuxt.config.ts
@@ -1,0 +1,13 @@
+import { fileURLToPath } from 'node:url'
+
+const serverConfig = fileURLToPath(new URL('./server/auth.config', import.meta.url))
+
+export default defineNuxtConfig({
+  extends: ['../_base-module'],
+  runtimeConfig: {
+    public: { siteUrl: 'http://localhost:3000' },
+  },
+  auth: {
+    serverConfig,
+  },
+})

--- a/test/cases/use-fetch-endpoints-type-inference/server/auth.config.ts
+++ b/test/cases/use-fetch-endpoints-type-inference/server/auth.config.ts
@@ -1,0 +1,32 @@
+import { createAuthEndpoint } from 'better-auth/api'
+import { defineServerAuth } from '../../../../src/runtime/config'
+
+function customerPlugin() {
+  return {
+    id: 'customer-plugin',
+    endpoints: {
+      customerState: createAuthEndpoint('/customer/state', { method: 'GET' }, async () => {
+        return {
+          activeSubscriptions: ['starter', 'pro'],
+          hasBillingIssue: false,
+        }
+      }),
+      customerStateById: createAuthEndpoint('/customer/:id/state', { method: 'GET' }, async () => {
+        return {
+          customerId: 'customer-123',
+          status: 'active' as const,
+        }
+      }),
+      customerSession: createAuthEndpoint('/customer/session', { method: ['GET', 'POST'] as const }, async () => {
+        return {
+          ok: true,
+        }
+      }),
+    },
+  } as const
+}
+
+export default defineServerAuth({
+  emailAndPassword: { enabled: true },
+  plugins: [customerPlugin()] as const,
+})

--- a/test/cases/use-fetch-endpoints-type-inference/tsconfig.json
+++ b/test/cases/use-fetch-endpoints-type-inference/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/test/cases/use-fetch-endpoints-type-inference/tsconfig.type-check.json
+++ b/test/cases/use-fetch-endpoints-type-inference/tsconfig.type-check.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
+    "baseUrl": ".",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "paths": {
+      "#auth/client": ["../_base-module/app/auth.config"],
+      "#auth/server": ["./server/auth.config"],
+      "#nuxt-better-auth": ["../../../src/runtime/types/augment"],
+      "#imports": ["./imports-shim"]
+    },
+    "types": [],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "files": [
+    "./imports-shim.d.ts",
+    "./.nuxt/types/nuxt-better-auth-infer.d.ts",
+    "./.nuxt/types/nuxt-better-auth-nitro.d.ts",
+    "./typecheck-target.ts"
+  ]
+}

--- a/test/cases/use-fetch-endpoints-type-inference/typecheck-target.ts
+++ b/test/cases/use-fetch-endpoints-type-inference/typecheck-target.ts
@@ -1,0 +1,45 @@
+import type { AuthApiEndpointPath, AuthApiEndpointPatternPath, AuthApiEndpointResponse } from '#nuxt-better-auth'
+import { useFetch, useLazyFetch } from 'nuxt/app'
+import { useAuthRequestFetch } from '../../../src/runtime/app/composables/useAuthRequestFetch'
+
+type DynamicPath = Extract<AuthApiEndpointPath, `/api/auth/customer/${string}/state`>
+const dynamicPath: DynamicPath = '/api/auth/customer/123/state'
+
+type DynamicPattern = Extract<AuthApiEndpointPatternPath, '/api/auth/customer/:id/state'>
+const dynamicPattern: DynamicPattern = '/api/auth/customer/:id/state'
+
+type DynamicResponse = AuthApiEndpointResponse<`/api/auth/customer/${string}/state`, 'get'>
+type CustomerStateResponse = AuthApiEndpointResponse<'/api/auth/customer/state', 'get'>
+declare const customerStateResponse: CustomerStateResponse
+
+async function assertUseFetchPathInference() {
+  const customerStateResult = await useFetch('/api/auth/customer/state')
+  customerStateResult.data.value?.activeSubscriptions[0]?.toUpperCase()
+  customerStateResult.data.value?.hasBillingIssue.valueOf()
+
+  const lazyCustomerState = await useLazyFetch('/api/auth/customer/state')
+  lazyCustomerState.data.value?.activeSubscriptions[0]?.toUpperCase()
+
+  const dynamicStateResult = await useFetch('/api/auth/customer/123/state')
+  dynamicStateResult.data.value?.customerId.toUpperCase()
+  dynamicStateResult.data.value?.status.toUpperCase()
+
+  const customerSessionPost = await useFetch('/api/auth/customer/session', { method: 'POST' })
+  customerSessionPost.data.value?.ok.valueOf()
+
+  const requestFetch = useAuthRequestFetch()
+  const dynamicViaRequestFetch = await requestFetch('/api/auth/customer/123/state')
+  dynamicViaRequestFetch.customerId.toUpperCase()
+
+  const typedDynamic: DynamicResponse = dynamicViaRequestFetch
+  void typedDynamic
+
+  const unknownAuthEndpoint = await useFetch('/api/auth/unknown-custom-endpoint')
+  void unknownAuthEndpoint
+}
+
+void dynamicPath
+void dynamicPattern
+// @ts-expect-error no unknown key on inferred endpoint response
+void customerStateResponse.missingField
+void assertUseFetchPathInference

--- a/test/infer-use-fetch-endpoints-types.test.ts
+++ b/test/infer-use-fetch-endpoints-types.test.ts
@@ -1,0 +1,27 @@
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const fixtureDir = fileURLToPath(new URL('./cases/use-fetch-endpoints-type-inference', import.meta.url))
+const env = {
+  ...process.env,
+  BETTER_AUTH_SECRET: 'test-secret-for-testing-only-32chars',
+}
+
+describe('typed useFetch auth endpoint inference', () => {
+  it('typechecks useFetch/useLazyFetch/useAuthRequestFetch endpoint path inference for /api/auth routes', () => {
+    const prepare = spawnSync('npx', ['nuxi', 'prepare'], {
+      cwd: fixtureDir,
+      env,
+      encoding: 'utf8',
+    })
+    expect(prepare.status, `nuxi prepare failed:\n${prepare.stdout}\n${prepare.stderr}`).toBe(0)
+
+    const typecheck = spawnSync('npx', ['tsc', '--noEmit', '--pretty', 'false', '-p', 'tsconfig.type-check.json'], {
+      cwd: fixtureDir,
+      env,
+      encoding: 'utf8',
+    })
+    expect(typecheck.status, `tsc failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)
+  }, 60_000)
+})


### PR DESCRIPTION
## Summary
- add generated request-path helpers for auth endpoints, including dynamic path support (`:id` -> `${string}`)
- augment `useFetch` and `useLazyFetch` typing for `/api/auth/...` path autocomplete and payload inference
- type `useAuthRequestFetch` with auth endpoint inference while keeping fallback behavior
- add a dedicated type regression fixture and harness for fetch path inference
- update docs to show inferred auth fetch usage first, including dynamic path examples

## Tests
- `pnpm lint`
- `pnpm vitest run test/infer-use-fetch-endpoints-types.test.ts test/infer-nitro-endpoints-types.test.ts test/infer-plugins-types.test.ts`

## Related
- #194
