### PR TITLE
fix(types): include auth augmentations in shared context

### DIFF
--- a/src/module/type-templates.ts
+++ b/src/module/type-templates.ts
@@ -111,7 +111,7 @@ declare module '@onmax/nuxt-better-auth/config' {
   export function defineServerAuth<const R>(config: R & ServerAuthConfig): (ctx: _AugmentedServerAuthContext) => R
 }
 `,
-  }, { nuxt: true, nitro: true, node: true })
+  }, { nuxt: true, nitro: true, node: true, shared: true })
 
   addTypeTemplate({
     filename: 'types/nuxt-better-auth-social-providers.d.ts',
@@ -128,7 +128,7 @@ declare module '#nuxt-better-auth' {
   }
 }
 `,
-  }, { nuxt: true, nitro: true, node: true })
+  }, { nuxt: true, nitro: true, node: true, shared: true })
 
   addTypeTemplate({
     filename: 'types/nuxt-better-auth-nitro.d.ts',

--- a/test/cases/plugins-type-inference/.nuxtrc
+++ b/test/cases/plugins-type-inference/.nuxtrc
@@ -1,1 +1,1 @@
-setups.@onmax/nuxt-better-auth="0.0.2-alpha.30"
+setups.@onmax/nuxt-better-auth="0.0.2-alpha.31"

--- a/test/cases/plugins-type-inference/server/auth.config.ts
+++ b/test/cases/plugins-type-inference/server/auth.config.ts
@@ -11,6 +11,15 @@ function customAdminLikePlugin() {
       },
     },
     schema: {
+      session: {
+        fields: {
+          workspaceId: {
+            type: 'string',
+            required: false,
+            input: false,
+          },
+        },
+      },
       user: {
         fields: {
           role: {
@@ -27,6 +36,12 @@ function customAdminLikePlugin() {
 export default defineServerAuth(() => ({
   emailAndPassword: { enabled: true },
   plugins: [customAdminLikePlugin(), username()] as const,
+  socialProviders: {
+    github: {
+      clientId: 'test-client-id',
+      clientSecret: 'test-client-secret',
+    },
+  },
   user: {
     additionalFields: {
       internalCode: {

--- a/test/cases/plugins-type-inference/shared/auth-types.ts
+++ b/test/cases/plugins-type-inference/shared/auth-types.ts
@@ -1,0 +1,16 @@
+import type { AuthSession, AuthUser } from '#nuxt-better-auth'
+import type { AuthSocialProviderId } from '../../../../src/runtime/types'
+
+export function assertSharedAuthTypes(user: AuthUser, session: AuthSession) {
+  const role: string | null | undefined = user.role
+  const internalCode: string | null | undefined = user.internalCode
+  const workspaceId: string | null | undefined = session.workspaceId
+  const provider: AuthSocialProviderId = 'github'
+
+  return {
+    internalCode,
+    provider,
+    role,
+    workspaceId,
+  }
+}

--- a/test/cases/plugins-type-inference/tsconfig.type-check.json
+++ b/test/cases/plugins-type-inference/tsconfig.type-check.json
@@ -20,6 +20,7 @@
   },
   "files": [
     "./.nuxt/types/nuxt-better-auth-infer.d.ts",
+    "./.nuxt/types/nuxt-better-auth-social-providers.d.ts",
     "./.nuxt/types/nuxt-better-auth-nitro.d.ts",
     "./typecheck-target.ts"
   ]

--- a/test/cases/plugins-type-inference/typecheck-target.ts
+++ b/test/cases/plugins-type-inference/typecheck-target.ts
@@ -1,5 +1,6 @@
-import type { AuthUser } from '#nuxt-better-auth'
+import type { AuthSession, AuthUser } from '#nuxt-better-auth'
 import type { NitroRouteRules } from 'nitropack/types'
+import type { AuthSocialProviderId } from '../../../src/runtime/types'
 
 declare const serverAuth: typeof import('../../../src/runtime/server/utils/auth').serverAuth
 
@@ -21,6 +22,18 @@ const user: AuthUser = {
   foo: 'bar',
 }
 
+const session: AuthSession = {
+  id: 'session-1',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  userId: '1',
+  expiresAt: new Date(),
+  token: 'token',
+  workspaceId: 'workspace-1',
+}
+
+const provider: AuthSocialProviderId = 'github'
+
 const rules: NitroRouteRules = {
   auth: {
     user: { role: 'admin', internalCode: 'x', foo: 'bar' },
@@ -34,3 +47,5 @@ void user
 void rules
 void auth
 void signInUsername
+void session
+void provider

--- a/test/infer-plugins-types.test.ts
+++ b/test/infer-plugins-types.test.ts
@@ -30,5 +30,12 @@ describe('type inference regressions #107 and #192', () => {
     expect(output).not.toContain(`'internalCode' does not exist in type`)
     expect(output).not.toContain(`Property 'signInUsername' does not exist on type`)
     expect(output).not.toContain(`'signInUsername' does not exist on type`)
+
+    const sharedTypecheck = spawnSync('npx', ['vue-tsc', '--noEmit', '--pretty', 'false', '-p', '.nuxt/tsconfig.shared.json'], {
+      cwd: fixtureDir,
+      env,
+      encoding: 'utf8',
+    })
+    expect(sharedTypecheck.status, `shared vue-tsc failed:\n${sharedTypecheck.stdout}\n${sharedTypecheck.stderr}`).toBe(0)
   }, 60_000)
 })


### PR DESCRIPTION
## Summary

Generated Better Auth module augmentations were only referenced by the main Nuxt type context, so Nuxt 4 `shared/` files saw the base `#nuxt-better-auth` types without plugin/config fields.

This adds the user/session and social-provider augmentation templates to Nuxt's shared type references, while leaving app/Nitro-only auth API templates out of the shared context.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxt-better-auth-shared-types](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-better-auth-shared-types/nuxt-better-auth-shared-types?startScript=typecheck) | Typecheck fails in `shared/` |
| Fix | [nuxt-better-auth-shared-types-fix](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-better-auth-shared-types/nuxt-better-auth-shared-types-fix?startScript=typecheck) | Typecheck succeeds |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxt-better-auth-shared-types https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxt-better-auth-shared-types
cd nuxt-better-auth-shared-types && pnpm i && pnpm typecheck
```

## Verify fix

```bash
git sparse-checkout add nuxt-better-auth-shared-types-fix
cd ../nuxt-better-auth-shared-types-fix && pnpm i && pnpm typecheck
```

The `-fix` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.

## Local verification

```bash
pnpm test test/infer-plugins-types.test.ts
pnpm lint
pnpm typecheck
```
