### PR TITLE
fix(types): support server auth config project refs

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -110,11 +110,21 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
     nuxt.options.alias['#auth/client'] = clientConfigPath
 
     if (!clientOnly) {
-      nuxt.hook('prepare:types', ({ nodeTsConfig }) => {
+      nuxt.hook('prepare:types', ({ nodeTsConfig, nodeReferences, sharedReferences }) => {
         nodeTsConfig.compilerOptions ||= {}
         nodeTsConfig.compilerOptions.paths ||= {}
 
         const serverDir = dirname(serverConfigPath)
+        const projectReferenceTypePaths = [
+          join(nuxt.options.buildDir, 'types/nitro-imports.d.ts'),
+          join(nuxt.options.buildDir, 'types/auth-database.d.ts'),
+          join(nuxt.options.buildDir, 'types/auth-schema.d.ts'),
+          join(nuxt.options.buildDir, 'types/auth-secondary-storage.d.ts'),
+        ]
+
+        if (hasHubDb)
+          projectReferenceTypePaths.push(join(nuxt.options.buildDir, 'hub/db.d.ts'))
+
         const exactNodeAliases = {
           '#server': serverDir,
           '#auth/server': nuxt.options.alias['#auth/server'],
@@ -132,6 +142,13 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
         }
 
         nodeTsConfig.compilerOptions.paths['#server/*'] = [join(serverDir, '*')]
+
+        for (const path of projectReferenceTypePaths) {
+          if (!nodeReferences.some(reference => 'path' in reference && reference.path === path))
+            nodeReferences.push({ path })
+          if (!sharedReferences.some(reference => 'path' in reference && reference.path === path))
+            sharedReferences.push({ path })
+        }
       })
     }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -109,6 +109,32 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
       nuxt.options.alias['#auth/server'] = serverConfigPath
     nuxt.options.alias['#auth/client'] = clientConfigPath
 
+    if (!clientOnly) {
+      nuxt.hook('prepare:types', ({ nodeTsConfig }) => {
+        nodeTsConfig.compilerOptions ||= {}
+        nodeTsConfig.compilerOptions.paths ||= {}
+
+        const serverDir = dirname(serverConfigPath)
+        const exactNodeAliases = {
+          '#server': serverDir,
+          '#auth/server': nuxt.options.alias['#auth/server'],
+          '#auth/client': nuxt.options.alias['#auth/client'],
+          '#auth/database': nuxt.options.alias['#auth/database'],
+          '#auth/schema': nuxt.options.alias['#auth/schema'],
+          '#auth/secondary-storage': nuxt.options.alias['#auth/secondary-storage'],
+          '#auth/route-rules': nuxt.options.alias['#auth/route-rules'],
+          '#nuxt-better-auth': nuxt.options.alias['#nuxt-better-auth'],
+        } as const
+
+        for (const [key, value] of Object.entries(exactNodeAliases)) {
+          if (typeof value === 'string')
+            nodeTsConfig.compilerOptions.paths[key] = [value]
+        }
+
+        nodeTsConfig.compilerOptions.paths['#server/*'] = [join(serverDir, '*')]
+      })
+    }
+
     if (clientOnly) {
       setupRuntimeConfig({
         nuxt,

--- a/src/module/schema.ts
+++ b/src/module/schema.ts
@@ -68,7 +68,12 @@ export function resolveHubSchemaPath(
 async function loadAuthOptions(context: SchemaContext) {
   const isProduction = !context.nuxt.options.dev
   const configFile = `${context.serverConfigPath}.ts`
-  const userConfig = await loadUserAuthConfig(configFile, isProduction)
+  const alias = Object.fromEntries(
+    Object.entries(context.nuxt.options.alias)
+      .filter(([, value]) => typeof value === 'string')
+      .map(([key, value]) => [key, value as string]),
+  )
+  const userConfig = await loadUserAuthConfig(configFile, isProduction, alias)
 
   const extendedConfig: { plugins?: BetterAuthPlugin[] } = {}
   await context.nuxt.callHook('better-auth:config:extend', extendedConfig)

--- a/src/module/type-templates.ts
+++ b/src/module/type-templates.ts
@@ -60,13 +60,17 @@ declare module '#auth/schema' {
 /// <reference path="./auth-database.d.ts" />
 /// <reference path="./auth-schema.d.ts" />
 /// <reference path="./auth-secondary-storage.d.ts" />
-${hasHubDb ? '/// <reference path="../hub/db.d.ts" />' : ''}
+${hasHubDb
+  ? '/// <reference path="../hub/db.d.ts" />'
+  : ''}
 
-${hasHubDb ? `declare module '@nuxthub/db' {
+${hasHubDb
+  ? `declare module '@nuxthub/db' {
   export const db: typeof import('#auth/database')['db']
   export const schema: typeof import('#auth/schema')['schema']
 }
-` : ''}
+`
+  : ''}
 export {}
 `,
   }, { node: true, shared: true })

--- a/src/module/type-templates.ts
+++ b/src/module/type-templates.ts
@@ -28,7 +28,7 @@ declare module '#auth/secondary-storage' {
     getContents: () => `
 declare module '#auth/database' {
   import type { BetterAuthOptions } from 'better-auth'
-  export function createDatabase(): BetterAuthOptions['database']
+  export function createDatabase(event?: import('h3').H3Event): BetterAuthOptions['database']
   export const db: ${hasHubDb ? `typeof import('@nuxthub/db')['db']` : 'undefined'}
 }
 `,

--- a/src/module/type-templates.ts
+++ b/src/module/type-templates.ts
@@ -21,7 +21,7 @@ declare module '#auth/secondary-storage' {
   export function createSecondaryStorage(): SecondaryStorage | undefined
 }
 `,
-  }, { nitro: true, node: true })
+  }, { nitro: true })
 
   addTypeTemplate({
     filename: 'types/auth-database.d.ts',
@@ -32,7 +32,7 @@ declare module '#auth/database' {
   export const db: ${hasHubDb ? `typeof import('@nuxthub/db')['db']` : 'undefined'}
 }
 `,
-  }, { nitro: true, node: true })
+  }, { nitro: true })
 
   addTypeTemplate({
     filename: 'types/auth-schema.d.ts',
@@ -51,29 +51,7 @@ declare module '#auth/schema' {
   } | undefined
 }
 `,
-  }, { nitro: true, node: true })
-
-  addTypeTemplate({
-    filename: 'types/nuxt-better-auth-server-context.d.ts',
-    getContents: () => `
-/// <reference path="./nitro-imports.d.ts" />
-/// <reference path="./auth-database.d.ts" />
-/// <reference path="./auth-schema.d.ts" />
-/// <reference path="./auth-secondary-storage.d.ts" />
-${hasHubDb
-  ? '/// <reference path="../hub/db.d.ts" />'
-  : ''}
-
-${hasHubDb
-  ? `declare module '@nuxthub/db' {
-  export const db: typeof import('#auth/database')['db']
-  export const schema: typeof import('#auth/schema')['schema']
-}
-`
-  : ''}
-export {}
-`,
-  }, { node: true, shared: true })
+  }, { nitro: true })
 
   addTypeTemplate({
     filename: 'types/nuxt-better-auth-infer.d.ts',

--- a/src/module/type-templates.ts
+++ b/src/module/type-templates.ts
@@ -54,6 +54,24 @@ declare module '#auth/schema' {
   }, { nitro: true, node: true })
 
   addTypeTemplate({
+    filename: 'types/nuxt-better-auth-server-context.d.ts',
+    getContents: () => `
+/// <reference path="./nitro-imports.d.ts" />
+/// <reference path="./auth-database.d.ts" />
+/// <reference path="./auth-schema.d.ts" />
+/// <reference path="./auth-secondary-storage.d.ts" />
+${hasHubDb ? '/// <reference path="../hub/db.d.ts" />' : ''}
+
+${hasHubDb ? `declare module '@nuxthub/db' {
+  export const db: typeof import('#auth/database')['db']
+  export const schema: typeof import('#auth/schema')['schema']
+}
+` : ''}
+export {}
+`,
+  }, { node: true, shared: true })
+
+  addTypeTemplate({
     filename: 'types/nuxt-better-auth-infer.d.ts',
     getContents: () => `
 import type { BetterAuthOptions, BetterAuthPlugin, InferPluginTypes, UnionToIntersection } from 'better-auth'
@@ -307,6 +325,15 @@ declare module 'nitropack' {
   interface InternalApi extends _GeneratedAuthInternalApi {}
 }
 declare module 'nitropack/types' {
+  interface NitroRouteRules {
+    auth?: import('${runtimeTypesPath}').AuthMeta
+  }
+  interface NitroRouteConfig {
+    auth?: import('${runtimeTypesPath}').AuthMeta
+  }
+  interface InternalApi extends _GeneratedAuthInternalApi {}
+}
+declare module 'nitro/types' {
   interface NitroRouteRules {
     auth?: import('${runtimeTypesPath}').AuthMeta
   }

--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -1,8 +1,6 @@
 import type { BetterAuthOptions } from 'better-auth'
 import type { H3Event } from 'h3'
-// @ts-expect-error Nuxt generates this virtual module in app builds.
 import { createDatabase, db } from '#auth/database'
-// @ts-expect-error Nuxt generates this virtual module in app builds.
 import { createSecondaryStorage } from '#auth/secondary-storage'
 import createServerAuth from '#auth/server'
 import { betterAuth } from 'better-auth'
@@ -12,11 +10,41 @@ import { withoutProtocol } from 'ufo'
 import { resolveCustomSecondaryStorageRequirement } from './custom-secondary-storage'
 
 type AuthOptions = ReturnType<typeof createServerAuth>
-type AuthInstance = ReturnType<typeof betterAuth<AuthOptions>>
+type UserAuthConfig = AuthOptions & {
+  trustedOrigins?: BetterAuthOptions['trustedOrigins']
+  secondaryStorage?: BetterAuthOptions['secondaryStorage']
+}
+type ResolvedAuthOptions = UserAuthConfig & {
+  secret: string
+  baseURL: string
+  trustedOrigins?: BetterAuthOptions['trustedOrigins']
+  database?: BetterAuthOptions['database']
+}
+type AuthInstance = ReturnType<typeof betterAuth<ResolvedAuthOptions>>
 
 const _authCache = new Map<string, AuthInstance>()
+const requestAuthKey = Symbol.for('nuxt-better-auth.requestAuth')
 let _baseURLInferenceLogged = false
 let _customSecondaryStorageMisconfigWarned = false
+
+interface RequestAuthContext {
+  [requestAuthKey]?: AuthInstance
+}
+
+const fallbackRequestAuthContext = new WeakMap<object, RequestAuthContext>()
+
+function getRequestAuthContext(event: H3Event): RequestAuthContext {
+  const eventWithContext = event as H3Event & { context?: unknown }
+  if (eventWithContext.context && typeof eventWithContext.context === 'object')
+    return eventWithContext.context as RequestAuthContext
+
+  let context = fallbackRequestAuthContext.get(event as object)
+  if (!context) {
+    context = {}
+    fallbackRequestAuthContext.set(event as object, context)
+  }
+  return context
+}
 
 function normalizeLoopbackOrigin(origin: string): string {
   if (!import.meta.dev)
@@ -252,15 +280,13 @@ export function serverAuth(event?: H3Event): AuthInstance {
   const requestOrigin = resolveEventOrigin(event)
   const hasExplicitSiteUrl = runtimeConfig.public.siteUrl && typeof runtimeConfig.public.siteUrl === 'string'
   const cacheKey = hasExplicitSiteUrl ? '__explicit__' : siteUrl
+  const requestContext = event ? getRequestAuthContext(event) : undefined
 
-  const cached = _authCache.get(cacheKey)
-  if (cached)
-    return cached
+  if (requestContext?.[requestAuthKey])
+    return requestContext[requestAuthKey]
 
-  const database = createDatabase()
-  const userConfig = createServerAuth({ runtimeConfig, db, requestOrigin }) as BetterAuthOptions & {
-    secondaryStorage?: BetterAuthOptions['secondaryStorage']
-  }
+  const database = createDatabase(event)
+  const userConfig = createServerAuth({ runtimeConfig, db, requestOrigin }) as UserAuthConfig
   const trustedOrigins = withDevTrustedOrigins(userConfig.trustedOrigins, Boolean(hasExplicitSiteUrl))
 
   const hubSecondaryStorage = (runtimeConfig.auth as { hubSecondaryStorage?: boolean | 'custom' })?.hubSecondaryStorage
@@ -272,15 +298,30 @@ export function serverAuth(event?: H3Event): AuthInstance {
     console.warn(customSecondaryStorage.message)
   }
 
-  const auth = betterAuth({
+  if (!database) {
+    const cached = _authCache.get(cacheKey)
+    if (cached) {
+      if (requestContext)
+        requestContext[requestAuthKey] = cached
+      return cached
+    }
+  }
+
+  const authOptions: ResolvedAuthOptions = {
     ...userConfig,
-    ...(database && { database }),
-    ...(hubSecondaryStorage === true && { secondaryStorage: createSecondaryStorage() }),
+    ...(database ? { database } : {}),
+    ...(hubSecondaryStorage === true ? { secondaryStorage: createSecondaryStorage() } : {}),
     secret: runtimeConfig.betterAuthSecret,
     baseURL: siteUrl,
     trustedOrigins,
-  })
+  }
+  const auth = betterAuth(authOptions)
 
-  _authCache.set(cacheKey, auth)
+  if (requestContext)
+    requestContext[requestAuthKey] = auth
+
+  if (!database)
+    _authCache.set(cacheKey, auth)
+
   return auth
 }

--- a/src/runtime/server/virtual-modules.d.ts
+++ b/src/runtime/server/virtual-modules.d.ts
@@ -3,6 +3,11 @@ declare module '#auth/database' {
   export function createDatabase(...args: any[]): any
 }
 
+declare module '#imports' {
+  export function getRouteRules(event: any): any
+  export function useRuntimeConfig(): any
+}
+
 declare module '#auth/secondary-storage' {
   export function createSecondaryStorage(...args: any[]): any
 }

--- a/src/schema-generator.ts
+++ b/src/schema-generator.ts
@@ -64,10 +64,14 @@ declare global {
   var __nuxtBetterAuthDefineServerAuth: RuntimeDefineServerAuthFn | undefined
 }
 
-export async function loadUserAuthConfig(configPath: string, throwOnError = false): Promise<Partial<BetterAuthOptions>> {
+export async function loadUserAuthConfig(
+  configPath: string,
+  throwOnError = false,
+  alias?: Record<string, string>,
+): Promise<Partial<BetterAuthOptions>> {
   const { createJiti } = await import('jiti')
   const { defineServerAuth: runtimeDefineServerAuth } = await import('./runtime/config')
-  const jiti = createJiti(import.meta.url, { interopDefault: true, moduleCache: false })
+  const jiti = createJiti(import.meta.url, { interopDefault: true, moduleCache: false, alias })
   const schemaGlobals = globalThis as typeof globalThis & SchemaGeneratorGlobals
 
   if (!schemaGlobals.__nuxtBetterAuthDefineServerAuth) {

--- a/test/cases/layer-server-auth-typecheck-base/app/app.vue
+++ b/test/cases/layer-server-auth-typecheck-base/app/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <NuxtPage />
+</template>

--- a/test/cases/layer-server-auth-typecheck-base/app/auth.config.ts
+++ b/test/cases/layer-server-auth-typecheck-base/app/auth.config.ts
@@ -1,0 +1,3 @@
+import { defineClientAuth } from '@onmax/nuxt-better-auth/config'
+
+export default defineClientAuth({})

--- a/test/cases/layer-server-auth-typecheck-base/nuxt.config.ts
+++ b/test/cases/layer-server-auth-typecheck-base/nuxt.config.ts
@@ -1,0 +1,9 @@
+export default defineNuxtConfig({
+  modules: ['@nuxthub/core', '@onmax/nuxt-better-auth'],
+
+  hub: { db: 'sqlite' },
+
+  runtimeConfig: {
+    betterAuthSecret: 'test-secret-for-testing-only-32chars!',
+  },
+})

--- a/test/cases/layer-server-auth-typecheck-base/server/auth.config.ts
+++ b/test/cases/layer-server-auth-typecheck-base/server/auth.config.ts
@@ -1,0 +1,16 @@
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
+
+export default defineServerAuth(() => ({
+  emailAndPassword: {
+    enabled: true,
+  },
+  databaseHooks: {
+    session: {
+      create: {
+        async after() {
+          await sessionHookAfter()
+        },
+      },
+    },
+  },
+}))

--- a/test/cases/layer-server-auth-typecheck-base/server/utils/hooks.ts
+++ b/test/cases/layer-server-auth-typecheck-base/server/utils/hooks.ts
@@ -1,0 +1,3 @@
+export async function sessionHookAfter() {
+  return db
+}

--- a/test/cases/layer-server-auth-typecheck/.nuxtrc
+++ b/test/cases/layer-server-auth-typecheck/.nuxtrc
@@ -1,0 +1,1 @@
+setups.@onmax/nuxt-better-auth="0.0.2-alpha.31"

--- a/test/cases/layer-server-auth-typecheck/nuxt.config.ts
+++ b/test/cases/layer-server-auth-typecheck/nuxt.config.ts
@@ -1,0 +1,3 @@
+export default defineNuxtConfig({
+  extends: ['../layer-server-auth-typecheck-base'],
+})

--- a/test/cases/layer-server-auth-typecheck/tsconfig.json
+++ b/test/cases/layer-server-auth-typecheck/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./.nuxt/tsconfig.app.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.node.json"
+    }
+  ]
+}

--- a/test/cases/layer-server-auth-typecheck/tsconfig.json
+++ b/test/cases/layer-server-auth-typecheck/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "files": [],
   "references": [
     {
       "path": "./.nuxt/tsconfig.app.json"
@@ -13,5 +12,6 @@
     {
       "path": "./.nuxt/tsconfig.node.json"
     }
-  ]
+  ],
+  "files": []
 }

--- a/test/cases/plugins-type-inference/.nuxtrc
+++ b/test/cases/plugins-type-inference/.nuxtrc
@@ -1,1 +1,1 @@
-setups.@onmax/nuxt-better-auth="0.0.2-alpha.30"
+setups.@onmax/nuxt-better-auth="0.0.2-alpha.31"

--- a/test/cases/plugins-type-inference/tsconfig.type-check.json
+++ b/test/cases/plugins-type-inference/tsconfig.type-check.json
@@ -1,24 +1,11 @@
 {
+  "extends": "./.nuxt/tsconfig.server.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "lib": [
-      "ESNext",
-      "DOM"
-    ],
-    "baseUrl": ".",
-    "module": "preserve",
-    "moduleResolution": "bundler",
-    "paths": {
-      "#auth/client": ["./app/auth.config"],
-      "#auth/server": ["./server/auth.config"],
-      "#nuxt-better-auth": ["../../../src/runtime/types/augment"]
-    },
-    "types": [],
-    "strict": true,
-    "noEmit": true,
-    "skipLibCheck": true
+    "noEmit": true
   },
-  "files": [
+  "include": [
+    "./.nuxt/types/auth-database.d.ts",
+    "./.nuxt/types/auth-secondary-storage.d.ts",
     "./.nuxt/types/nuxt-better-auth-infer.d.ts",
     "./.nuxt/types/nuxt-better-auth-nitro.d.ts",
     "./typecheck-target.ts"

--- a/test/cases/server-auth-alias-typecheck/.nuxtrc
+++ b/test/cases/server-auth-alias-typecheck/.nuxtrc
@@ -1,0 +1,1 @@
+setups.@onmax/nuxt-better-auth="0.0.2-alpha.31"

--- a/test/cases/server-auth-alias-typecheck/app/app.vue
+++ b/test/cases/server-auth-alias-typecheck/app/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <NuxtPage />
+</template>

--- a/test/cases/server-auth-alias-typecheck/app/auth.config.ts
+++ b/test/cases/server-auth-alias-typecheck/app/auth.config.ts
@@ -1,0 +1,3 @@
+import { defineClientAuth } from '@onmax/nuxt-better-auth/config'
+
+export default defineClientAuth({})

--- a/test/cases/server-auth-alias-typecheck/nuxt.config.ts
+++ b/test/cases/server-auth-alias-typecheck/nuxt.config.ts
@@ -1,0 +1,9 @@
+export default defineNuxtConfig({
+  modules: ['@nuxthub/core', '@onmax/nuxt-better-auth'],
+
+  hub: { db: 'sqlite' },
+
+  runtimeConfig: {
+    betterAuthSecret: 'test-secret-for-testing-only-32chars!',
+  },
+})

--- a/test/cases/server-auth-alias-typecheck/server/auth.config.ts
+++ b/test/cases/server-auth-alias-typecheck/server/auth.config.ts
@@ -1,0 +1,17 @@
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
+import { sessionHookAfter } from '#server/utils/hooks'
+
+export default defineServerAuth(() => ({
+  emailAndPassword: {
+    enabled: true,
+  },
+  databaseHooks: {
+    session: {
+      create: {
+        async after() {
+          await sessionHookAfter()
+        },
+      },
+    },
+  },
+}))

--- a/test/cases/server-auth-alias-typecheck/server/auth.config.ts
+++ b/test/cases/server-auth-alias-typecheck/server/auth.config.ts
@@ -1,5 +1,5 @@
-import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 import { sessionHookAfter } from '#server/utils/hooks'
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 
 export default defineServerAuth(() => ({
   emailAndPassword: {

--- a/test/cases/server-auth-alias-typecheck/server/utils/hooks.ts
+++ b/test/cases/server-auth-alias-typecheck/server/utils/hooks.ts
@@ -1,0 +1,3 @@
+export async function sessionHookAfter() {
+  return db
+}

--- a/test/cases/server-auth-alias-typecheck/tsconfig.json
+++ b/test/cases/server-auth-alias-typecheck/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./.nuxt/tsconfig.app.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.node.json"
+    }
+  ]
+}

--- a/test/cases/server-auth-alias-typecheck/tsconfig.json
+++ b/test/cases/server-auth-alias-typecheck/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "files": [],
   "references": [
     {
       "path": "./.nuxt/tsconfig.app.json"
@@ -13,5 +12,6 @@
     {
       "path": "./.nuxt/tsconfig.node.json"
     }
-  ]
+  ],
+  "files": []
 }

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -16,5 +16,5 @@ describe('exports-snapshot', async () => {
 
     const manifest = await getPackageExportsManifest({ importMode: 'dist' })
     await expect(yaml.stringify(manifest.exports)).toMatchFileSnapshot('./exports/module.yaml')
-  }, 20_000)
+  }, 60_000)
 })

--- a/test/schema-generator.test.ts
+++ b/test/schema-generator.test.ts
@@ -135,6 +135,20 @@ describe('loadUserAuthConfig', () => {
     const result = await loadUserAuthConfig(configPath, false)
     expect(result).toEqual({ appName: 'Readonly', plugins: [{ id: 'test-plugin', schema: { user: { fields: {} } } }] })
   })
+
+  it('resolves aliased imports when provided', async () => {
+    const helperPath = join(TEST_DIR, 'helper.ts')
+    const configPath = join(TEST_DIR, 'aliased-config.ts')
+
+    writeFileSync(helperPath, `export function getPlugins() { return [] }`)
+    writeFileSync(configPath, `import { getPlugins } from '#server/helper'\nexport default defineServerAuth(() => ({ plugins: getPlugins() }))`)
+
+    const result = await loadUserAuthConfig(configPath, false, {
+      '#server': TEST_DIR,
+    })
+
+    expect(result).toEqual({ plugins: [] })
+  })
 })
 
 describe('defineServerAuth', () => {

--- a/test/server-auth-project-references-typecheck.test.ts
+++ b/test/server-auth-project-references-typecheck.test.ts
@@ -1,0 +1,43 @@
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+const env = {
+  ...process.env,
+  BETTER_AUTH_SECRET: 'test-secret-for-testing-only-32chars',
+}
+
+beforeAll(() => {
+  const build = spawnSync('pnpm', ['exec', 'nuxt-module-build', 'build'], {
+    cwd: fileURLToPath(new URL('..', import.meta.url)),
+    env,
+    encoding: 'utf8',
+  })
+  expect(build.status, `nuxt-module-build failed:\n${build.stdout}\n${build.stderr}`).toBe(0)
+})
+
+function runProjectReferenceTypecheck(fixtureDir: string) {
+  const prepare = spawnSync('npx', ['nuxi', 'prepare'], {
+    cwd: fixtureDir,
+    env,
+    encoding: 'utf8',
+  })
+  expect(prepare.status, `nuxi prepare failed:\n${prepare.stdout}\n${prepare.stderr}`).toBe(0)
+
+  const typecheck = spawnSync('npx', ['vue-tsc', '-b', '--noEmit', '--pretty', 'false'], {
+    cwd: fixtureDir,
+    env,
+    encoding: 'utf8',
+  })
+  expect(typecheck.status, `vue-tsc -b failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)
+}
+
+describe('server auth config project-reference typecheck regression #309', () => {
+  it('typechecks a layered auth config that uses Nitro auto-imported helpers', () => {
+    runProjectReferenceTypecheck(fileURLToPath(new URL('./cases/layer-server-auth-typecheck', import.meta.url)))
+  }, 60_000)
+
+  it('typechecks auth config imports that use the #server alias', () => {
+    runProjectReferenceTypecheck(fileURLToPath(new URL('./cases/server-auth-alias-typecheck', import.meta.url)))
+  }, 60_000)
+})

--- a/test/server-auth-project-references-typecheck.test.ts
+++ b/test/server-auth-project-references-typecheck.test.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { beforeAll, describe, expect, it } from 'vitest'
 
@@ -6,15 +7,21 @@ const env = {
   ...process.env,
   BETTER_AUTH_SECRET: 'test-secret-for-testing-only-32chars',
 }
+const rootDir = fileURLToPath(new URL('..', import.meta.url))
 
 beforeAll(() => {
+  if (existsSync(fileURLToPath(new URL('../dist/module.mjs', import.meta.url)))
+    && existsSync(fileURLToPath(new URL('../dist/runtime/config.js', import.meta.url)))) {
+    return
+  }
+
   const build = spawnSync('pnpm', ['exec', 'nuxt-module-build', 'build'], {
-    cwd: fileURLToPath(new URL('..', import.meta.url)),
+    cwd: rootDir,
     env,
     encoding: 'utf8',
   })
   expect(build.status, `nuxt-module-build failed:\n${build.stdout}\n${build.stderr}`).toBe(0)
-})
+}, 180_000)
 
 function runProjectReferenceTypecheck(fixtureDir: string) {
   const prepare = spawnSync('npx', ['nuxi', 'prepare'], {


### PR DESCRIPTION
fixes #309

This updates the generated type setup so `vue-tsc -b` can typecheck `server/auth.config.ts` when it depends on Nitro server authoring surfaces. Shared and node type projects now receive a compatibility shim for server auth context, the node project restores the server aliases it needs for auth-config imports, and schema generation resolves auth-config imports with Nuxt aliases so `#server/...` works during `nuxi prepare` as well.

It also adds focused regression coverage for the reported cases: a layered fixture that relies on Nitro auto-imported helpers, a fixture that imports helpers through `#server`, and a schema-loader test that verifies aliased imports resolve correctly.
