### PR TITLE
docs: clean up stale warnings, nav CTAs, i18n

### DIFF
--- a/docs/content/1.getting-started/0.index.md
+++ b/docs/content/1.getting-started/0.index.md
@@ -113,7 +113,3 @@ If this is your first setup, follow this order:
 3. [Client Setup](/getting-started/client-setup)
 4. [Route Protection](/core-concepts/route-protection)
 5. [API Reference](/api/composables)
-
-::callout{icon="i-lucide-arrow-right" to="/getting-started/installation"}
-Continue to **Installation** for detailed setup options.
-::

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -109,7 +109,3 @@ export default defineClientAuth({})
 ::callout{icon="i-lucide-hard-drive" to="/guides/custom-database"}
 **Bring your own database?** Use Drizzle, Prisma, or Kysely adapters with any database.
 ::
-
-::callout{icon="i-lucide-arrow-right" to="/getting-started/configuration"}
-Continue to **Configuration** to set up these files.
-::

--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -285,7 +285,3 @@ Access sessions from server handlers:
 const { user, session } = await getUserSession(event)
 if (!user) throw createError({ statusCode: 401 })
 ```
-
-::callout{icon="i-lucide-arrow-right" to="/getting-started/client-setup"}
-Next, set up the **Client Configuration**.
-::

--- a/docs/content/1.getting-started/3.client-setup.md
+++ b/docs/content/1.getting-started/3.client-setup.md
@@ -72,7 +72,3 @@ export default defineClientAuth({
 ```
 
 :read-more{to="https://www.better-auth.com/docs/plugins" title="All Better Auth plugins"}
-
-::callout{icon="i-lucide-arrow-right" to="/getting-started/type-augmentation"}
-Learn how to enable **Type Augmentation** for full type safety.
-::

--- a/docs/content/1.getting-started/4.type-augmentation.md
+++ b/docs/content/1.getting-started/4.type-augmentation.md
@@ -92,7 +92,3 @@ Otherwise, Nuxt/TypeScript may not pick them up and your augmentation will have 
 2. Run `npx nuxi prepare` to regenerate types
 3. Check that your `server/auth.config.ts` has no syntax errors
 4. Ensure your augmentation `.d.ts` file is included by TypeScript (see note above)
-
-::callout{icon="i-lucide-arrow-right" to="/getting-started/how-it-works"}
-Now that you are set up, learn **How it Works**.
-::

--- a/docs/content/4.integrations/1.nuxthub.md
+++ b/docs/content/4.integrations/1.nuxthub.md
@@ -9,10 +9,6 @@ NuxtHub provides the easiest way to add database persistence to your authenticat
 NuxtHub is vendor-agnostic. Deploy to Cloudflare, Vercel, or self-host. See [NuxtHub deployment docs](https://hub.nuxt.com/docs/getting-started/deploy).
 ::
 
-::warning{icon="i-lucide-flask-conical"}
-**Beta Requirement**: Schema generation requires `better-auth` beta. Install with `pnpm add better-auth@beta`.
-::
-
 ## Features
 
 - **Auto Schema Generation** - Tables for users, sessions, accounts created automatically

--- a/docs/content/4.integrations/4.i18n.md
+++ b/docs/content/4.integrations/4.i18n.md
@@ -94,59 +94,6 @@ const localizedErrorMessage = computed(() => {
 
 This pattern uses typed `error.code` for translation and falls back to `error.message` when no localized key exists.
 
-## App-Local Message Resolver
-
-For a reusable message resolver across auth and plugin actions, keep it app-local:
-
-```ts [app/utils/auth-error.ts]
-type AuthErrorLike = {
-  message?: string
-  code?: string
-  status?: number
-}
-
-interface ResolveAuthErrorMessageOptions {
-  fallback?: string
-  translate?: (ctx: { code?: string, message: string, status?: number }) => string | undefined
-}
-
-const DEFAULT_FALLBACK = 'Please try again.'
-
-export function resolveAuthErrorMessage(
-  error: unknown,
-  options: ResolveAuthErrorMessageOptions = {},
-): string {
-  const normalized = (typeof error === 'object' && error !== null ? error : {}) as AuthErrorLike
-  const message = typeof normalized.message === 'string' && normalized.message.length > 0
-    ? normalized.message
-    : DEFAULT_FALLBACK
-
-  const translated = options.translate?.({
-    code: normalized.code,
-    message,
-    status: normalized.status,
-  })
-
-  if (translated)
-    return translated
-
-  return message === DEFAULT_FALLBACK ? (options.fallback || DEFAULT_FALLBACK) : message
-}
-```
-
-```ts [pages/login.vue]
-const { t, te } = useI18n()
-
-const message = resolveAuthErrorMessage(signInEmail.error.value, {
-  translate: ({ code }) => {
-    if (!code)
-      return
-    const key = `auth.errors.${code}`
-    return te(key) ? t(key) : undefined
-  },
-})
-```
-
 ## Server-Side Locale Detection
 
 For auth config callbacks like `sendResetPassword`, use `@intlify/utils/h3` to detect the user's locale:
@@ -172,21 +119,6 @@ export default defineServerAuth(() => ({
   }
 }))
 ```
-
-## Error Codes Reference
-
-| Code | Default Message |
-|------|-----------------|
-| `USER_NOT_FOUND` | User not found |
-| `INVALID_PASSWORD` | Invalid password |
-| `INVALID_EMAIL_OR_PASSWORD` | Invalid email or password |
-| `EMAIL_NOT_VERIFIED` | Email not verified |
-| `SESSION_EXPIRED` | Session expired |
-| `INVALID_TOKEN` | Invalid token |
-| `USER_ALREADY_EXISTS` | User already exists |
-| `INVALID_EMAIL` | Invalid email |
-| `PASSWORD_TOO_SHORT` | Password too short |
-| `RATE_LIMIT_EXCEEDED` | Too many requests |
 
 ::callout{icon="i-lucide-book" to="https://www.better-auth.com/docs/concepts/client#error-codes"}
 See [Better Auth Error Codes](https://www.better-auth.com/docs/concepts/client#error-codes) for the complete list of error codes.


### PR DESCRIPTION
## Summary
- Remove stale `better-auth@beta` warning from NuxtHub docs (no longer needed)
- Remove duplicate "Continue to..." navigation CTAs (docus already has bottom nav)
- Simplify i18n page: remove over-engineered App-Local Message Resolver section and duplicated error codes table