### PR TITLE
fix(types): enforce auth endpoint methods

### DIFF
--- a/docs/app/components/content/landing/features.yml
+++ b/docs/app/components/content/landing/features.yml
@@ -14,7 +14,7 @@ items:
     description: Auth tables generated automatically from your plugins. Zero manual migrations.
     icon: i-lucide-wand
   - title: SSR-Safe Sessions
-    description: useUserSession composable works seamlessly on server and client with automatic hydration.
+    description: useUserSession keeps session state consistent from SSR hydration through client updates.
     icon: i-lucide-shield-check
   - title: Declarative Route Protection
     description: 'Protect routes with routeRules. Define auth requirements once, enforce everywhere.'

--- a/docs/content/2.core-concepts/2.sessions.md
+++ b/docs/content/2.core-concepts/2.sessions.md
@@ -21,7 +21,19 @@ const {
 During server-side rendering (SSR), the module fetches the session using incoming request cookies and populates state before rendering. A client plugin then keeps the state in sync after hydration.
 
 - **Server render:** `user` and `session` are set when a valid session cookie exists, and `ready` is `true`.
+- **Server runtime client access:** `useUserSession().client` is `null` during SSR.
 - **After hydration:** State stays in sync with client-side updates.
+
+Use a split model:
+- In pages and components, use `useUserSession()` state and SSR-safe fetch helpers (`useAuthRequestFetch`, `useAuthAsyncData`).
+- In server handlers and routes, use server utilities (`serverAuth`, `getUserSession`, `requireUserSession`).
+
+```ts [server/api/profile.get.ts]
+export default defineEventHandler(async (event) => {
+  const { user } = await requireUserSession(event)
+  return { id: user.id, email: user.email }
+})
+```
 
 ### Optional: Skip Hydrated SSR Session Fetch
 

--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -25,8 +25,17 @@ const { loggedIn, user, session, client, signIn, signOut } = useUserSession()
     `true` when initial session resolution is complete (from SSR hydration or client fetch).
   ::
   ::field{name="client" type="AuthClient | null"}
-    Direct access to the Better Auth client instance.
+    Direct access to the Better Auth client instance. Available on client runtime; `null` during SSR/server runtime.
   ::
+::
+
+::note
+`useUserSession().client` is browser-only. During SSR/server runtime it is `null`.
+
+For SSR-safe auth access:
+- Use `user`, `session`, `loggedIn`, `ready`, and `fetchSession` from `useUserSession()`.
+- Use `useAuthRequestFetch()` or `useAuthAsyncData()` for auth-bound data in pages.
+- Use server helpers like `serverAuth(event)`, `getUserSession(event)`, or `requireUserSession(event)` in `server/` handlers.
 ::
 
 ### Methods
@@ -151,6 +160,8 @@ During SSR, `updateUser` only patches local state since no client is available.
 
 Returns Nuxt's request-scoped fetch function. On SSR it preserves request context (including cookies); on client it behaves like regular fetch.
 
+`useAuthRequestFetch()` defaults to `GET`. For endpoints that only allow `POST` (or another method), pass `method` explicitly to preserve response type inference.
+
 When endpoint typing is enabled, `useFetch('/api/auth/...')` and `useLazyFetch('/api/auth/...')` infer payloads directly from your Better Auth config:
 
 ```ts [pages/app.vue]
@@ -166,6 +177,7 @@ Global `$fetch` keeps Nitro `InternalApi` response inference, but path autocompl
 ```ts [pages/app.vue]
 const requestFetch = useAuthRequestFetch()
 const state = await requestFetch('/api/auth/customer/state')
+const postOnly = await requestFetch('/api/auth/customer/post-only', { method: 'POST' })
 ```
 
 Use this when you need low-level control and want to build your own data loader pattern.

--- a/docs/content/6.troubleshooting/1.faq.md
+++ b/docs/content/6.troubleshooting/1.faq.md
@@ -49,8 +49,31 @@ export default defineNuxtConfig({
 Only routes with `routeRules.auth` are enforced automatically for `/api/**`.
 Use `routeRules.auth` or call `requireUserSession(event)` inside handlers.
 
+### `useUserSession().client` is `null` on server
+
+This is expected. The Better Auth client from `useUserSession().client` is browser-only.
+
+For SSR and server-side code:
+- Use `useUserSession()` reactive state (`user`, `session`, `loggedIn`, `ready`) and `fetchSession()` in pages/components.
+- Use `useAuthRequestFetch()` or `useAuthAsyncData()` for SSR-friendly auth-bound data loading.
+- Use `serverAuth(event)`, `getUserSession(event)`, or `requireUserSession(event)` in `server/` routes and handlers.
+
+### `useAuthRequestFetch` does not infer a response for my endpoint
+
+`useAuthRequestFetch()` defaults to `GET` when no `method` is provided.
+
+If your endpoint only supports another method (for example `POST`), pass it explicitly:
+
+```ts [pages/app.vue]
+const requestFetch = useAuthRequestFetch()
+const result = await requestFetch('/api/auth/customer/post-only', { method: 'POST' })
+```
+
 ## Related docs
 
 - [Configuration](/getting-started/configuration)
+- [Composables API](/api/composables)
+- [Sessions](/core-concepts/sessions)
+- [Server Utilities](/api/server-utils)
 - [Route Protection](/core-concepts/route-protection)
 - [NuxtHub Integration](/integrations/nuxthub)

--- a/src/module/type-templates.ts
+++ b/src/module/type-templates.ts
@@ -157,18 +157,19 @@ type _RoutePathFromEndpoint<E> = E extends { path: infer P extends string }
       : \`/api/auth\${P}\`
   : never
 type _RouteResponseFromEndpoint<E> = E extends (...args: any[]) => Promise<infer R> ? Simplify<Serialize<Awaited<R>>> : never
+type _RouteDefaultResponse<E> = never
 type _UnionToIntersection<U> = (U extends unknown ? (value: U) => void : never) extends (value: infer I) => void ? I : never
 
 type _CoreAuthInternalApi = {
   [K in keyof _AuthApi as _RoutePathFromEndpoint<_AuthApi[K]>]: {
-    [M in _RouteMethodFromEndpoint<_AuthApi[K]> | 'default']: _RouteResponseFromEndpoint<_AuthApi[K]>
+    [M in _RouteMethodFromEndpoint<_AuthApi[K]> | 'default']: M extends 'default' ? _RouteDefaultResponse<_AuthApi[K]> : _RouteResponseFromEndpoint<_AuthApi[K]>
   }
 }
 type _PluginEndpointMaps<Plugins> = Plugins extends readonly (infer Plugin)[]
   ? Plugin extends { endpoints: infer Endpoints extends Record<string, unknown> }
       ? {
           [K in keyof Endpoints as _RoutePathFromEndpoint<Endpoints[K]>]: {
-            [M in _RouteMethodFromEndpoint<Endpoints[K]> | 'default']: _RouteResponseFromEndpoint<Endpoints[K]>
+            [M in _RouteMethodFromEndpoint<Endpoints[K]> | 'default']: M extends 'default' ? _RouteDefaultResponse<Endpoints[K]> : _RouteResponseFromEndpoint<Endpoints[K]>
           }
         }
       : {}
@@ -176,7 +177,7 @@ type _PluginEndpointMaps<Plugins> = Plugins extends readonly (infer Plugin)[]
       ? Plugin extends { endpoints: infer Endpoints extends Record<string, unknown> }
           ? {
               [K in keyof Endpoints as _RoutePathFromEndpoint<Endpoints[K]>]: {
-                [M in _RouteMethodFromEndpoint<Endpoints[K]> | 'default']: _RouteResponseFromEndpoint<Endpoints[K]>
+                [M in _RouteMethodFromEndpoint<Endpoints[K]> | 'default']: M extends 'default' ? _RouteDefaultResponse<Endpoints[K]> : _RouteResponseFromEndpoint<Endpoints[K]>
               }
             }
           : {}
@@ -196,21 +197,11 @@ type _AuthPatternFromRequestPath<Path extends string> = {
 }[_AuthApiPatternPath]
 type _AuthEndpointMethod<Path extends _AuthApiRequestPath> = Extract<keyof _GeneratedAuthInternalApi[_AuthPatternFromRequestPath<Path>], string>
 
-type _AuthFetchExplicitMethod<Path extends _AuthApiRequestPath> = Exclude<_AuthEndpointMethod<Path>, 'default'>
-type _AuthFetchMethod<Path extends _AuthApiRequestPath> = _AuthFetchExplicitMethod<Path> extends never
-  ? 'get'
-  : _AuthFetchExplicitMethod<Path> | Uppercase<_AuthFetchExplicitMethod<Path>>
-type _AuthFetchDefaultMethod<Path extends _AuthApiRequestPath> = 'get' extends _AuthFetchMethod<Path>
-  ? 'get'
-  : _AuthFetchMethod<Path>
+type _AuthFetchMethod<Path extends _AuthApiRequestPath> = Extract<Exclude<import('nitropack/types').NitroFetchOptions<Path>['method'], undefined>, string>
+type _AuthFetchDefaultMethod<Path extends _AuthApiRequestPath> = 'get'
 type _AuthFetchResolvedMethod<Path extends _AuthApiRequestPath, Method extends string> = Lowercase<Method> extends _AuthEndpointMethod<Path>
   ? Lowercase<Method>
-  : 'default'
-type _AuthExtractedRouteMethod<Options> = Options extends undefined
-  ? 'get'
-  : Lowercase<Exclude<Options extends { method?: infer M } ? M : never, undefined>> extends infer Method extends string
-      ? Method
-      : 'get'
+  : never
 type _AuthFetchResult<Path extends _AuthApiRequestPath, Method extends string> = _GeneratedAuthInternalApi[_AuthPatternFromRequestPath<Path>][_AuthFetchResolvedMethod<Path, Method>]
 
 declare module '#nuxt-better-auth' {

--- a/src/runtime/app/composables/useAuthRequestFetch.ts
+++ b/src/runtime/app/composables/useAuthRequestFetch.ts
@@ -13,8 +13,8 @@ type AuthRequestFetchMethodFromOptions<Path extends AuthApiEndpointPath, Options
   : AuthRequestFetchExtractedMethod<Options>
 
 type AuthRequestFetchResolvedMethod<Path extends AuthApiEndpointPath, Options> = Extract<AuthRequestFetchMethodFromOptions<Path, Options>, AuthApiEndpointMethod<Path>> extends infer Method extends string
-  ? Method extends never ? 'default' : Method
-  : 'default'
+  ? Method
+  : never
 
 type AuthRequestFetch = <
   Path extends AuthApiEndpointPath,

--- a/test/cases/use-fetch-endpoints-type-inference/server/auth.config.ts
+++ b/test/cases/use-fetch-endpoints-type-inference/server/auth.config.ts
@@ -22,6 +22,11 @@ function customerPlugin() {
           ok: true,
         }
       }),
+      customerPostOnly: createAuthEndpoint('/customer/post-only', { method: 'POST' }, async () => {
+        return {
+          created: true,
+        }
+      }),
     },
   } as const
 }

--- a/test/cases/use-fetch-endpoints-type-inference/typecheck-target.ts
+++ b/test/cases/use-fetch-endpoints-type-inference/typecheck-target.ts
@@ -11,9 +11,9 @@ const dynamicPattern: DynamicPattern = '/api/auth/customer/:id/state'
 type DynamicResponse = AuthApiEndpointResponse<`/api/auth/customer/${string}/state`, 'get'>
 type CustomerStateResponse = AuthApiEndpointResponse<'/api/auth/customer/state', 'get'>
 // @ts-expect-error GET should not be valid for POST-only endpoint helper responses
-type PostOnlyGetResponse = AuthApiEndpointResponse<'/api/auth/customer/post-only', 'get'>
+type _PostOnlyGetResponse = AuthApiEndpointResponse<'/api/auth/customer/post-only', 'get'>
 // @ts-expect-error POST should not be valid for GET-only endpoint helper responses
-type CustomerStatePostResponse = AuthApiEndpointResponse<'/api/auth/customer/state', 'post'>
+type _CustomerStatePostResponse = AuthApiEndpointResponse<'/api/auth/customer/state', 'post'>
 type CustomerStateMethods = AuthApiEndpointMethod<'/api/auth/customer/state'>
 type PostOnlyMethods = AuthApiEndpointMethod<'/api/auth/customer/post-only'>
 declare const customerStateResponse: CustomerStateResponse

--- a/test/cases/use-fetch-endpoints-type-inference/typecheck-target.ts
+++ b/test/cases/use-fetch-endpoints-type-inference/typecheck-target.ts
@@ -1,4 +1,4 @@
-import type { AuthApiEndpointPath, AuthApiEndpointPatternPath, AuthApiEndpointResponse } from '#nuxt-better-auth'
+import type { AuthApiEndpointMethod, AuthApiEndpointPath, AuthApiEndpointPatternPath, AuthApiEndpointResponse } from '#nuxt-better-auth'
 import { useFetch, useLazyFetch } from 'nuxt/app'
 import { useAuthRequestFetch } from '../../../src/runtime/app/composables/useAuthRequestFetch'
 
@@ -10,7 +10,19 @@ const dynamicPattern: DynamicPattern = '/api/auth/customer/:id/state'
 
 type DynamicResponse = AuthApiEndpointResponse<`/api/auth/customer/${string}/state`, 'get'>
 type CustomerStateResponse = AuthApiEndpointResponse<'/api/auth/customer/state', 'get'>
+// @ts-expect-error GET should not be valid for POST-only endpoint helper responses
+type PostOnlyGetResponse = AuthApiEndpointResponse<'/api/auth/customer/post-only', 'get'>
+// @ts-expect-error POST should not be valid for GET-only endpoint helper responses
+type CustomerStatePostResponse = AuthApiEndpointResponse<'/api/auth/customer/state', 'post'>
+type CustomerStateMethods = AuthApiEndpointMethod<'/api/auth/customer/state'>
+type PostOnlyMethods = AuthApiEndpointMethod<'/api/auth/customer/post-only'>
 declare const customerStateResponse: CustomerStateResponse
+const validMethodForState: CustomerStateMethods = 'get'
+const validMethodForPostOnly: PostOnlyMethods = 'post'
+// @ts-expect-error POST should not be valid for GET-only endpoint
+const invalidMethodForState: CustomerStateMethods = 'post'
+// @ts-expect-error GET should not be valid for POST-only endpoint
+const invalidMethodForPostOnly: PostOnlyMethods = 'get'
 
 async function assertUseFetchPathInference() {
   const customerStateResult = await useFetch('/api/auth/customer/state')
@@ -27,9 +39,29 @@ async function assertUseFetchPathInference() {
   const customerSessionPost = await useFetch('/api/auth/customer/session', { method: 'POST' })
   customerSessionPost.data.value?.ok.valueOf()
 
+  const postOnlyDefault = await useFetch('/api/auth/customer/post-only')
+  void postOnlyDefault
+
+  const postOnlyExplicit = await useFetch('/api/auth/customer/post-only', { method: 'POST' })
+  postOnlyExplicit.data.value?.created.valueOf()
+
+  const customerStatePost = await useFetch('/api/auth/customer/state', { method: 'POST' })
+  void customerStatePost
+
   const requestFetch = useAuthRequestFetch()
   const dynamicViaRequestFetch = await requestFetch('/api/auth/customer/123/state')
   dynamicViaRequestFetch.customerId.toUpperCase()
+
+  const postOnlyViaRequestDefault = await requestFetch('/api/auth/customer/post-only')
+  // @ts-expect-error request fetch defaults to GET without explicit method
+  postOnlyViaRequestDefault.created.valueOf()
+
+  const postOnlyViaRequest = await requestFetch('/api/auth/customer/post-only', { method: 'POST' })
+  postOnlyViaRequest.created.valueOf()
+
+  const dynamicWrongMethod = await requestFetch('/api/auth/customer/123/state', { method: 'POST' })
+  // @ts-expect-error unsupported method must not infer endpoint payload
+  dynamicWrongMethod.customerId.toUpperCase()
 
   const typedDynamic: DynamicResponse = dynamicViaRequestFetch
   void typedDynamic
@@ -40,6 +72,10 @@ async function assertUseFetchPathInference() {
 
 void dynamicPath
 void dynamicPattern
+void validMethodForState
+void validMethodForPostOnly
+void invalidMethodForState
+void invalidMethodForPostOnly
 // @ts-expect-error no unknown key on inferred endpoint response
 void customerStateResponse.missingField
 void assertUseFetchPathInference

--- a/test/use-user-session.test.ts
+++ b/test/use-user-session.test.ts
@@ -429,6 +429,15 @@ describe('useUserSession hydration bootstrap', () => {
     expect(auth.ready.value).toBe(true)
   })
 
+  it('exposes client as null on server runtime', async () => {
+    setRuntimeFlags({ client: false, server: true })
+
+    const useUserSession = await loadUseUserSession()
+    const auth = useUserSession()
+
+    expect(auth.client).toBeNull()
+  })
+
   it('signIn uses auth.redirects.authenticated when no callback is provided', async () => {
     runtimeConfig.public.auth.redirects = { authenticated: '/app' }
     mockClient.getSession.mockResolvedValueOnce({
@@ -778,5 +787,14 @@ describe('useUserSession hydration bootstrap', () => {
     await auth.signOut()
 
     expect(navigateTo).not.toHaveBeenCalled()
+  })
+
+  it('signOut throws on server runtime', async () => {
+    setRuntimeFlags({ client: false, server: true })
+
+    const useUserSession = await loadUseUserSession()
+    const auth = useUserSession()
+
+    await expect(auth.signOut()).rejects.toThrow('signOut can only be called on client-side')
   })
 })


### PR DESCRIPTION
## Summary
- remove fallback method inference for auth endpoint response typing
- enforce explicit methods for non-GET auth endpoints in `useAuthRequestFetch` typings
- add type tests for method validity and post-only endpoint behavior
- update docs and faq for SSR-safe `useUserSession().client` usage and request method guidance

## Tests
- `pnpm vitest run test/use-user-session.test.ts`
- `pnpm vitest run test/infer-use-fetch-endpoints-types.test.ts`
