### PR TITLE
fix: resolve schema.casing typed as any

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -1,5 +1,5 @@
 import { defineBuildConfig } from 'unbuild'
 
 export default defineBuildConfig({
-  externals: ['consola', '@better-auth/cli', '@better-auth/cli/api'],
+  externals: ['consola', '@better-auth/cli', '@better-auth/cli/api', 'drizzle-orm/utils'],
 })

--- a/src/module/hub.ts
+++ b/src/module/hub.ts
@@ -1,9 +1,9 @@
-import type { CasingOption } from '../schema-generator'
+import type { Casing } from 'drizzle-orm/utils'
 
 export type DbDialect = 'sqlite' | 'postgresql' | 'mysql'
 
 export interface NuxtHubOptions {
-  db?: boolean | DbDialect | { dialect?: DbDialect, casing?: CasingOption }
+  db?: boolean | DbDialect | { dialect?: DbDialect, casing?: Casing }
   kv?: boolean
 }
 
@@ -17,7 +17,7 @@ export function getHubDialect(hub?: NuxtHubOptions): DbDialect | undefined {
   return undefined
 }
 
-export function getHubCasing(hub?: NuxtHubOptions): CasingOption | undefined {
+export function getHubCasing(hub?: NuxtHubOptions): Casing | undefined {
   if (!hub?.db || typeof hub.db !== 'object' || hub.db === null)
     return undefined
   return hub.db.casing

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -1,6 +1,6 @@
 import type { BetterAuthOptions, BetterAuthPlugin } from 'better-auth'
 import type { BetterAuthClientOptions } from 'better-auth/client'
-import type { CasingOption } from '../schema-generator'
+import type { Casing } from 'drizzle-orm/utils'
 import type { ServerAuthContext } from './types/augment'
 import { createAuthClient } from 'better-auth/vue'
 
@@ -74,7 +74,7 @@ export interface BetterAuthModuleOptions {
     /** Plural table names: user → users. Default: false */
     usePlural?: boolean
     /** Column/table name casing. Explicit value takes precedence over hub.db.casing. */
-    casing?: CasingOption
+    casing?: Casing
   }
 }
 

--- a/src/schema-generator.ts
+++ b/src/schema-generator.ts
@@ -1,8 +1,7 @@
 import type { BetterAuthOptions } from 'better-auth'
+import type { Casing } from 'drizzle-orm/utils'
 import { generateDrizzleSchema as _generateDrizzleSchema } from '@better-auth/cli/api'
 import { consola } from 'consola'
-
-import type { Casing } from 'drizzle-orm/utils'
 
 export interface SchemaOptions { usePlural?: boolean, useUuid?: boolean, casing?: Casing }
 

--- a/src/schema-generator.ts
+++ b/src/schema-generator.ts
@@ -2,8 +2,9 @@ import type { BetterAuthOptions } from 'better-auth'
 import { generateDrizzleSchema as _generateDrizzleSchema } from '@better-auth/cli/api'
 import { consola } from 'consola'
 
-export type CasingOption = 'camelCase' | 'snake_case'
-export interface SchemaOptions { usePlural?: boolean, useUuid?: boolean, casing?: CasingOption }
+import type { Casing } from 'drizzle-orm/utils'
+
+export interface SchemaOptions { usePlural?: boolean, useUuid?: boolean, casing?: Casing }
 
 type Dialect = 'sqlite' | 'postgresql' | 'mysql'
 type Provider = 'sqlite' | 'pg' | 'mysql'


### PR DESCRIPTION
Closes #269

## Summary

`auth.schema.casing` was typed as `any` because `dist/runtime/config.d.ts` imported `CasingOption` from `../schema-generator.js` — a file that doesn't exist in `dist/` (nuxt-module-build only emits `dist/runtime/**`). Fix: import `Casing` from `drizzle-orm/utils` instead.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxt-better-auth-269](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-better-auth-269/nuxt-better-auth-269?startScript=typecheck) | ❌ Unused @ts-expect-error (casing is any) |
| Fix | [nuxt-better-auth-269-fix](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-better-auth-269/nuxt-better-auth-269-fix?startScript=typecheck) | ✅ Typecheck passes |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxt-better-auth-269 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxt-better-auth-269
cd nuxt-better-auth-269 && pnpm i && npx nuxi typecheck
```

## Verify fix

```bash
git sparse-checkout add nuxt-better-auth-269-fix
cd ../nuxt-better-auth-269-fix && pnpm i && npx nuxi typecheck
```

The `-fix` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.