### PR TITLE
fix: defer auth secret validation to runtime

### DIFF
--- a/docs/content/3.guides/9.production-deployment.md
+++ b/docs/content/3.guides/9.production-deployment.md
@@ -5,7 +5,7 @@ description: Checklist and best practices for deploying Nuxt Better Auth in prod
 
 ## Environment Variables
 
-Production requires these environment variables:
+Production requires these environment variables at runtime:
 
 ```ini [.env.production]
 # Required: 32+ character secret for session encryption
@@ -25,7 +25,7 @@ GOOGLE_CLIENT_SECRET="..."
 node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 ```
 
-The secret must be at least 32 characters. Shorter secrets will cause the module to throw an error.
+The secret must be at least 32 characters. Shorter secrets will cause auth initialization to throw an error at runtime.
 
 ## Security Checklist
 
@@ -79,6 +79,10 @@ export default defineEventHandler((event) => {
 
 For production, consider using Cloudflare rate limiting or a Redis-backed solution.
 
+### Separate Build And Runtime Environments
+
+Some platforms, including Cloudflare deployments, expose build-time and runtime environment variables separately. `NUXT_BETTER_AUTH_SECRET` must be available to the deployed runtime, but it does not need to be present in the build container.
+
 ### Trusted Origins for Preview Environments
 
 If your workflow uses preview URLs (for example, `*.workers.dev`), include those origins in your Better Auth server config.
@@ -117,7 +121,11 @@ export default defineNuxtConfig({
 
 ### "NUXT_BETTER_AUTH_SECRET must be at least 32 characters"
 
-Your secret is too short. Generate a new one using the command above. `BETTER_AUTH_SECRET` is still accepted as a fallback, but `NUXT_BETTER_AUTH_SECRET` is the recommended variable.
+Your secret is too short. Generate a new one using the command above. This error is raised when auth initializes at runtime. `BETTER_AUTH_SECRET` is still accepted as a fallback, but `NUXT_BETTER_AUTH_SECRET` is the recommended variable.
+
+### "NUXT_BETTER_AUTH_SECRET is required in production"
+
+The deployed server runtime could not resolve an auth secret. Set `NUXT_BETTER_AUTH_SECRET` or `BETTER_AUTH_SECRET` in the runtime environment for your app.
 
 ### "siteUrl required in production"
 

--- a/src/module/runtime.ts
+++ b/src/module/runtime.ts
@@ -68,14 +68,6 @@ export function setupRuntimeConfig(input: SetupRuntimeConfigInput): { useHubKV: 
   const currentSecret = nuxt.options.runtimeConfig.betterAuthSecret as string | undefined
   nuxt.options.runtimeConfig.betterAuthSecret = currentSecret || process.env.NUXT_BETTER_AUTH_SECRET || process.env.BETTER_AUTH_SECRET || ''
 
-  const betterAuthSecret = nuxt.options.runtimeConfig.betterAuthSecret as string
-  if (!nuxt.options.dev && !nuxt.options._prepare && !betterAuthSecret) {
-    throw new Error('[nuxt-better-auth] NUXT_BETTER_AUTH_SECRET is required in production. Set NUXT_BETTER_AUTH_SECRET or BETTER_AUTH_SECRET environment variable.')
-  }
-  if (betterAuthSecret && betterAuthSecret.length < 32) {
-    throw new Error('[nuxt-better-auth] NUXT_BETTER_AUTH_SECRET must be at least 32 characters for security')
-  }
-
   nuxt.options.runtimeConfig.auth = defu(nuxt.options.runtimeConfig.auth as Record<string, unknown>, {
     hubSecondaryStorage: options.hubSecondaryStorage ?? false,
   }) as AuthPrivateRuntimeConfig

--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -10,6 +10,7 @@ import { getRequestHost, getRequestProtocol } from 'h3'
 import { useRuntimeConfig } from 'nitropack/runtime'
 import { withoutProtocol } from 'ufo'
 import { resolveCustomSecondaryStorageRequirement } from './custom-secondary-storage'
+import { validateAuthSecret } from './validate-secret'
 
 type AuthOptions = ReturnType<typeof createServerAuth>
 type AuthInstance = ReturnType<typeof betterAuth<AuthOptions>>
@@ -17,16 +18,6 @@ type AuthInstance = ReturnType<typeof betterAuth<AuthOptions>>
 const _authCache = new Map<string, AuthInstance>()
 let _baseURLInferenceLogged = false
 let _customSecondaryStorageMisconfigWarned = false
-
-function validateAuthSecret(secret: string | undefined): string {
-  if (!secret) {
-    throw new Error('[nuxt-better-auth] NUXT_BETTER_AUTH_SECRET is required in production. Set NUXT_BETTER_AUTH_SECRET or BETTER_AUTH_SECRET environment variable.')
-  }
-  if (secret.length < 32)
-    throw new Error('[nuxt-better-auth] NUXT_BETTER_AUTH_SECRET must be at least 32 characters for security')
-
-  return secret
-}
 
 function normalizeLoopbackOrigin(origin: string): string {
   if (!import.meta.dev)
@@ -258,7 +249,6 @@ function withDevTrustedOrigins(
 /** Returns Better Auth instance. Caches per resolved host (or single instance when siteUrl is explicit). */
 export function serverAuth(event?: H3Event): AuthInstance {
   const runtimeConfig = useRuntimeConfig()
-  const betterAuthSecret = validateAuthSecret(runtimeConfig.betterAuthSecret)
   const siteUrl = getBaseURL(event)
   const hasExplicitSiteUrl = runtimeConfig.public.siteUrl && typeof runtimeConfig.public.siteUrl === 'string'
   const cacheKey = hasExplicitSiteUrl ? '__explicit__' : siteUrl
@@ -267,6 +257,7 @@ export function serverAuth(event?: H3Event): AuthInstance {
   if (cached)
     return cached
 
+  const betterAuthSecret = validateAuthSecret(runtimeConfig.betterAuthSecret)
   const database = createDatabase()
   const userConfig = createServerAuth({ runtimeConfig, db }) as BetterAuthOptions & {
     secondaryStorage?: BetterAuthOptions['secondaryStorage']

--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -18,6 +18,16 @@ const _authCache = new Map<string, AuthInstance>()
 let _baseURLInferenceLogged = false
 let _customSecondaryStorageMisconfigWarned = false
 
+function validateAuthSecret(secret: string | undefined): string {
+  if (!secret) {
+    throw new Error('[nuxt-better-auth] NUXT_BETTER_AUTH_SECRET is required in production. Set NUXT_BETTER_AUTH_SECRET or BETTER_AUTH_SECRET environment variable.')
+  }
+  if (secret.length < 32)
+    throw new Error('[nuxt-better-auth] NUXT_BETTER_AUTH_SECRET must be at least 32 characters for security')
+
+  return secret
+}
+
 function normalizeLoopbackOrigin(origin: string): string {
   if (!import.meta.dev)
     return origin
@@ -248,6 +258,7 @@ function withDevTrustedOrigins(
 /** Returns Better Auth instance. Caches per resolved host (or single instance when siteUrl is explicit). */
 export function serverAuth(event?: H3Event): AuthInstance {
   const runtimeConfig = useRuntimeConfig()
+  const betterAuthSecret = validateAuthSecret(runtimeConfig.betterAuthSecret)
   const siteUrl = getBaseURL(event)
   const hasExplicitSiteUrl = runtimeConfig.public.siteUrl && typeof runtimeConfig.public.siteUrl === 'string'
   const cacheKey = hasExplicitSiteUrl ? '__explicit__' : siteUrl
@@ -275,7 +286,7 @@ export function serverAuth(event?: H3Event): AuthInstance {
     ...userConfig,
     ...(database && { database }),
     ...(hubSecondaryStorage === true && { secondaryStorage: createSecondaryStorage() }),
-    secret: runtimeConfig.betterAuthSecret,
+    secret: betterAuthSecret,
     baseURL: siteUrl,
     trustedOrigins,
   })

--- a/src/runtime/server/utils/validate-secret.ts
+++ b/src/runtime/server/utils/validate-secret.ts
@@ -1,0 +1,8 @@
+export function validateAuthSecret(secret: string | undefined): string {
+  if (!import.meta.dev && !secret)
+    throw new Error('[nuxt-better-auth] NUXT_BETTER_AUTH_SECRET is required in production. Set NUXT_BETTER_AUTH_SECRET or BETTER_AUTH_SECRET environment variable.')
+  if (secret && secret.length < 32)
+    throw new Error('[nuxt-better-auth] NUXT_BETTER_AUTH_SECRET must be at least 32 characters for security')
+
+  return secret || ''
+}

--- a/test/runtime-config.test.ts
+++ b/test/runtime-config.test.ts
@@ -135,7 +135,7 @@ describe('setupRuntimeConfig secret resolution', () => {
     expect((nuxt.options as any).runtimeConfig.betterAuthSecret).toBe('fallback-secret-for-testing-only-32chars')
   })
 
-  it('throws in production when no secret is configured', () => {
+  it('does not throw in production when no secret is configured', () => {
     const nuxt = createNuxtWithRuntimeConfig()
     nuxt.options.dev = false
     const consola = createConsolaMock()
@@ -147,7 +147,8 @@ describe('setupRuntimeConfig secret resolution', () => {
       databaseProvider: 'none',
       hasNuxtHub: false,
       consola,
-    })).toThrow('NUXT_BETTER_AUTH_SECRET is required in production')
+    })).not.toThrow()
+    expect((nuxt.options as any).runtimeConfig.betterAuthSecret).toBe('')
   })
 })
 

--- a/test/server-auth-runtime-validation.test.ts
+++ b/test/server-auth-runtime-validation.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const betterAuthMock = vi.fn()
+const createDatabaseMock = vi.fn()
+const createSecondaryStorageMock = vi.fn()
+const createServerAuthMock = vi.fn()
+const useRuntimeConfigMock = vi.fn()
+
+vi.mock('#auth/database', () => ({
+  createDatabase: createDatabaseMock,
+  db: { query: {} },
+}))
+
+vi.mock('#auth/secondary-storage', () => ({
+  createSecondaryStorage: createSecondaryStorageMock,
+}))
+
+vi.mock('#auth/server', () => ({
+  default: createServerAuthMock,
+}))
+
+vi.mock('better-auth', () => ({
+  betterAuth: betterAuthMock,
+}))
+
+vi.mock('nitropack/runtime', () => ({
+  useRuntimeConfig: useRuntimeConfigMock,
+}))
+
+describe('serverAuth runtime secret validation', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+
+    useRuntimeConfigMock.mockReturnValue({
+      public: {
+        siteUrl: 'https://example.com',
+      },
+      auth: {},
+      betterAuthSecret: 'test-secret-for-testing-only-32chars',
+    })
+
+    createDatabaseMock.mockReturnValue(undefined)
+    createSecondaryStorageMock.mockReturnValue(undefined)
+    createServerAuthMock.mockReturnValue({
+      trustedOrigins: undefined,
+    })
+    betterAuthMock.mockImplementation((options: Record<string, unknown>) => ({ options }))
+  })
+
+  it('throws when the runtime auth secret is missing', async () => {
+    useRuntimeConfigMock.mockReturnValue({
+      public: {
+        siteUrl: 'https://example.com',
+      },
+      auth: {},
+      betterAuthSecret: '',
+    })
+
+    const { serverAuth } = await import('../src/runtime/server/utils/auth')
+
+    expect(() => serverAuth()).toThrow('NUXT_BETTER_AUTH_SECRET is required in production')
+    expect(createDatabaseMock).not.toHaveBeenCalled()
+    expect(betterAuthMock).not.toHaveBeenCalled()
+  })
+
+  it('throws when the runtime auth secret is shorter than 32 characters', async () => {
+    useRuntimeConfigMock.mockReturnValue({
+      public: {
+        siteUrl: 'https://example.com',
+      },
+      auth: {},
+      betterAuthSecret: 'too-short-secret',
+    })
+
+    const { serverAuth } = await import('../src/runtime/server/utils/auth')
+
+    expect(() => serverAuth()).toThrow('NUXT_BETTER_AUTH_SECRET must be at least 32 characters')
+    expect(createDatabaseMock).not.toHaveBeenCalled()
+    expect(betterAuthMock).not.toHaveBeenCalled()
+  })
+
+  it('initializes auth when the runtime auth secret is valid', async () => {
+    const { serverAuth } = await import('../src/runtime/server/utils/auth')
+
+    const auth = serverAuth()
+
+    expect(auth).toEqual({
+      options: expect.objectContaining({
+        secret: 'test-secret-for-testing-only-32chars',
+        baseURL: 'https://example.com',
+      }),
+    })
+    expect(createDatabaseMock).toHaveBeenCalledTimes(1)
+    expect(betterAuthMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/server-auth-runtime-validation.test.ts
+++ b/test/server-auth-runtime-validation.test.ts
@@ -1,97 +1,17 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
+import { validateAuthSecret } from '../src/runtime/server/utils/validate-secret'
 
-const betterAuthMock = vi.fn()
-const createDatabaseMock = vi.fn()
-const createSecondaryStorageMock = vi.fn()
-const createServerAuthMock = vi.fn()
-const useRuntimeConfigMock = vi.fn()
-
-vi.mock('#auth/database', () => ({
-  createDatabase: createDatabaseMock,
-  db: { query: {} },
-}))
-
-vi.mock('#auth/secondary-storage', () => ({
-  createSecondaryStorage: createSecondaryStorageMock,
-}))
-
-vi.mock('#auth/server', () => ({
-  default: createServerAuthMock,
-}))
-
-vi.mock('better-auth', () => ({
-  betterAuth: betterAuthMock,
-}))
-
-vi.mock('nitropack/runtime', () => ({
-  useRuntimeConfig: useRuntimeConfigMock,
-}))
-
-describe('serverAuth runtime secret validation', () => {
-  beforeEach(() => {
-    vi.resetModules()
-    vi.clearAllMocks()
-
-    useRuntimeConfigMock.mockReturnValue({
-      public: {
-        siteUrl: 'https://example.com',
-      },
-      auth: {},
-      betterAuthSecret: 'test-secret-for-testing-only-32chars',
-    })
-
-    createDatabaseMock.mockReturnValue(undefined)
-    createSecondaryStorageMock.mockReturnValue(undefined)
-    createServerAuthMock.mockReturnValue({
-      trustedOrigins: undefined,
-    })
-    betterAuthMock.mockImplementation((options: Record<string, unknown>) => ({ options }))
+describe('validateAuthSecret', () => {
+  it('throws when secret is missing', () => {
+    expect(() => validateAuthSecret('')).toThrow('NUXT_BETTER_AUTH_SECRET is required in production')
   })
 
-  it('throws when the runtime auth secret is missing', async () => {
-    useRuntimeConfigMock.mockReturnValue({
-      public: {
-        siteUrl: 'https://example.com',
-      },
-      auth: {},
-      betterAuthSecret: '',
-    })
-
-    const { serverAuth } = await import('../src/runtime/server/utils/auth')
-
-    expect(() => serverAuth()).toThrow('NUXT_BETTER_AUTH_SECRET is required in production')
-    expect(createDatabaseMock).not.toHaveBeenCalled()
-    expect(betterAuthMock).not.toHaveBeenCalled()
+  it('throws when secret is shorter than 32 characters', () => {
+    expect(() => validateAuthSecret('too-short')).toThrow('NUXT_BETTER_AUTH_SECRET must be at least 32 characters')
   })
 
-  it('throws when the runtime auth secret is shorter than 32 characters', async () => {
-    useRuntimeConfigMock.mockReturnValue({
-      public: {
-        siteUrl: 'https://example.com',
-      },
-      auth: {},
-      betterAuthSecret: 'too-short-secret',
-    })
-
-    const { serverAuth } = await import('../src/runtime/server/utils/auth')
-
-    expect(() => serverAuth()).toThrow('NUXT_BETTER_AUTH_SECRET must be at least 32 characters')
-    expect(createDatabaseMock).not.toHaveBeenCalled()
-    expect(betterAuthMock).not.toHaveBeenCalled()
-  })
-
-  it('initializes auth when the runtime auth secret is valid', async () => {
-    const { serverAuth } = await import('../src/runtime/server/utils/auth')
-
-    const auth = serverAuth()
-
-    expect(auth).toEqual({
-      options: expect.objectContaining({
-        secret: 'test-secret-for-testing-only-32chars',
-        baseURL: 'https://example.com',
-      }),
-    })
-    expect(createDatabaseMock).toHaveBeenCalledTimes(1)
-    expect(betterAuthMock).toHaveBeenCalledTimes(1)
+  it('returns valid secret', () => {
+    const secret = 'a'.repeat(32)
+    expect(validateAuthSecret(secret)).toBe(secret)
   })
 })


### PR DESCRIPTION
## Summary
- stop throwing for a missing or short auth secret during module setup
- validate the resolved secret when `serverAuth()` initializes at runtime instead
- update tests and production deployment docs to match the runtime-only enforcement

Closes #302

## Testing
- `pnpm test test/runtime-config.test.ts test/server-auth-runtime-validation.test.ts`
- `pnpm test test/server-auth-base-url-cache.test.ts`