### PR TITLE
fix(ci): restore plugin inference fixture

### DIFF
--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -1,8 +1,6 @@
 import type { BetterAuthOptions } from 'better-auth'
 import type { H3Event } from 'h3'
-// @ts-expect-error Nuxt generates this virtual module in app builds.
 import { createDatabase, db } from '#auth/database'
-// @ts-expect-error Nuxt generates this virtual module in app builds.
 import { createSecondaryStorage } from '#auth/secondary-storage'
 import createServerAuth from '#auth/server'
 import { betterAuth } from 'better-auth'

--- a/test/cases/plugins-type-inference/tsconfig.type-check.json
+++ b/test/cases/plugins-type-inference/tsconfig.type-check.json
@@ -1,26 +1,11 @@
 {
+  "extends": "./.nuxt/tsconfig.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "lib": [
-      "ESNext",
-      "DOM"
-    ],
-    "baseUrl": ".",
-    "module": "preserve",
-    "moduleResolution": "bundler",
-    "paths": {
-      "#auth/client": ["./app/auth.config"],
-      "#auth/server": ["./server/auth.config"],
-      "#nuxt-better-auth": ["../../../src/runtime/types/augment"]
-    },
-    "types": [],
-    "strict": true,
-    "noEmit": true,
-    "skipLibCheck": true
+    "noEmit": true
   },
-  "files": [
-    "./.nuxt/types/nuxt-better-auth-infer.d.ts",
-    "./.nuxt/types/nuxt-better-auth-nitro.d.ts",
+  "include": [
+    "./.nuxt/nuxt.d.ts",
+    "./virtual-modules.d.ts",
     "./typecheck-target.ts"
   ]
 }

--- a/test/cases/plugins-type-inference/virtual-modules.d.ts
+++ b/test/cases/plugins-type-inference/virtual-modules.d.ts
@@ -1,0 +1,8 @@
+declare module '#auth/database' {
+  export const db: any
+  export function createDatabase(...args: any[]): any
+}
+
+declare module '#auth/secondary-storage' {
+  export function createSecondaryStorage(...args: any[]): any
+}


### PR DESCRIPTION
## Summary

Restores the plugin inference fixture typecheck setup by extending the generated Nuxt tsconfig and declaring the virtual auth modules used by the fixture.

Also removes obsolete `@ts-expect-error` comments from the runtime virtual-module imports now that local stubs cover those modules during typechecking.

## Verify

- `pnpm test test/infer-plugins-types.test.ts`
- `pnpm lint`