### PR TITLE
fix(auth): use nuxt imports in server runtime

### DIFF
--- a/src/runtime/server/api/_better-auth/config.get.ts
+++ b/src/runtime/server/api/_better-auth/config.get.ts
@@ -1,5 +1,5 @@
+import { useRuntimeConfig } from '#imports'
 import { defineEventHandler } from 'h3'
-import { useRuntimeConfig } from 'nitropack/runtime'
 import { serverAuth } from '../../utils/auth'
 
 export default defineEventHandler(async (event) => {

--- a/src/runtime/server/middleware/route-access.ts
+++ b/src/runtime/server/middleware/route-access.ts
@@ -1,6 +1,6 @@
 import type { AuthMeta, AuthMode, AuthRouteRules } from '../../types'
+import { getRouteRules } from '#imports'
 import { createError, defineEventHandler, getRequestURL } from 'h3'
-import { getRouteRules } from 'nitropack/runtime'
 import { matchesUser } from '../../utils/match-user'
 import { getUserSession, requireUserSession } from '../utils/session'
 


### PR DESCRIPTION
## Before

Two server runtime files imported from `nitropack/runtime`.

## After

Use the `#imports` alias — Nuxt-convention, avoids reaching into nitropack internals.

## Change

- `src/runtime/server/api/_better-auth/config.get.ts`
- `src/runtime/server/middleware/route-access.ts`