### PR TITLE
feat: expose request origin in server auth context

### DIFF
--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -198,15 +198,27 @@ import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 export default defineServerAuth((ctx) => ({
   emailAndPassword: { enabled: true },
 
-  // Access the database connection via ctx.db when using NuxtHub
-  // Example: pass ctx.db to your own plugin/helper.
-  // Do not set `database` here when using module-managed adapters.
   appName: ctx.runtimeConfig.public.siteUrl ? 'Better Auth App' : 'Better Auth',
-
-  // Access runtime config if needed
-  // someValue: ctx.runtimeConfig.customKey
 }))
 ```
+
+- `ctx.runtimeConfig`: Nuxt runtime config.
+- `ctx.db`: NuxtHub database connection when NuxtHub DB is enabled. Do not set `database` when using module-managed adapters.
+- `ctx.requestOrigin`: Current request origin when auth is created with `serverAuth(event)`.
+
+Use `requestOrigin` when Better Auth config needs the current request host, such as trusted origins:
+
+```ts [server/auth.config.ts]
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
+
+export default defineServerAuth(({ requestOrigin }) => ({
+  trustedOrigins: requestOrigin ? [requestOrigin] : [],
+}))
+```
+
+::note
+For configured canonical URLs, read `runtimeConfig.public.siteUrl`. `requestOrigin` is optional and only available when auth is created from a request event. If allowed origins vary while using an explicit `siteUrl`, configure those origins explicitly or use Better Auth's `trustedOrigins` function form, because the auth instance can be cached.
+::
 
 ### Session Enrichment
 

--- a/src/module/type-templates.ts
+++ b/src/module/type-templates.ts
@@ -91,6 +91,7 @@ declare module '#nuxt-better-auth' {
   interface ServerAuthContext {
     runtimeConfig: RuntimeConfig
     db: ${hasHubDb ? `typeof import('@nuxthub/db')['db']` : 'undefined'}
+    requestOrigin?: string
   }
   type PluginTypes = InferPluginTypes<_Config>
 }
@@ -98,6 +99,7 @@ declare module '#nuxt-better-auth' {
 interface _AugmentedServerAuthContext {
   runtimeConfig: RuntimeConfig
   db: ${hasHubDb ? `typeof import('@nuxthub/db')['db']` : 'undefined'}
+  requestOrigin?: string
 }
 
 declare module '@onmax/nuxt-better-auth/config' {

--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -250,6 +250,7 @@ function withDevTrustedOrigins(
 export function serverAuth(event?: H3Event): AuthInstance {
   const runtimeConfig = useRuntimeConfig()
   const siteUrl = getBaseURL(event)
+  const requestOrigin = resolveEventOrigin(event)
   const hasExplicitSiteUrl = runtimeConfig.public.siteUrl && typeof runtimeConfig.public.siteUrl === 'string'
   const cacheKey = hasExplicitSiteUrl ? '__explicit__' : siteUrl
 
@@ -259,7 +260,7 @@ export function serverAuth(event?: H3Event): AuthInstance {
 
   const betterAuthSecret = validateAuthSecret(runtimeConfig.betterAuthSecret)
   const database = createDatabase()
-  const userConfig = createServerAuth({ runtimeConfig, db }) as BetterAuthOptions & {
+  const userConfig = createServerAuth({ runtimeConfig, db, requestOrigin }) as BetterAuthOptions & {
     secondaryStorage?: BetterAuthOptions['secondaryStorage']
   }
   const trustedOrigins = withDevTrustedOrigins(userConfig.trustedOrigins, Boolean(hasExplicitSiteUrl))

--- a/src/runtime/types/augment.ts
+++ b/src/runtime/types/augment.ts
@@ -30,6 +30,7 @@ export interface AuthSession {
 export interface ServerAuthContext {
   runtimeConfig: Record<string, unknown>
   db: unknown
+  requestOrigin?: string
 }
 
 // Extended by generated types from configured socialProviders keys.

--- a/src/schema-generator.ts
+++ b/src/schema-generator.ts
@@ -83,7 +83,7 @@ export async function loadUserAuthConfig(configPath: string, throwOnError = fals
     const mod = await jiti.import(configPath) as { default?: unknown }
     const configFn = mod.default
     if (typeof configFn === 'function') {
-      return configFn({ runtimeConfig: {}, db: null, requestOrigin: undefined })
+      return configFn({ runtimeConfig: {}, db: null })
     }
     consola.warn('[@onmax/nuxt-better-auth] auth.config.ts does not export default. Expected: export default defineServerAuth(...)')
     if (throwOnError) {

--- a/src/schema-generator.ts
+++ b/src/schema-generator.ts
@@ -83,7 +83,7 @@ export async function loadUserAuthConfig(configPath: string, throwOnError = fals
     const mod = await jiti.import(configPath) as { default?: unknown }
     const configFn = mod.default
     if (typeof configFn === 'function') {
-      return configFn({ runtimeConfig: {}, db: null })
+      return configFn({ runtimeConfig: {}, db: null, requestOrigin: undefined })
     }
     consola.warn('[@onmax/nuxt-better-auth] auth.config.ts does not export default. Expected: export default defineServerAuth(...)')
     if (throwOnError) {

--- a/test/cases/base-url-inference/nuxt.config.ts
+++ b/test/cases/base-url-inference/nuxt.config.ts
@@ -1,3 +1,10 @@
+import { fileURLToPath } from 'node:url'
+
+const serverConfig = fileURLToPath(new URL('./server/auth.config', import.meta.url))
+
 export default defineNuxtConfig({
   extends: ['../_base-module'],
+  auth: {
+    serverConfig,
+  },
 })

--- a/test/cases/base-url-inference/server/api/test/base-url.get.ts
+++ b/test/cases/base-url-inference/server/api/test/base-url.get.ts
@@ -1,4 +1,4 @@
 export default defineEventHandler((event) => {
-  const auth = serverAuth(event) as { options?: { baseURL?: string } }
-  return { baseURL: auth.options?.baseURL }
+  const auth = serverAuth(event) as { options?: { appName?: string, baseURL?: string } }
+  return { appName: auth.options?.appName, baseURL: auth.options?.baseURL }
 })

--- a/test/cases/base-url-inference/server/auth.config.ts
+++ b/test/cases/base-url-inference/server/auth.config.ts
@@ -1,0 +1,8 @@
+import { defineServerAuth } from '../../../../src/runtime/config'
+
+export default defineServerAuth(({ requestOrigin }) => ({
+  appName: requestOrigin || 'missing-request-origin',
+  socialProviders: {
+    github: { clientId: 'test', clientSecret: 'test' },
+  },
+}))

--- a/test/cases/plugins-type-inference/server/auth.config.ts
+++ b/test/cases/plugins-type-inference/server/auth.config.ts
@@ -24,7 +24,8 @@ function customAdminLikePlugin() {
   } as const
 }
 
-export default defineServerAuth({
+export default defineServerAuth(ctx => ({
+  appName: ctx.requestOrigin ? 'request-origin' : 'fallback',
   emailAndPassword: { enabled: true },
   plugins: [customAdminLikePlugin(), username()] as const,
   user: {
@@ -35,4 +36,4 @@ export default defineServerAuth({
       },
     },
   },
-})
+}))

--- a/test/cases/plugins-type-inference/server/auth.config.ts
+++ b/test/cases/plugins-type-inference/server/auth.config.ts
@@ -24,8 +24,7 @@ function customAdminLikePlugin() {
   } as const
 }
 
-export default defineServerAuth(ctx => ({
-  appName: ctx.requestOrigin ? 'request-origin' : 'fallback',
+export default defineServerAuth(() => ({
   emailAndPassword: { enabled: true },
   plugins: [customAdminLikePlugin(), username()] as const,
   user: {

--- a/test/schema-generator.test.ts
+++ b/test/schema-generator.test.ts
@@ -157,6 +157,15 @@ describe('defineServerAuth', () => {
     expect(factory({ runtimeConfig: {} as any, db: {} as any })).toEqual({ hasDb: true })
     expect(factory({ runtimeConfig: {} as any, db: undefined })).toEqual({ hasDb: false })
   })
+
+  it('function syntax receives requestOrigin context', () => {
+    const factory = defineServerAuth(({ requestOrigin }) => ({ requestOrigin }))
+    expect(factory({
+      runtimeConfig: {} as any,
+      db: undefined,
+      requestOrigin: 'https://example.com',
+    })).toEqual({ requestOrigin: 'https://example.com' })
+  })
 })
 
 describe('defineClientAuth', () => {

--- a/test/server-auth-base-url-cache.test.ts
+++ b/test/server-auth-base-url-cache.test.ts
@@ -15,7 +15,7 @@ describe('serverAuth baseURL inference', async () => {
       },
     })
     expect(firstResponse.status).toBe(200)
-    const firstBody = await firstResponse.json() as { baseURL: string | undefined }
+    const firstBody = await firstResponse.json() as { appName: string | undefined, baseURL: string | undefined }
 
     const secondResponse = await fetch(url('/api/test/base-url'), {
       headers: {
@@ -24,9 +24,11 @@ describe('serverAuth baseURL inference', async () => {
       },
     })
     expect(secondResponse.status).toBe(200)
-    const secondBody = await secondResponse.json() as { baseURL: string | undefined }
+    const secondBody = await secondResponse.json() as { appName: string | undefined, baseURL: string | undefined }
 
+    expect(firstBody.appName).toBe('https://first.example.com')
     expect(firstBody.baseURL).toBe('https://first.example.com')
+    expect(secondBody.appName).toBe('https://second.example.com')
     expect(secondBody.baseURL).toBe('https://second.example.com')
   })
 })


### PR DESCRIPTION
## Summary

- Adds `requestOrigin?: string` to `defineServerAuth` callback context
- Passes the current Nitro request origin from `serverAuth(event)` into user auth config
- Documents using `requestOrigin` for dynamic trusted origins without adding a redundant `siteUrl` context field

## Notes

`requestOrigin` is intentionally event-only and optional. Configured canonical URLs remain available through `runtimeConfig.public.siteUrl`.

## Tests

- `pnpm test test/schema-generator.test.ts`
- `pnpm test test/get-base-url.test.ts`
- `pnpm test test/server-auth-base-url-cache.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test -- --maxWorkers=1`

## Additional check

- `pnpm typecheck:runtime-server` currently fails on existing runtime-server typing issues unrelated to this change: virtual-module `@ts-expect-error` directives, `ZodError.errors`, and mixed `h3` versions.