### PR TITLE
fix(playground): prevent auth hydration and logout regressions

### DIFF
--- a/playground/app/components/AppSecurityCard.vue
+++ b/playground/app/components/AppSecurityCard.vue
@@ -1,0 +1,194 @@
+<script setup lang="ts">
+import type { Ref } from 'vue'
+
+type AsyncFn = (...args: unknown[]) => Promise<unknown>
+interface PasskeyRecord { id: string, name?: string | null }
+
+const { user, client } = useUserSession()
+const { t } = useI18n()
+const toast = useToast()
+
+const authClient = client as typeof client & {
+  twoFactor: { enable: AsyncFn, disable: AsyncFn, verifyTotp: AsyncFn }
+  passkey: { addPasskey: AsyncFn, deletePasskey: AsyncFn }
+  useListPasskeys: () => Ref<{ data?: PasskeyRecord[] } | undefined>
+}
+
+const twoFaOpen = ref(false)
+const twoFaPassword = ref('')
+const twoFaUri = ref('')
+const twoFaCode = ref('')
+const twoFaLoading = ref(false)
+
+const passkeysRef = authClient?.useListPasskeys()
+const passkeys = computed(() => passkeysRef?.value?.data || [])
+const passkeyOpen = ref(false)
+const passkeyName = ref('')
+const passkeyLoading = ref(false)
+
+async function enable2FA() {
+  twoFaLoading.value = true
+  try {
+    if (twoFaUri.value) {
+      const res = await authClient?.twoFactor.verifyTotp({ code: twoFaCode.value })
+      if (res?.data) {
+        toast.add({ title: t('app.twoFactorEnabledSuccess'), color: 'success' })
+        twoFaOpen.value = false
+        twoFaUri.value = ''
+        twoFaCode.value = ''
+      }
+      else {
+        toast.add({ title: t('app.invalidCode'), color: 'error' })
+      }
+    }
+    else {
+      const res = await authClient?.twoFactor.enable({ password: twoFaPassword.value })
+      if (res?.data?.totpURI) {
+        twoFaUri.value = res.data.totpURI
+      }
+      else {
+        toast.add({ title: 'Error', description: 'Failed to enable 2FA', color: 'error' })
+      }
+    }
+  }
+  catch (e: any) {
+    toast.add({ title: 'Error', description: e.message, color: 'error' })
+  }
+  twoFaLoading.value = false
+}
+
+async function disable2FA() {
+  twoFaLoading.value = true
+  try {
+    await authClient?.twoFactor.disable({ password: twoFaPassword.value })
+    toast.add({ title: t('app.twoFactorDisabledSuccess'), color: 'success' })
+    twoFaOpen.value = false
+    twoFaPassword.value = ''
+  }
+  catch (e: any) {
+    toast.add({ title: 'Error', description: e.message, color: 'error' })
+  }
+  twoFaLoading.value = false
+}
+
+async function addPasskey() {
+  passkeyLoading.value = true
+  try {
+    await authClient?.passkey.addPasskey({ name: passkeyName.value || 'My Passkey' })
+    toast.add({ title: t('app.passkeyAdded'), color: 'success' })
+    passkeyOpen.value = false
+    passkeyName.value = ''
+  }
+  catch (e: any) {
+    toast.add({ title: 'Error', description: e.message, color: 'error' })
+  }
+  passkeyLoading.value = false
+}
+
+async function deletePasskey(id: string) {
+  await authClient?.passkey.deletePasskey({ id })
+  toast.add({ title: t('app.passkeyDeleted'), color: 'success' })
+}
+</script>
+
+<template>
+  <UCard>
+    <template #header>
+      <h2 class="text-lg font-semibold">
+        {{ t('app.security') }}
+      </h2>
+    </template>
+
+    <div class="space-y-4">
+      <div class="flex justify-between items-center">
+        <div>
+          <p class="font-medium">
+            {{ t('app.twoFactor') }}
+          </p>
+          <p class="text-sm text-muted-foreground">
+            {{ user?.twoFactorEnabled ? t('app.twoFactorEnabled') : t('app.twoFactorDisabled') }}
+          </p>
+        </div>
+        <UButton :color="user?.twoFactorEnabled ? 'error' : 'primary'" variant="soft" @click="twoFaOpen = true">
+          {{ user?.twoFactorEnabled ? t('app.disable2fa') : t('app.enable2fa') }}
+        </UButton>
+      </div>
+
+      <UDivider />
+
+      <div class="flex justify-between items-center">
+        <div>
+          <p class="font-medium">
+            {{ t('app.passkeys') }}
+          </p>
+          <p class="text-sm text-muted-foreground">
+            {{ passkeys.length }} {{ t('app.registered') }}
+          </p>
+        </div>
+        <UButton variant="soft" @click="passkeyOpen = true">
+          {{ t('app.addPasskey') }}
+        </UButton>
+      </div>
+
+      <div v-if="passkeys.length" class="space-y-2">
+        <div v-for="pk in passkeys" :key="pk.id" class="flex justify-between items-center p-2 bg-muted rounded">
+          <div class="flex items-center gap-2">
+            <UIcon name="i-lucide-key-round" />
+            <span class="text-sm">{{ pk.name || 'Passkey' }}</span>
+          </div>
+          <UButton size="xs" color="error" variant="ghost" @click="deletePasskey(pk.id)">
+            <UIcon name="i-lucide-trash-2" />
+          </UButton>
+        </div>
+      </div>
+    </div>
+  </UCard>
+
+  <UModal v-model:open="twoFaOpen">
+    <template #header>
+      {{ user?.twoFactorEnabled ? t('app.disable2fa') : t('app.enable2fa') }}
+    </template>
+    <template #body>
+      <div class="space-y-4 p-4">
+        <template v-if="twoFaUri">
+          <div class="flex justify-center">
+            <QRCode :value="twoFaUri" :size="200" />
+          </div>
+          <p class="text-sm text-center text-muted-foreground">
+            {{ t('app.scanQr') }}
+          </p>
+          <UFormField :label="t('app.verificationCode')">
+            <UInput v-model="twoFaCode" inputmode="numeric" maxlength="6" :placeholder="t('app.enterCode')" />
+          </UFormField>
+          <UButton block :loading="twoFaLoading" @click="enable2FA">
+            {{ t('app.verifyEnable') }}
+          </UButton>
+        </template>
+        <template v-else>
+          <UFormField :label="t('common.password')">
+            <UInput v-model="twoFaPassword" type="password" :placeholder="t('common.password')" />
+          </UFormField>
+          <UButton block :loading="twoFaLoading" @click="user?.twoFactorEnabled ? disable2FA() : enable2FA()">
+            {{ user?.twoFactorEnabled ? t('app.disable2fa') : t('app.continue') }}
+          </UButton>
+        </template>
+      </div>
+    </template>
+  </UModal>
+
+  <UModal v-model:open="passkeyOpen">
+    <template #header>
+      {{ t('app.addPasskey') }}
+    </template>
+    <template #body>
+      <div class="space-y-4 p-4">
+        <UFormField :label="t('app.passkeyName')">
+          <UInput v-model="passkeyName" placeholder="My Passkey" />
+        </UFormField>
+        <UButton block :loading="passkeyLoading" @click="addPasskey">
+          {{ t('app.createPasskey') }}
+        </UButton>
+      </div>
+    </template>
+  </UModal>
+</template>

