### PR TITLE
feat: add createSession(event, userId) server utility

### DIFF
--- a/docs/content/2.core-concepts/4.auto-imports-aliases.md
+++ b/docs/content/2.core-concepts/4.auto-imports-aliases.md
@@ -9,7 +9,7 @@ description: What the module registers for you.
 Use auto-imported utilities from @onmax/nuxt-better-auth.
 
 - Client (auto-imported in Vue): `useUserSession()`, `useSignIn()`, `useSignUp()`
-- Server (auto-imported in `server/`): `serverAuth(event?)`, `getRequestSession(event)`, `getUserSession(event)`, `requireUserSession(event, options?)`
+- Server (auto-imported in `server/`): `serverAuth(event?)`, `getRequestSession(event)`, `getUserSession(event)`, `createSession(event, userId)`, `requireUserSession(event, options?)`
 - Component: `<BetterAuthState>` for auth-ready rendering
 - Alias `#nuxt-better-auth` exports types: `AuthUser`, `AuthSession`, `AuthSocialProviderId`
 - Use `getRequestSession(event)` over repeated `getUserSession(event)` calls — it caches per request
@@ -33,6 +33,7 @@ Source: https://github.com/nuxt-modules/better-auth
 - `serverAuth(event?)`
 - `getRequestSession(event)`
 - `getUserSession(event)`
+- `createSession(event, userId)`
 - `requireUserSession(event, options?)`
 
 **Components**
