### PR TITLE
fix(ci): add server imports type stubs

### DIFF
--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -1,8 +1,6 @@
 import type { BetterAuthOptions } from 'better-auth'
 import type { H3Event } from 'h3'
-// @ts-expect-error Nuxt generates this virtual module in app builds.
 import { createDatabase, db } from '#auth/database'
-// @ts-expect-error Nuxt generates this virtual module in app builds.
 import { createSecondaryStorage } from '#auth/secondary-storage'
 import createServerAuth from '#auth/server'
 import { betterAuth } from 'better-auth'

--- a/src/runtime/server/virtual-modules.d.ts
+++ b/src/runtime/server/virtual-modules.d.ts
@@ -3,6 +3,11 @@ declare module '#auth/database' {
   export function createDatabase(...args: any[]): any
 }
 
+declare module '#imports' {
+  export function getRouteRules(event: any): any
+  export function useRuntimeConfig(): any
+}
+
 declare module '#auth/secondary-storage' {
   export function createSecondaryStorage(...args: any[]): any
 }


### PR DESCRIPTION
## Summary

Adds a standalone `#imports` declaration for the server runtime typecheck after the server runtime import migration in #306.

Also removes obsolete `@ts-expect-error` comments from the generated auth virtual-module imports now that the runtime type stubs cover those modules.

## Verify

- `pnpm typecheck:runtime-server`
- `pnpm lint`