--- a/playground/app/composables/usePlaygroundSignOut.ts
+++ b/playground/app/composables/usePlaygroundSignOut.ts
@@ -1,0 +1,27 @@
+export function usePlaygroundSignOut() {
+  const signOutPending = useState('playground:sign-out-pending', () => false)
+  const { signOut } = useUserSession()
+
+  async function executeSignOut() {
+    if (signOutPending.value)
+      return
+
+    signOutPending.value = true
+
+    try {
+      await signOut({
+        onSuccess: async () => {
+          await navigateTo('/login')
+        },
+      })
+    }
+    finally {
+      signOutPending.value = false
+    }
+  }
+
+  return {
+    signOutPending,
+    signOut: executeSignOut,
+  }
+}

--- a/playground/app/layouts/default.vue
+++ b/playground/app/layouts/default.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-const { user, loggedIn, ready, signOut } = useUserSession()
+const { user, loggedIn, ready } = useUserSession()
 const { locale, locales, setLocale } = useI18n()
 const { t } = useI18n()
+const { signOutPending, signOut } = usePlaygroundSignOut()
 
 const availableLocales = computed(() =>
   (locales.value as Array<{ code: string, name: string }>).map(l => ({ label: l.name, value: l.code })),
@@ -50,6 +51,7 @@ const availableLocales = computed(() =>
                 <span class="text-sm text-muted-foreground">{{ user?.name || user?.email }}</span>
                 <button
                   class="inline-flex items-center justify-center whitespace-nowrap text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 px-3"
+                  :disabled="signOutPending"
                   @click="signOut()"
                 >
                   {{ t('common.signOut') }}

--- a/playground/app/pages/app/index.vue
+++ b/playground/app/pages/app/index.vue
@@ -1,17 +1,17 @@
 <script setup lang="ts">
-const { user, session, client, signOut } = useUserSession()
-const { t } = useI18n()
+const { user, session, client, loggedIn } = useUserSession()
+const { t, locale } = useI18n()
 const toast = useToast()
 const emailWarning = useEmailWarning()
+const { signOutPending, signOut: handleSignOut } = usePlaygroundSignOut()
 
-type AsyncFn = (...args: unknown[]) => Promise<unknown>
 const authClient = client as typeof client & {
-  twoFactor: { enable: AsyncFn, disable: AsyncFn, verifyTotp: AsyncFn }
-  passkey: { addPasskey: AsyncFn, deletePasskey: AsyncFn }
   getLastUsedLoginMethod: () => string | null
 }
 
 const lastLoginMethod = ref<string | null>(null)
+const isAuthUiActive = computed(() => loggedIn.value && Boolean(client) && !signOutPending.value)
+const sessionsRequestId = ref(0)
 
 // Profile editing
 const editOpen = ref(false)
@@ -53,19 +53,35 @@ async function resendVerification() {
 
 // Sessions
 const sessions = ref<any[]>([])
-const sessionsLoading = ref(true)
+const sessionsLoading = ref(false)
 
 async function loadSessions() {
+  if (!isAuthUiActive.value) {
+    sessions.value = []
+    sessionsLoading.value = false
+    return
+  }
+
+  const requestId = ++sessionsRequestId.value
   sessionsLoading.value = true
   try {
     const res = await client?.listSessions()
-    sessions.value = res?.data || []
+    if (requestId === sessionsRequestId.value && isAuthUiActive.value)
+      sessions.value = res?.data || []
   }
-  catch { sessions.value = [] }
-  sessionsLoading.value = false
+  catch {
+    if (requestId === sessionsRequestId.value)
+      sessions.value = []
+  }
+  finally {
+    if (requestId === sessionsRequestId.value)
+      sessionsLoading.value = false
+  }
 }
 
 async function terminateSession(token: string) {
+  if (!isAuthUiActive.value)
+    return
   await client?.revokeSession({ token })
   sessions.value = sessions.value.filter(s => s.token !== token)
   toast.add({ title: t('app.sessionTerminated'), color: 'success' })
@@ -76,85 +92,6 @@ const sessionColumns = computed(() => [
   { id: 'createdAt', header: t('app.created'), accessorKey: 'createdAt' },
   { id: 'actions', header: '', accessorKey: 'actions' },
 ])
-
-// Two-Factor
-const twoFaOpen = ref(false)
-const twoFaPassword = ref('')
-const twoFaUri = ref('')
-const twoFaCode = ref('')
-const twoFaLoading = ref(false)
-
-async function enable2FA() {
-  twoFaLoading.value = true
-  try {
-    if (twoFaUri.value) {
-      // Verify step
-      const res = await authClient?.twoFactor.verifyTotp({ code: twoFaCode.value })
-      if (res?.data) {
-        toast.add({ title: t('app.twoFactorEnabledSuccess'), color: 'success' })
-        twoFaOpen.value = false
-        twoFaUri.value = ''
-        twoFaCode.value = ''
-      }
-      else {
-        toast.add({ title: t('app.invalidCode'), color: 'error' })
-      }
-    }
-    else {
-      // Enable step
-      const res = await authClient?.twoFactor.enable({ password: twoFaPassword.value })
-      if (res?.data?.totpURI) {
-        twoFaUri.value = res.data.totpURI
-      }
-      else {
-        toast.add({ title: 'Error', description: 'Failed to enable 2FA', color: 'error' })
-      }
-    }
-  }
-  catch (e: any) {
-    toast.add({ title: 'Error', description: e.message, color: 'error' })
-  }
-  twoFaLoading.value = false
-}
-
-async function disable2FA() {
-  twoFaLoading.value = true
-  try {
-    await authClient?.twoFactor.disable({ password: twoFaPassword.value })
-    toast.add({ title: t('app.twoFactorDisabledSuccess'), color: 'success' })
-    twoFaOpen.value = false
-    twoFaPassword.value = ''
-  }
-  catch (e: any) {
-    toast.add({ title: 'Error', description: e.message, color: 'error' })
-  }
-  twoFaLoading.value = false
-}
-
-const passkeysRef = client?.useListPasskeys()
-const passkeys = computed(() => passkeysRef?.value?.data || [])
-const passkeyOpen = ref(false)
-const passkeyName = ref('')
-const passkeyLoading = ref(false)
-
-async function addPasskey() {
-  passkeyLoading.value = true
-  try {
-    await authClient?.passkey.addPasskey({ name: passkeyName.value || 'My Passkey' })
-    toast.add({ title: t('app.passkeyAdded'), color: 'success' })
-    passkeyOpen.value = false
-    passkeyName.value = ''
-  }
-  catch (e: any) {
-    toast.add({ title: 'Error', description: e.message, color: 'error' })
-  }
-  passkeyLoading.value = false
-}
-
-async function deletePasskey(id: string) {
-  await authClient?.passkey.deletePasskey({ id })
-  toast.add({ title: t('app.passkeyDeleted'), color: 'success' })
-}
 
 // Password change
 const passwordOpen = ref(false)
@@ -186,18 +123,34 @@ async function changePassword() {
   passwordLoading.value = false
 }
 
-// Sign out
-const signOutLoading = ref(false)
-async function handleSignOut() {
-  signOutLoading.value = true
-  await signOut()
-  navigateTo('/login')
+function resetDashboardState() {
+  sessionsRequestId.value += 1
+  sessions.value = []
+  sessionsLoading.value = false
+  lastLoginMethod.value = null
+  editOpen.value = false
+  passwordOpen.value = false
 }
 
-onMounted(() => {
-  loadSessions()
+watch(isAuthUiActive, (active) => {
+  if (!active) {
+    resetDashboardState()
+    return
+  }
+
   lastLoginMethod.value = authClient?.getLastUsedLoginMethod?.() || null
+  void loadSessions()
+}, { immediate: true })
+
+watch(signOutPending, (pending) => {
+  if (pending)
+    resetDashboardState()
 })
+
+async function handlePageSignOut() {
+  resetDashboardState()
+  await handleSignOut()
+}
 </script>
 
 <template>
@@ -266,7 +219,14 @@ onMounted(() => {
           </div>
         </template>
         <template #createdAt-cell="{ row }">
-          <span class="text-sm text-muted-foreground">{{ new Date(row.original.createdAt).toLocaleDateString() }}</span>
+          <NuxtTime
+            :datetime="row.original.createdAt"
+            :locale="locale"
+            year="numeric"
+            month="short"
+            day="numeric"
+            class="text-sm text-muted-foreground"
+          />
         </template>
         <template #actions-cell="{ row }">
           <UButton size="xs" :color="row.original.id === session?.id ? 'error' : 'neutral'" variant="soft" @click="terminateSession(row.original.token)">
@@ -276,60 +236,7 @@ onMounted(() => {
       </UTable>
     </UCard>
 
-    <!-- Security -->
-    <UCard>
-      <template #header>
-        <h2 class="text-lg font-semibold">
-          {{ t('app.security') }}
-        </h2>
-      </template>
-
-      <div class="space-y-4">
-        <!-- 2FA -->
-        <div class="flex justify-between items-center">
-          <div>
-            <p class="font-medium">
-              {{ t('app.twoFactor') }}
-            </p>
-            <p class="text-sm text-muted-foreground">
-              {{ user?.twoFactorEnabled ? t('app.twoFactorEnabled') : t('app.twoFactorDisabled') }}
-            </p>
-          </div>
-          <UButton :color="user?.twoFactorEnabled ? 'error' : 'primary'" variant="soft" @click="twoFaOpen = true">
-            {{ user?.twoFactorEnabled ? t('app.disable2fa') : t('app.enable2fa') }}
-          </UButton>
-        </div>
-
-        <UDivider />
-
-        <!-- Passkeys -->
-        <div class="flex justify-between items-center">
-          <div>
-            <p class="font-medium">
-              {{ t('app.passkeys') }}
-            </p>
-            <p class="text-sm text-muted-foreground">
-              {{ passkeys.length }} {{ t('app.registered') }}
-            </p>
-          </div>
-          <UButton variant="soft" @click="passkeyOpen = true">
-            {{ t('app.addPasskey') }}
-          </UButton>
-        </div>
-
-        <div v-if="passkeys.length" class="space-y-2">
-          <div v-for="pk in passkeys" :key="pk.id" class="flex justify-between items-center p-2 bg-muted rounded">
-            <div class="flex items-center gap-2">
-              <UIcon name="i-lucide-key-round" />
-              <span class="text-sm">{{ pk.name || 'Passkey' }}</span>
-            </div>
-            <UButton size="xs" color="error" variant="ghost" @click="deletePasskey(pk.id)">
-              <UIcon name="i-lucide-trash-2" />
-            </UButton>
-          </div>
-        </div>
-      </div>
-    </UCard>
+    <AppSecurityCard v-if="isAuthUiActive" />
 
     <!-- Actions -->
     <div class="flex justify-between">
@@ -337,7 +244,7 @@ onMounted(() => {
         <UIcon name="i-lucide-lock" />
         {{ t('app.changePassword') }}
       </UButton>
-      <UButton color="error" variant="soft" :loading="signOutLoading" @click="handleSignOut">
+      <UButton color="error" variant="soft" :loading="signOutPending" @click="handlePageSignOut">
         <UIcon name="i-lucide-log-out" />
         {{ t('common.signOut') }}
       </UButton>
@@ -355,56 +262,6 @@ onMounted(() => {
           </UFormField>
           <UButton block :loading="editLoading" @click="saveProfile">
             {{ t('common.save') }}
-          </UButton>
-        </div>
-      </template>
-    </UModal>
-
-    <!-- 2FA Modal -->
-    <UModal v-model:open="twoFaOpen">
-      <template #header>
-        {{ user?.twoFactorEnabled ? t('app.disable2fa') : t('app.enable2fa') }}
-      </template>
-      <template #body>
-        <div class="space-y-4 p-4">
-          <template v-if="twoFaUri">
-            <div class="flex justify-center">
-              <QRCode :value="twoFaUri" :size="200" />
-            </div>
-            <p class="text-sm text-center text-muted-foreground">
-              {{ t('app.scanQr') }}
-            </p>
-            <UFormField :label="t('app.verificationCode')">
-              <UInput v-model="twoFaCode" inputmode="numeric" maxlength="6" :placeholder="t('app.enterCode')" />
-            </UFormField>
-            <UButton block :loading="twoFaLoading" @click="enable2FA">
-              {{ t('app.verifyEnable') }}
-            </UButton>
-          </template>
-          <template v-else>
-            <UFormField :label="t('common.password')">
-              <UInput v-model="twoFaPassword" type="password" :placeholder="t('common.password')" />
-            </UFormField>
-            <UButton block :loading="twoFaLoading" @click="user?.twoFactorEnabled ? disable2FA() : enable2FA()">
-              {{ user?.twoFactorEnabled ? t('app.disable2fa') : t('app.continue') }}
-            </UButton>
-          </template>
-        </div>
-      </template>
-    </UModal>
-
-    <!-- Passkey Modal -->
-    <UModal v-model:open="passkeyOpen">
-      <template #header>
-        {{ t('app.addPasskey') }}
-      </template>
-      <template #body>
-        <div class="space-y-4 p-4">
-          <UFormField :label="t('app.passkeyName')">
-            <UInput v-model="passkeyName" placeholder="My Passkey" />
-          </UFormField>
-          <UButton block :loading="passkeyLoading" @click="addPasskey">
-            {{ t('app.createPasskey') }}
           </UButton>
         </div>
       </template>

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -26,6 +26,9 @@ export default defineNuxtConfig({
     lazy: true,
     langDir: 'locales',
     strategy: 'no_prefix',
+    experimental: {
+      preload: true,
+    },
   },
 
   app: {

--- a/src/module.ts
+++ b/src/module.ts
@@ -14,7 +14,7 @@ import { consola as _consola } from 'consola'
 import { dirname, join, relative } from 'pathe'
 import { version } from '../package.json'
 import { resolveDatabaseProvider } from './database-provider'
-import { resolveModuleConfigPath } from './module/config-paths'
+import { getEffectiveModuleConfigFile, resolveModuleConfigPath, shouldCreateDefaultModuleConfig } from './module/config-paths'
 import { registerAuthMiddlewareHook, registerDevtools, registerRouteRulesMetaHook, registerServerRuntime, registerTemplateHmrHook } from './module/hooks'
 import { getHubCasing, getHubDialect } from './module/hub'
 import { setupRuntimeConfig } from './module/runtime'
@@ -32,10 +32,8 @@ async function createDefaultAuthConfigFiles(nuxt: Nuxt): Promise<void> {
   const rootDir = project.root
   const serverPath = join(project.server, 'auth.config.ts')
   const clientPath = join(project.app, 'auth.config.ts')
-  const resolvedServerConfig = resolveModuleConfigPath(nuxt, 'server', 'server/auth.config')
-  const resolvedClientConfig = resolveModuleConfigPath(nuxt, 'client', 'app/auth.config')
-  const hasServerConfig = existsSync(`${resolvedServerConfig.path}.ts`) || existsSync(`${resolvedServerConfig.path}.js`)
-  const hasClientConfig = existsSync(`${resolvedClientConfig.path}.ts`) || existsSync(`${resolvedClientConfig.path}.js`)
+  const serverConfigFile = getEffectiveModuleConfigFile(nuxt, 'server')
+  const clientConfigFile = getEffectiveModuleConfigFile(nuxt, 'client')
 
   const serverTemplate = `import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 
@@ -49,13 +47,13 @@ export default defineServerAuth({
 export default defineClientAuth({})
 `
 
-  if (!hasServerConfig) {
+  if (shouldCreateDefaultModuleConfig(nuxt, 'server', serverConfigFile)) {
     await mkdir(dirname(serverPath), { recursive: true })
     await writeFile(serverPath, serverTemplate)
     consola.success(`Created ${relative(rootDir, serverPath)}`)
   }
 
-  if (!hasClientConfig) {
+  if (shouldCreateDefaultModuleConfig(nuxt, 'client', clientConfigFile)) {
     await mkdir(dirname(clientPath), { recursive: true })
     await writeFile(clientPath, clientTemplate)
     consola.success(`Created ${relative(rootDir, clientPath)}`)

--- a/src/module/config-paths.ts
+++ b/src/module/config-paths.ts
@@ -1,4 +1,5 @@
 import type { Nuxt } from '@nuxt/schema'
+import type { BetterAuthModuleOptions } from '../runtime/config'
 import { existsSync } from 'node:fs'
 import { getLayerDirectories } from '@nuxt/kit'
 import { isAbsolute, join, relative } from 'pathe'
@@ -8,14 +9,18 @@ export type ModuleConfigKind = 'server' | 'client'
 export interface ResolvedModuleConfigPath {
   file: string
   path: string
+  isDefault: boolean
 }
 
+const CONFIG_EXTENSIONS = ['.ts', '.js']
 const DEFAULT_CONFIG_FILES = {
   server: 'server/auth.config',
   client: 'app/auth.config',
 } satisfies Record<ModuleConfigKind, string>
-
-const CONFIG_EXTENSIONS = ['.ts', '.js']
+const OPTION_KEY_BY_KIND = {
+  server: 'serverConfig',
+  client: 'clientConfig',
+} satisfies Record<ModuleConfigKind, keyof BetterAuthModuleOptions>
 
 function stripConfigExtension(path: string): string {
   return path.replace(/\.(?:ts|js)$/, '')
@@ -25,47 +30,91 @@ function configExists(path: string): boolean {
   return CONFIG_EXTENSIONS.some(ext => existsSync(`${path}${ext}`))
 }
 
-function getProjectRoot(nuxt: Nuxt): string {
-  return getLayerDirectories(nuxt)[0]!.root
+function getLayerDirectoriesWithConfigs(nuxt: Nuxt) {
+  const directories = getLayerDirectories(nuxt)
+  const layers = nuxt.options._layers as readonly { config?: { auth?: BetterAuthModuleOptions } }[]
+  return directories.map((directory, index) => ({ directory, layer: layers[index] }))
+}
+
+function getProjectDirectory(nuxt: Nuxt) {
+  return getLayerDirectories(nuxt)[0]!
 }
 
 function getDefaultConfigPath(nuxt: Nuxt, kind: ModuleConfigKind): string {
-  const project = getLayerDirectories(nuxt)[0]!
+  const project = getProjectDirectory(nuxt)
   return kind === 'server'
     ? join(project.server, 'auth.config')
     : join(project.app, 'auth.config')
 }
 
 function getLayerDefaultConfigPath(nuxt: Nuxt, kind: ModuleConfigKind): string | undefined {
-  for (const layer of getLayerDirectories(nuxt)) {
+  for (const { directory } of getLayerDirectoriesWithConfigs(nuxt)) {
     const candidate = kind === 'server'
-      ? join(layer.server, 'auth.config')
-      : join(layer.app, 'auth.config')
+      ? join(directory.server, 'auth.config')
+      : join(directory.app, 'auth.config')
 
     if (configExists(candidate))
       return candidate
   }
 }
 
+function resolveDeclaringLayerRoot(nuxt: Nuxt, kind: ModuleConfigKind, file: string): string {
+  const optionKey = OPTION_KEY_BY_KIND[kind]
+
+  for (const { directory, layer } of getLayerDirectoriesWithConfigs(nuxt)) {
+    const declared = layer?.config?.auth?.[optionKey]
+    if (typeof declared === 'string' && stripConfigExtension(declared) === file)
+      return directory.root
+  }
+
+  return getProjectDirectory(nuxt).root
+}
+
 function getRelativeConfigFile(nuxt: Nuxt, path: string): string {
-  return relative(getProjectRoot(nuxt), path)
+  return relative(getProjectDirectory(nuxt).root, path)
+}
+
+export function getEffectiveModuleConfigFile(nuxt: Nuxt, kind: ModuleConfigKind): string {
+  const optionKey = OPTION_KEY_BY_KIND[kind]
+  const authOptions = (nuxt.options as { auth?: BetterAuthModuleOptions }).auth
+  return authOptions?.[optionKey] ?? DEFAULT_CONFIG_FILES[kind]
+}
+
+export function shouldCreateDefaultModuleConfig(nuxt: Nuxt, kind: ModuleConfigKind, file = getEffectiveModuleConfigFile(nuxt, kind)): boolean {
+  const normalizedFile = stripConfigExtension(file)
+  if (normalizedFile !== DEFAULT_CONFIG_FILES[kind])
+    return false
+
+  const resolved = resolveModuleConfigPath(nuxt, kind, normalizedFile)
+  return !configExists(resolved.path)
 }
 
 export function resolveModuleConfigPath(nuxt: Nuxt, kind: ModuleConfigKind, file: string): ResolvedModuleConfigPath {
-  if (isAbsolute(file)) {
-    const path = stripConfigExtension(file)
-    return { file, path }
+  const normalizedFile = stripConfigExtension(file)
+
+  if (isAbsolute(normalizedFile)) {
+    return {
+      file: normalizedFile,
+      path: normalizedFile,
+      isDefault: false,
+    }
   }
 
-  const defaultFile = DEFAULT_CONFIG_FILES[kind]
-  if (file === defaultFile) {
+  if (normalizedFile === DEFAULT_CONFIG_FILES[kind]) {
     const discoveredPath = getLayerDefaultConfigPath(nuxt, kind) ?? getDefaultConfigPath(nuxt, kind)
     return {
       file: getRelativeConfigFile(nuxt, discoveredPath),
       path: discoveredPath,
+      isDefault: true,
     }
   }
 
-  const path = stripConfigExtension(join(getProjectRoot(nuxt), file))
-  return { file, path }
+  const baseRoot = resolveDeclaringLayerRoot(nuxt, kind, normalizedFile)
+  const path = join(baseRoot, normalizedFile)
+
+  return {
+    file: getRelativeConfigFile(nuxt, path),
+    path,
+    isDefault: false,
+  }
 }

--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -9,6 +9,7 @@ interface RuntimeFlags { client: boolean, server: boolean }
 interface SessionResponse { session: AuthSession & { token?: string }, user: AuthUser }
 
 let _sessionSignalListenerBound = false
+let _signOutPromise: Promise<void> | null = null
 
 export interface UseUserSessionReturn {
   client: AppAuthClient | null
@@ -36,6 +37,13 @@ function getClient(baseURL: string): AppAuthClient {
   if (!_client)
     _client = createAppAuthClient(baseURL)
   return _client
+}
+
+function isExpectedSignedOutSessionError(error: unknown): boolean {
+  const normalizedError = normalizeAuthActionError(error)
+  if (normalizedError.status === 401)
+    return true
+  return normalizedError.code === 'UNAUTHORIZED'
 }
 
 function getRuntimeFlags(): RuntimeFlags {
@@ -253,7 +261,7 @@ export function useUserSession(): UseUserSessionReturn {
     return isSafeLocalRedirect(authConfig?.redirects?.authenticated)
   }
 
-  function resolvePostAuthSuccessRedirect(): () => Promise<void> | undefined {
+  function resolvePostAuthSuccessRedirect(): (() => Promise<void>) | undefined {
     const target = resolvePostAuthRedirect()
     if (!target)
       return
@@ -451,7 +459,8 @@ export function useUserSession(): UseUserSessionReturn {
       }
       catch (error) {
         clearSession()
-        console.error('[nuxt-better-auth] Failed to fetch session:', error)
+        if (!isExpectedSignedOutSessionError(error))
+          console.error('[nuxt-better-auth] Failed to fetch session:', error)
       }
       finally {
         if (!authReady.value)
@@ -467,17 +476,30 @@ export function useUserSession(): UseUserSessionReturn {
   async function signOut(options?: SignOutOptions) {
     if (!client)
       throw new Error('signOut can only be called on client-side')
-    await client.signOut()
-    clearSession()
-    if (options?.onSuccess) {
-      await options.onSuccess()
+
+    if (_signOutPromise) {
+      await _signOutPromise
       return
     }
 
-    const authConfig = runtimeConfig.public.auth as { redirects?: { logout?: string } } | undefined
-    const logoutRedirect = authConfig?.redirects?.logout
-    if (logoutRedirect)
-      await navigateTo(logoutRedirect)
+    _signOutPromise = (async () => {
+      await client.signOut()
+      clearSession()
+
+      if (options?.onSuccess) {
+        await options.onSuccess()
+        return
+      }
+
+      const authConfig = runtimeConfig.public.auth as { redirects?: { logout?: string } } | undefined
+      const logoutRedirect = authConfig?.redirects?.logout
+      if (logoutRedirect)
+        await navigateTo(logoutRedirect)
+    })().finally(() => {
+      _signOutPromise = null
+    })
+
+    await _signOutPromise
   }
 
   return {

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -25,9 +25,9 @@ export type EffectiveDatabaseProviderId = 'user' | ModuleDatabaseProviderId
 export interface BetterAuthModuleOptions {
   /** Client-only mode - skip server setup for external auth backends */
   clientOnly?: boolean
-  /** Server config path relative to rootDir. Default: 'server/auth.config' */
+  /** Server config path. Relative paths resolve from the layer that declares them. Default: 'server/auth.config' */
   serverConfig?: string
-  /** Client config path relative to rootDir. Default: 'app/auth.config' */
+  /** Client config path. Relative paths resolve from the layer that declares them. Default: 'app/auth.config' */
   clientConfig?: string
   redirects?: {
     /** Where to redirect unauthenticated users. Default: '/login' */
@@ -104,6 +104,8 @@ export function defineClientAuth<T extends ClientAuthConfig>(config: T | ((ctx: 
   return (baseURL: string) => {
     const ctx: ClientAuthContext = { siteUrl: baseURL }
     const resolved = typeof config === 'function' ? config(ctx) : config
-    return createAuthClient({ baseURL, ...resolved })
+    const { baseURL: configuredBaseURL, ...resolvedOptions } = resolved
+    const clientOptions = { ...resolvedOptions, baseURL: configuredBaseURL ?? baseURL } as T
+    return createAuthClient(clientOptions)
   }
 }

--- a/src/schema-generator.ts
+++ b/src/schema-generator.ts
@@ -54,27 +54,30 @@ export async function generateDrizzleSchema(authOptions: BetterAuthOptions, dial
 
 // Type for cached runtime helper with reference counting
 interface RuntimeDefineServerAuthFn { (...args: unknown[]): unknown, _count: number }
+interface SchemaGeneratorGlobals {
+  __nuxtBetterAuthDefineServerAuth?: RuntimeDefineServerAuthFn
+  defineServerAuth?: RuntimeDefineServerAuthFn
+}
 
 declare global {
   // eslint-disable-next-line vars-on-top
   var __nuxtBetterAuthDefineServerAuth: RuntimeDefineServerAuthFn | undefined
-  // eslint-disable-next-line vars-on-top
-  var defineServerAuth: RuntimeDefineServerAuthFn | undefined
 }
 
 export async function loadUserAuthConfig(configPath: string, throwOnError = false): Promise<Partial<BetterAuthOptions>> {
   const { createJiti } = await import('jiti')
   const { defineServerAuth: runtimeDefineServerAuth } = await import('./runtime/config')
   const jiti = createJiti(import.meta.url, { interopDefault: true, moduleCache: false })
+  const schemaGlobals = globalThis as typeof globalThis & SchemaGeneratorGlobals
 
-  if (!globalThis.__nuxtBetterAuthDefineServerAuth) {
+  if (!schemaGlobals.__nuxtBetterAuthDefineServerAuth) {
     (runtimeDefineServerAuth as unknown as RuntimeDefineServerAuthFn)._count = 0
-    globalThis.__nuxtBetterAuthDefineServerAuth = runtimeDefineServerAuth as unknown as RuntimeDefineServerAuthFn
+    schemaGlobals.__nuxtBetterAuthDefineServerAuth = runtimeDefineServerAuth as unknown as RuntimeDefineServerAuthFn
   }
-  if (!globalThis.defineServerAuth) {
-    globalThis.defineServerAuth = globalThis.__nuxtBetterAuthDefineServerAuth
+  if (!schemaGlobals.defineServerAuth) {
+    schemaGlobals.defineServerAuth = schemaGlobals.__nuxtBetterAuthDefineServerAuth
   }
-  globalThis.__nuxtBetterAuthDefineServerAuth!._count++
+  schemaGlobals.__nuxtBetterAuthDefineServerAuth!._count++
 
   try {
     const mod = await jiti.import(configPath) as { default?: unknown }
@@ -96,13 +99,13 @@ export async function loadUserAuthConfig(configPath: string, throwOnError = fals
     return {}
   }
   finally {
-    const sharedDefineServerAuth = globalThis.__nuxtBetterAuthDefineServerAuth
+    const sharedDefineServerAuth = schemaGlobals.__nuxtBetterAuthDefineServerAuth
     if (sharedDefineServerAuth) {
       sharedDefineServerAuth._count--
       if (!sharedDefineServerAuth._count) {
-        globalThis.__nuxtBetterAuthDefineServerAuth = undefined
-        if (globalThis.defineServerAuth === sharedDefineServerAuth) {
-          globalThis.defineServerAuth = undefined
+        schemaGlobals.__nuxtBetterAuthDefineServerAuth = undefined
+        if (schemaGlobals.defineServerAuth === sharedDefineServerAuth) {
+          schemaGlobals.defineServerAuth = undefined
         }
       }
     }

--- a/test/cases/_base-module/nuxt.config.ts
+++ b/test/cases/_base-module/nuxt.config.ts
@@ -11,7 +11,7 @@ export default defineNuxtConfig({
   },
 
   auth: {
-    // Keep this fixture explicit so override behavior stays covered alongside default layer discovery.
+    // Keep this fixture explicit so override behavior stays covered alongside layer-aware discovery.
     serverConfig,
     clientConfig,
   },

--- a/test/cases/layer-explicit-configs-base/custom/client-auth.ts
+++ b/test/cases/layer-explicit-configs-base/custom/client-auth.ts
@@ -1,0 +1,3 @@
+import { defineClientAuth } from '../../../../src/runtime/config'
+
+export default defineClientAuth({})

--- a/test/cases/layer-explicit-configs-base/custom/server-auth.ts
+++ b/test/cases/layer-explicit-configs-base/custom/server-auth.ts
@@ -1,0 +1,5 @@
+import { defineServerAuth } from '../../../../src/runtime/config'
+
+export default defineServerAuth({
+  emailAndPassword: { enabled: true },
+})

--- a/test/cases/layer-explicit-configs-base/nuxt.config.ts
+++ b/test/cases/layer-explicit-configs-base/nuxt.config.ts
@@ -1,0 +1,8 @@
+export default defineNuxtConfig({
+  extends: ['../core-auth'],
+
+  auth: {
+    serverConfig: 'custom/server-auth',
+    clientConfig: 'custom/client-auth',
+  },
+})

--- a/test/cases/layer-explicit-configs/nuxt.config.ts
+++ b/test/cases/layer-explicit-configs/nuxt.config.ts
@@ -1,0 +1,3 @@
+export default defineNuxtConfig({
+  extends: ['../layer-explicit-configs-base'],
+})

--- a/test/cases/project-explicit-configs/custom/client-auth.ts
+++ b/test/cases/project-explicit-configs/custom/client-auth.ts
@@ -1,0 +1,3 @@
+import { defineClientAuth } from '../../../../src/runtime/config'
+
+export default defineClientAuth({})

--- a/test/cases/project-explicit-configs/custom/server-auth.ts
+++ b/test/cases/project-explicit-configs/custom/server-auth.ts
@@ -1,0 +1,5 @@
+import { defineServerAuth } from '../../../../src/runtime/config'
+
+export default defineServerAuth({
+  emailAndPassword: { enabled: true },
+})

--- a/test/cases/project-explicit-configs/nuxt.config.ts
+++ b/test/cases/project-explicit-configs/nuxt.config.ts
@@ -1,0 +1,6 @@
+export default defineNuxtConfig({
+  auth: {
+    serverConfig: 'custom/server-auth',
+    clientConfig: 'custom/client-auth',
+  },
+})

--- a/test/client-auth-config.test.ts
+++ b/test/client-auth-config.test.ts
@@ -27,7 +27,7 @@ describe('defineClientAuth', () => {
     expect(capturedUrl).toBe('http://test.local')
   })
 
-  it('keeps the resolved baseURL authoritative', () => {
+  it('keeps an explicit baseURL override', () => {
     const factory = defineClientAuth({
       baseURL: 'https://explicit.example/api/auth',
       plugins: [],
@@ -41,6 +41,38 @@ describe('defineClientAuth', () => {
     }))
     expect(client).toMatchObject({
       baseURL: 'https://explicit.example/api/auth',
+    })
+  })
+
+  it('falls back to the inferred baseURL when object syntax leaves it undefined', () => {
+    const factory = defineClientAuth({
+      baseURL: undefined,
+      plugins: [],
+    })
+
+    const client = factory('https://derived.example/api/auth')
+
+    expect(createAuthClient).toHaveBeenCalledWith(expect.objectContaining({
+      baseURL: 'https://derived.example/api/auth',
+    }))
+    expect(client).toMatchObject({
+      baseURL: 'https://derived.example/api/auth',
+    })
+  })
+
+  it('falls back to the inferred baseURL when function syntax leaves it undefined', () => {
+    const factory = defineClientAuth(() => ({
+      baseURL: undefined,
+      plugins: [],
+    }))
+
+    const client = factory('https://derived.example/api/auth')
+
+    expect(createAuthClient).toHaveBeenCalledWith(expect.objectContaining({
+      baseURL: 'https://derived.example/api/auth',
+    }))
+    expect(client).toMatchObject({
+      baseURL: 'https://derived.example/api/auth',
     })
   })
 })

--- a/test/config-paths.test.ts
+++ b/test/config-paths.test.ts
@@ -1,0 +1,109 @@
+import type { Nuxt } from '@nuxt/schema'
+import { fileURLToPath } from 'node:url'
+import { loadNuxt } from '@nuxt/kit'
+import { afterEach, describe, expect, it } from 'vitest'
+import { getEffectiveModuleConfigFile, resolveModuleConfigPath, shouldCreateDefaultModuleConfig } from '../src/module/config-paths'
+
+const loadedNuxtInstances: Nuxt[] = []
+
+async function loadCase(caseName: string): Promise<Nuxt> {
+  const nuxt = await loadNuxt({
+    cwd: fileURLToPath(new URL(`./cases/${caseName}`, import.meta.url)),
+    ready: false,
+    dev: false,
+    overrides: {},
+  })
+  loadedNuxtInstances.push(nuxt)
+  return nuxt
+}
+
+afterEach(async () => {
+  while (loadedNuxtInstances.length) {
+    const nuxt = loadedNuxtInstances.pop()
+    await nuxt?.close()
+  }
+})
+
+describe('resolveModuleConfigPath', () => {
+  it('discovers default configs from an extended layer', async () => {
+    const nuxt = await loadCase('layer-default-configs')
+
+    expect(resolveModuleConfigPath(nuxt, 'server', 'server/auth.config')).toMatchObject({
+      file: '../core-auth/server/auth.config',
+      path: expect.stringContaining('/test/cases/core-auth/server/auth.config'),
+      isDefault: true,
+    })
+    expect(resolveModuleConfigPath(nuxt, 'client', 'app/auth.config')).toMatchObject({
+      file: '../core-auth/app/auth.config',
+      path: expect.stringContaining('/test/cases/core-auth/app/auth.config'),
+      isDefault: true,
+    })
+  })
+
+  it('resolves inherited explicit relative config paths from the declaring layer', async () => {
+    const nuxt = await loadCase('layer-explicit-configs')
+    const serverConfigFile = getEffectiveModuleConfigFile(nuxt, 'server')
+    const clientConfigFile = getEffectiveModuleConfigFile(nuxt, 'client')
+
+    expect(resolveModuleConfigPath(nuxt, 'server', serverConfigFile)).toMatchObject({
+      file: '../layer-explicit-configs-base/custom/server-auth',
+      path: expect.stringContaining('/test/cases/layer-explicit-configs-base/custom/server-auth'),
+      isDefault: false,
+    })
+    expect(resolveModuleConfigPath(nuxt, 'client', clientConfigFile)).toMatchObject({
+      file: '../layer-explicit-configs-base/custom/client-auth',
+      path: expect.stringContaining('/test/cases/layer-explicit-configs-base/custom/client-auth'),
+      isDefault: false,
+    })
+  })
+
+  it('resolves project-defined explicit relative config paths from the project root', async () => {
+    const nuxt = await loadCase('project-explicit-configs')
+    const serverConfigFile = getEffectiveModuleConfigFile(nuxt, 'server')
+    const clientConfigFile = getEffectiveModuleConfigFile(nuxt, 'client')
+
+    expect(resolveModuleConfigPath(nuxt, 'server', serverConfigFile)).toMatchObject({
+      file: 'custom/server-auth',
+      path: expect.stringContaining('/test/cases/project-explicit-configs/custom/server-auth'),
+      isDefault: false,
+    })
+    expect(resolveModuleConfigPath(nuxt, 'client', clientConfigFile)).toMatchObject({
+      file: 'custom/client-auth',
+      path: expect.stringContaining('/test/cases/project-explicit-configs/custom/client-auth'),
+      isDefault: false,
+    })
+  })
+
+  it('passes through absolute config paths unchanged', async () => {
+    const nuxt = await loadCase('database-less')
+    const serverConfigFile = getEffectiveModuleConfigFile(nuxt, 'server')
+    const clientConfigFile = getEffectiveModuleConfigFile(nuxt, 'client')
+
+    expect(resolveModuleConfigPath(nuxt, 'server', serverConfigFile)).toEqual({
+      file: serverConfigFile,
+      path: serverConfigFile,
+      isDefault: false,
+    })
+    expect(resolveModuleConfigPath(nuxt, 'client', clientConfigFile)).toEqual({
+      file: clientConfigFile,
+      path: clientConfigFile,
+      isDefault: false,
+    })
+  })
+})
+
+describe('shouldCreateDefaultModuleConfig', () => {
+  it('does not scaffold defaults when an extended layer already provides default config files', async () => {
+    const nuxt = await loadCase('layer-default-configs')
+
+    expect(shouldCreateDefaultModuleConfig(nuxt, 'server')).toBe(false)
+    expect(shouldCreateDefaultModuleConfig(nuxt, 'client')).toBe(false)
+  })
+
+  it('does not scaffold defaults when effective config paths are explicit custom files from an extended layer', async () => {
+    const nuxt = await loadCase('layer-explicit-configs')
+
+    expect(shouldCreateDefaultModuleConfig(nuxt, 'server')).toBe(false)
+    expect(shouldCreateDefaultModuleConfig(nuxt, 'client')).toBe(false)
+  })
+})

--- a/test/layer-explicit-configs.test.ts
+++ b/test/layer-explicit-configs.test.ts
@@ -1,0 +1,29 @@
+import { fileURLToPath } from 'node:url'
+import { $fetch, setup, url } from '@nuxt/test-utils/e2e'
+import { describe, expect, it } from 'vitest'
+
+describe('layer-aware explicit auth config discovery', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('./cases/layer-explicit-configs', import.meta.url)),
+  })
+
+  it('renders the extended layer app using inherited explicit auth config paths', async () => {
+    const html = await $fetch('/')
+    expect(html).toContain('Home')
+    expect(html).toContain('Not logged in')
+  })
+
+  it('uses auth routes backed by the inherited explicit config paths', async () => {
+    const response = await fetch(url('/api/auth/sign-up/email'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: `explicit-layer-${Date.now()}@example.com`,
+        password: 'testpass123',
+        name: 'Explicit Layer User',
+      }),
+    })
+
+    expect(response.status).toBe(200)
+  })
+})

--- a/test/use-user-session.test.ts
+++ b/test/use-user-session.test.ts
@@ -789,6 +789,52 @@ describe('useUserSession hydration bootstrap', () => {
     expect(navigateTo).not.toHaveBeenCalled()
   })
 
+  it('coalesces concurrent signOut calls into a single client request and redirect', async () => {
+    runtimeConfig.public.auth.redirects = { logout: '/logged-out' }
+
+    let resolveSignOut: (() => void) | undefined
+    mockClient.signOut.mockImplementationOnce(() => new Promise<void>((resolve) => {
+      resolveSignOut = resolve
+    }))
+
+    const useUserSession = await loadUseUserSession()
+    const auth = useUserSession()
+
+    const firstSignOut = auth.signOut()
+    const secondSignOut = auth.signOut()
+
+    expect(mockClient.signOut).toHaveBeenCalledOnce()
+
+    resolveSignOut?.()
+    await Promise.all([firstSignOut, secondSignOut])
+
+    expect(mockClient.signOut).toHaveBeenCalledOnce()
+    expect(navigateTo).toHaveBeenCalledTimes(1)
+    expect(navigateTo).toHaveBeenCalledWith('/logged-out')
+  })
+
+  it('treats expected unauthenticated getSession errors as a normal signed-out state', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockClient.getSession.mockRejectedValueOnce({
+      code: 'UNAUTHORIZED',
+      message: 'Unauthorized',
+      status: 401,
+    })
+
+    const useUserSession = await loadUseUserSession()
+    const auth = useUserSession()
+    auth.session.value = { id: 'session-1' } as any
+    auth.user.value = { id: 'user-1', email: 'user@example.com' } as any
+
+    await auth.fetchSession()
+
+    expect(auth.session.value).toBeNull()
+    expect(auth.user.value).toBeNull()
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+
+    consoleErrorSpy.mockRestore()
+  })
+
   it('signOut throws on server runtime', async () => {
     setRuntimeFlags({ client: false, server: true })
 


### PR DESCRIPTION
## Summary
- preload playground i18n locale files on SSR so auth pages render translated content without hydration mismatch
- unify logout handling and stop auth-bound playground widgets from refetching during sign-out
- harden session/logout behavior and extend layer-aware auth config regression coverage on top of #252

## Testing
- pnpm exec vitest run test/use-user-session.test.ts test/client-auth-config.test.ts test/config-paths.test.ts test/layer-default-configs.test.ts test/layer-explicit-configs.test.ts
- pnpm typecheck
- pnpm typecheck:playground
- local browser smoke with agent-browser against the production-style preview confirmed translated SSR login output with no hydration mismatch