### PR TITLE
fix: resolve auth configs across nuxt layers

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,3 +1,4 @@
+import type { Nuxt } from '@nuxt/schema'
 import type { NuxtHubOptions } from './module/hub'
 import type { BetterAuthModuleOptions, ModuleDatabaseProviderId } from './runtime/config'
 import type {
@@ -8,11 +9,12 @@ import type {
 } from './types/hooks'
 import { existsSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
-import { addTemplate, createResolver, defineNuxtModule, hasNuxtModule } from '@nuxt/kit'
+import { addTemplate, createResolver, defineNuxtModule, getLayerDirectories, hasNuxtModule } from '@nuxt/kit'
 import { consola as _consola } from 'consola'
-import { dirname, join } from 'pathe'
+import { dirname, join, relative } from 'pathe'
 import { version } from '../package.json'
 import { resolveDatabaseProvider } from './database-provider'
+import { resolveModuleConfigPath } from './module/config-paths'
 import { registerAuthMiddlewareHook, registerDevtools, registerRouteRulesMetaHook, registerServerRuntime, registerTemplateHmrHook } from './module/hooks'
 import { getHubCasing, getHubDialect } from './module/hub'
 import { setupRuntimeConfig } from './module/runtime'
@@ -25,19 +27,15 @@ import './types/hooks'
 
 const consola = _consola.withTag('nuxt-better-auth')
 
-function resolveDefaultClientConfig(options: BetterAuthModuleOptions, rootDir: string, srcDir: string): void {
-  if (options.clientConfig !== 'app/auth.config')
-    return
-
-  const srcDirRelative = srcDir.replace(`${rootDir}/`, '')
-  options.clientConfig = srcDirRelative === srcDir
-    ? 'auth.config'
-    : `${srcDirRelative}/auth.config`
-}
-
-async function createDefaultAuthConfigFiles(rootDir: string, srcDir: string): Promise<void> {
-  const serverPath = join(rootDir, 'server/auth.config.ts')
-  const clientPath = join(srcDir, 'auth.config.ts')
+async function createDefaultAuthConfigFiles(nuxt: Nuxt): Promise<void> {
+  const project = getLayerDirectories(nuxt)[0]!
+  const rootDir = project.root
+  const serverPath = join(project.server, 'auth.config.ts')
+  const clientPath = join(project.app, 'auth.config.ts')
+  const resolvedServerConfig = resolveModuleConfigPath(nuxt, 'server', 'server/auth.config')
+  const resolvedClientConfig = resolveModuleConfigPath(nuxt, 'client', 'app/auth.config')
+  const hasServerConfig = existsSync(`${resolvedServerConfig.path}.ts`) || existsSync(`${resolvedServerConfig.path}.js`)
+  const hasClientConfig = existsSync(`${resolvedClientConfig.path}.ts`) || existsSync(`${resolvedClientConfig.path}.js`)
 
   const serverTemplate = `import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 
@@ -51,17 +49,16 @@ export default defineServerAuth({
 export default defineClientAuth({})
 `
 
-  if (!existsSync(serverPath)) {
+  if (!hasServerConfig) {
     await mkdir(dirname(serverPath), { recursive: true })
     await writeFile(serverPath, serverTemplate)
-    consola.success('Created server/auth.config.ts')
+    consola.success(`Created ${relative(rootDir, serverPath)}`)
   }
 
-  if (!existsSync(clientPath)) {
+  if (!hasClientConfig) {
     await mkdir(dirname(clientPath), { recursive: true })
     await writeFile(clientPath, clientTemplate)
-    const relativePath = clientPath.replace(`${rootDir}/`, '')
-    consola.success(`Created ${relativePath}`)
+    consola.success(`Created ${relative(rootDir, clientPath)}`)
   }
 }
 
@@ -84,25 +81,24 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
     if (generatedSecret)
       process.env.BETTER_AUTH_SECRET = generatedSecret
 
-    await createDefaultAuthConfigFiles(nuxt.options.rootDir, nuxt.options.srcDir)
+    await createDefaultAuthConfigFiles(nuxt)
   },
   async setup(options, nuxt) {
     const resolver = createResolver(import.meta.url)
 
-    resolveDefaultClientConfig(options, nuxt.options.rootDir, nuxt.options.srcDir)
     const clientOnly = options.clientOnly!
     const serverConfigFile = options.serverConfig!
     const clientConfigFile = options.clientConfig!
-    const serverConfigPath = resolver.resolve(nuxt.options.rootDir, serverConfigFile)
-    const clientConfigPath = resolver.resolve(nuxt.options.rootDir, clientConfigFile)
+    const { file: resolvedServerConfigFile, path: serverConfigPath } = resolveModuleConfigPath(nuxt, 'server', serverConfigFile)
+    const { file: resolvedClientConfigFile, path: clientConfigPath } = resolveModuleConfigPath(nuxt, 'client', clientConfigFile)
 
     const serverConfigExists = existsSync(`${serverConfigPath}.ts`) || existsSync(`${serverConfigPath}.js`)
     const clientConfigExists = existsSync(`${clientConfigPath}.ts`) || existsSync(`${clientConfigPath}.js`)
 
     if (!clientOnly && !serverConfigExists)
-      throw new Error(`[nuxt-better-auth] Missing ${serverConfigFile}.ts - export default defineServerAuth(...)`)
+      throw new Error(`[nuxt-better-auth] Missing ${resolvedServerConfigFile}.ts - export default defineServerAuth(...)`)
     if (!clientConfigExists)
-      throw new Error(`[nuxt-better-auth] Missing ${clientConfigFile}.ts - export default defineClientAuth(...)`)
+      throw new Error(`[nuxt-better-auth] Missing ${resolvedClientConfigFile}.ts - export default defineClientAuth(...)`)
 
     const hasNuxtHub = hasNuxtModule('@nuxthub/core', nuxt)
     const hub = hasNuxtHub ? (nuxt.options as { hub?: NuxtHubOptions }).hub : undefined

--- a/src/module/config-paths.ts
+++ b/src/module/config-paths.ts
@@ -1,0 +1,71 @@
+import type { Nuxt } from '@nuxt/schema'
+import { existsSync } from 'node:fs'
+import { getLayerDirectories } from '@nuxt/kit'
+import { isAbsolute, join, relative } from 'pathe'
+
+export type ModuleConfigKind = 'server' | 'client'
+
+export interface ResolvedModuleConfigPath {
+  file: string
+  path: string
+}
+
+const DEFAULT_CONFIG_FILES = {
+  server: 'server/auth.config',
+  client: 'app/auth.config',
+} satisfies Record<ModuleConfigKind, string>
+
+const CONFIG_EXTENSIONS = ['.ts', '.js']
+
+function stripConfigExtension(path: string): string {
+  return path.replace(/\.(?:ts|js)$/, '')
+}
+
+function configExists(path: string): boolean {
+  return CONFIG_EXTENSIONS.some(ext => existsSync(`${path}${ext}`))
+}
+
+function getProjectRoot(nuxt: Nuxt): string {
+  return getLayerDirectories(nuxt)[0]!.root
+}
+
+function getDefaultConfigPath(nuxt: Nuxt, kind: ModuleConfigKind): string {
+  const project = getLayerDirectories(nuxt)[0]!
+  return kind === 'server'
+    ? join(project.server, 'auth.config')
+    : join(project.app, 'auth.config')
+}
+
+function getLayerDefaultConfigPath(nuxt: Nuxt, kind: ModuleConfigKind): string | undefined {
+  for (const layer of getLayerDirectories(nuxt)) {
+    const candidate = kind === 'server'
+      ? join(layer.server, 'auth.config')
+      : join(layer.app, 'auth.config')
+
+    if (configExists(candidate))
+      return candidate
+  }
+}
+
+function getRelativeConfigFile(nuxt: Nuxt, path: string): string {
+  return relative(getProjectRoot(nuxt), path)
+}
+
+export function resolveModuleConfigPath(nuxt: Nuxt, kind: ModuleConfigKind, file: string): ResolvedModuleConfigPath {
+  if (isAbsolute(file)) {
+    const path = stripConfigExtension(file)
+    return { file, path }
+  }
+
+  const defaultFile = DEFAULT_CONFIG_FILES[kind]
+  if (file === defaultFile) {
+    const discoveredPath = getLayerDefaultConfigPath(nuxt, kind) ?? getDefaultConfigPath(nuxt, kind)
+    return {
+      file: getRelativeConfigFile(nuxt, discoveredPath),
+      path: discoveredPath,
+    }
+  }
+
+  const path = stripConfigExtension(join(getProjectRoot(nuxt), file))
+  return { file, path }
+}

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -104,6 +104,6 @@ export function defineClientAuth<T extends ClientAuthConfig>(config: T | ((ctx: 
   return (baseURL: string) => {
     const ctx: ClientAuthContext = { siteUrl: baseURL }
     const resolved = typeof config === 'function' ? config(ctx) : config
-    return createAuthClient({ ...resolved, baseURL })
+    return createAuthClient({ baseURL, ...resolved })
   }
 }

--- a/test/cases/_base-module/nuxt.config.ts
+++ b/test/cases/_base-module/nuxt.config.ts
@@ -11,7 +11,7 @@ export default defineNuxtConfig({
   },
 
   auth: {
-    // Absolute paths are required because the module validates existence relative to rootDir.
+    // Keep this fixture explicit so override behavior stays covered alongside default layer discovery.
     serverConfig,
     clientConfig,
   },

--- a/test/cases/layer-default-configs/nuxt.config.ts
+++ b/test/cases/layer-default-configs/nuxt.config.ts
@@ -1,0 +1,3 @@
+export default defineNuxtConfig({
+  extends: ['../core-auth'],
+})

--- a/test/client-auth-config.test.ts
+++ b/test/client-auth-config.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { createAuthClient } = vi.hoisted(() => ({
+  createAuthClient: vi.fn((options: unknown) => options),
+}))
+
+vi.mock('better-auth/vue', () => ({
+  createAuthClient,
+}))
+
+const { defineClientAuth } = await import('../src/runtime/config')
+
+describe('defineClientAuth', () => {
+  beforeEach(() => {
+    createAuthClient.mockClear()
+  })
+
+  it('passes the inferred siteUrl to function syntax', () => {
+    let capturedUrl = ''
+    const factory = defineClientAuth((ctx) => {
+      capturedUrl = ctx.siteUrl
+      return {}
+    })
+
+    factory('http://test.local')
+
+    expect(capturedUrl).toBe('http://test.local')
+  })
+
+  it('keeps the resolved baseURL authoritative', () => {
+    const factory = defineClientAuth({
+      baseURL: 'https://explicit.example/api/auth',
+      plugins: [],
+    })
+
+    const client = factory('https://derived.example/api/auth')
+
+    expect(createAuthClient).toHaveBeenCalledOnce()
+    expect(createAuthClient).toHaveBeenCalledWith(expect.objectContaining({
+      baseURL: 'https://explicit.example/api/auth',
+    }))
+    expect(client).toMatchObject({
+      baseURL: 'https://explicit.example/api/auth',
+    })
+  })
+})

--- a/test/layer-default-configs.test.ts
+++ b/test/layer-default-configs.test.ts
@@ -1,0 +1,29 @@
+import { fileURLToPath } from 'node:url'
+import { $fetch, setup, url } from '@nuxt/test-utils/e2e'
+import { describe, expect, it } from 'vitest'
+
+describe('layer-aware default auth config discovery', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('./cases/layer-default-configs', import.meta.url)),
+  })
+
+  it('renders the extended layer app without explicit auth config overrides', async () => {
+    const html = await $fetch('/')
+    expect(html).toContain('Home')
+    expect(html).toContain('Not logged in')
+  })
+
+  it('uses auth routes backed by the extended layer default configs', async () => {
+    const response = await fetch(url('/api/auth/sign-up/email'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: `layer-${Date.now()}@example.com`,
+        password: 'testpass123',
+        name: 'Layer User',
+      }),
+    })
+
+    expect(response.status).toBe(200)
+  })
+})


### PR DESCRIPTION
## Summary
- resolve default auth config paths across Nuxt layers instead of assuming root-only lookup
- keep explicit config paths authoritative
- preserve defineClientAuth merge order so resolved config can override the inferred base URL
- avoid scaffolding project auth configs when an extended layer already provides them
- add regression tests for layer-default discovery and client auth config merging

## Validation
- pnpm exec vitest run test/client-auth-config.test.ts test/layer-default-configs.test.ts test/schema-generator.test.ts
- pnpm typecheck
- pnpm exec eslint src/module.ts src/module/config-paths.ts src/runtime/config.ts test/client-auth-config.test.ts test/layer-default-configs.test.ts test/cases/_base-module/nuxt.config.ts