@@ -54,6 +55,8 @@ export default defineEventHandler(async (event) => {
 
 Use `getRequestSession(event)` when multiple handlers or middleware in the same request need session data. The helper should be preferred over repeated `getUserSession(event)` calls in the same request chain.
 `getUserSession(event)` does not memoize by itself.
+
+Use `createSession(event, userId)` when a custom server handler finishes its own verification logic and needs a Better Auth session record without reaching into module internals.
 
 ### Client Composables (auto-imported in Vue components)
 

--- a/docs/content/5.api/2.server-utils.md
+++ b/docs/content/5.api/2.server-utils.md
@@ -102,6 +102,25 @@ export default defineServerAuth({
 ::note
 This uses Better Auth's plugin API and does not require a module-specific option.
 ::
+
+## createSession
+
+Creates a Better Auth session for a user and returns the created session record. Use this helper in custom server-side authentication flows after your handler verifies the user identity.
+
+```ts [server/api/custom-auth.post.ts]
+export default defineEventHandler(async (event) => {
+  const userId = await verifyCustomLoginAndReturnUserId(event)
+  const session = await createSession(event, userId)
+
+  return {
+    sessionId: session.id,
+    token: session.token,
+  }
+})
+```
+
+Pair this helper with your preferred cookie strategy. When you also use the module cookie helper, you can set the returned token on the response after creating the session.
+
 ## requireUserSession
 
 Ensures the user is authenticated and optionally matches specific criteria. Throws a `401 Unauthorized` or `403 Forbidden` error if checks fail.

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -6,6 +6,12 @@ import { serverAuth } from './auth'
 
 const requestSessionLoadKey = Symbol.for('nuxt-better-auth.requestSessionLoad')
 
+interface ServerAuthContextLike {
+  internalAdapter: {
+    createSession: (userId: string, rememberMe: boolean) => Promise<unknown>
+  }
+}
+
 interface RequestSessionContext {
   requestSession?: AppSession | null
   [requestSessionLoadKey]?: Promise<AppSession | null>
@@ -29,6 +35,11 @@ function getRequestSessionContext(event: H3Event): RequestSessionContext {
 function loadSession(event: H3Event): Promise<AppSession | null> {
   const auth = serverAuth(event)
   return auth.api.getSession({ headers: event.headers }) as Promise<AppSession | null>
+}
+
+function getServerAuthContext(event: H3Event): Promise<ServerAuthContextLike> {
+  const auth = serverAuth(event) as ReturnType<typeof serverAuth> & { $context: Promise<ServerAuthContextLike> }
+  return auth.$context
 }
 
 export async function getRequestSession(event: H3Event): Promise<AppSession | null> {
@@ -66,8 +77,7 @@ export async function getUserSession(event: H3Event): Promise<AppSession | null>
 }
 
 export async function createSession(event: H3Event, userId: string): Promise<AuthSession> {
-  const auth = serverAuth(event)
-  const context = await auth.$context
+  const context = await getServerAuthContext(event)
   return context.internalAdapter.createSession(userId, false) as Promise<AuthSession>
 }
 

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -1,4 +1,4 @@
-import type { AppSession, RequireSessionOptions } from '#nuxt-better-auth'
+import type { AppSession, AuthSession, RequireSessionOptions } from '#nuxt-better-auth'
 import type { H3Event } from 'h3'
 import { createError } from 'h3'
 import { matchesUser } from '../../utils/match-user'
@@ -63,6 +63,12 @@ export async function getUserSession(event: H3Event): Promise<AppSession | null>
     return inFlight
 
   return loadSession(event)
+}
+
+export async function createSession(event: H3Event, userId: string): Promise<AuthSession> {
+  const auth = serverAuth(event)
+  const context = await auth.$context
+  return context.internalAdapter.createSession(userId, false) as Promise<AuthSession>
 }
 
 export async function requireUserSession(event: H3Event, options?: RequireSessionOptions): Promise<AppSession> {

--- a/test/get-request-session.test.ts
+++ b/test/get-request-session.test.ts
@@ -1,12 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const getSessionMock = vi.fn()
+const createSessionMock = vi.fn()
+
+const authContextMock = {
+  internalAdapter: {
+    createSession: createSessionMock,
+  },
+}
 
 vi.mock('../src/runtime/server/utils/auth', () => ({
   serverAuth: () => ({
     api: {
       getSession: getSessionMock,
     },
+    $context: Promise.resolve(authContextMock),
   }),
 }))
 
@@ -27,6 +35,7 @@ describe('getRequestSession', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     getSessionMock.mockReset()
+    createSessionMock.mockReset()
   })
 
   it('memoizes session on event.context.requestSession', async () => {
@@ -89,6 +98,7 @@ describe('getUserSession', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     getSessionMock.mockReset()
+    createSessionMock.mockReset()
   })
 
   it('does not memoize when session exists', async () => {
@@ -178,6 +188,7 @@ describe('requireUserSession', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     getSessionMock.mockReset()
+    createSessionMock.mockReset()
   })
 
   it('keeps existing 401 behavior when no session exists', async () => {
@@ -203,6 +214,36 @@ describe('requireUserSession', () => {
     await expect(requireUserSession(event, { user: { role: 'admin' } })).rejects.toMatchObject({
       statusCode: 403,
       statusMessage: 'Access denied',
+    })
+  })
+})
+
+describe('createSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getSessionMock.mockReset()
+    createSessionMock.mockReset()
+  })
+
+  it('delegates to Better Auth internalAdapter.createSession with dontRememberMe disabled', async () => {
+    createSessionMock.mockResolvedValue({
+      id: 's1',
+      userId: 'u1',
+      token: 'token-1',
+      expiresAt: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    const { createSession } = await import('../src/runtime/server/utils/session')
+    const event = createEvent()
+    const session = await createSession(event, 'u1')
+
+    expect(createSessionMock).toHaveBeenCalledWith('u1', false)
+    expect(session).toMatchObject({
+      id: 's1',
+      userId: 'u1',
+      token: 'token-1',
     })
   })
 })


### PR DESCRIPTION
Closes #297

## Summary
- add an auto-imported `createSession(event, userId)` server helper
- delegate to Better Auth session creation with `dontRememberMe` disabled
- document the helper as an escape hatch for custom server-side auth flows

## Validation
- `pnpm vitest run test/get-request-session.test.ts`
- fresh `/tmp/nuxt-better-auth-297-repro` app: `/api/me` returns `401`, `/api/custom-login` returns `200`, then `/api/me` returns `200` after the route creates a session through `createSession`
