### PR TITLE
fix(runtime): trust dev loopback aliases for inferred origins

### DIFF
--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -242,9 +242,8 @@ function getRequestOrigin(request?: Request): string | undefined {
 
 function withDevTrustedOrigins(
   trustedOrigins: BetterAuthOptions['trustedOrigins'] | undefined,
-  hasExplicitSiteUrl: boolean,
 ): BetterAuthOptions['trustedOrigins'] | undefined {
-  if (!import.meta.dev || !hasExplicitSiteUrl)
+  if (!import.meta.dev)
     return trustedOrigins
 
   const devOrigins = getDevTrustedOrigins()
@@ -287,7 +286,7 @@ export function serverAuth(event?: H3Event): AuthInstance {
 
   const database = createDatabase(event)
   const userConfig = createServerAuth({ runtimeConfig, db, requestOrigin }) as UserAuthConfig
-  const trustedOrigins = withDevTrustedOrigins(userConfig.trustedOrigins, Boolean(hasExplicitSiteUrl))
+  const trustedOrigins = withDevTrustedOrigins(userConfig.trustedOrigins)
 
   const hubSecondaryStorage = (runtimeConfig.auth as { hubSecondaryStorage?: boolean | 'custom' })?.hubSecondaryStorage
   const customSecondaryStorage = resolveCustomSecondaryStorageRequirement(hubSecondaryStorage, userConfig.secondaryStorage != null, Boolean(import.meta.dev))

--- a/test/get-base-url.test.ts
+++ b/test/get-base-url.test.ts
@@ -179,9 +179,9 @@ function getRequestOrigin(request?: Request): string | undefined {
 
 function withDevTrustedOrigins(
   trustedOrigins: TrustedOrigins,
-  options: GetNitroOriginOptions & { hasExplicitSiteUrl: boolean },
+  options: GetNitroOriginOptions,
 ): TrustedOrigins {
-  if (!options.isDev || !options.hasExplicitSiteUrl)
+  if (!options.isDev)
     return trustedOrigins
 
   const devOrigins = getDevTrustedOrigins(options)
@@ -307,7 +307,6 @@ describe('withDevTrustedOrigins', () => {
     const trustedOrigins = withDevTrustedOrigins(undefined, {
       isDev: true,
       isPrerender: false,
-      hasExplicitSiteUrl: true,
       env: {
         __NUXT_DEV__: JSON.stringify({ proxy: { url: 'http://127.0.0.1:4123' } }),
       },
@@ -324,7 +323,6 @@ describe('withDevTrustedOrigins', () => {
     const trustedOrigins = withDevTrustedOrigins(['https://foo.workers.dev', 'http://localhost:3001'], {
       isDev: true,
       isPrerender: false,
-      hasExplicitSiteUrl: true,
       env: {
         NITRO_HOST: 'localhost',
         NITRO_PORT: '3001',
@@ -343,7 +341,6 @@ describe('withDevTrustedOrigins', () => {
     const trustedOrigins = withDevTrustedOrigins(trustedOriginsFn, {
       isDev: true,
       isPrerender: false,
-      hasExplicitSiteUrl: true,
       env: {
         NITRO_HOST: '192.168.1.50',
         NITRO_PORT: '3002',
@@ -363,7 +360,6 @@ describe('withDevTrustedOrigins', () => {
     const trustedOrigins = withDevTrustedOrigins(undefined, {
       isDev: true,
       isPrerender: false,
-      hasExplicitSiteUrl: true,
       env: {
         NITRO_HOST: '0.0.0.0',
         NITRO_PORT: '3000',
@@ -384,7 +380,6 @@ describe('withDevTrustedOrigins', () => {
     const trustedOrigins = withDevTrustedOrigins(undefined, {
       isDev: false,
       isPrerender: false,
-      hasExplicitSiteUrl: true,
       env: {
         NITRO_HOST: 'localhost',
         NITRO_PORT: '3000',
@@ -394,18 +389,42 @@ describe('withDevTrustedOrigins', () => {
     expect(trustedOrigins).toBeUndefined()
   })
 
-  it('does not augment when siteUrl is not explicit', () => {
-    const configuredTrustedOrigins = ['https://foo.workers.dev']
-    const trustedOrigins = withDevTrustedOrigins(configuredTrustedOrigins, {
+  it('augments even when siteUrl is inferred', async () => {
+    const trustedOrigins = withDevTrustedOrigins(['https://foo.workers.dev'], {
       isDev: true,
       isPrerender: false,
-      hasExplicitSiteUrl: false,
       env: {
         NITRO_HOST: 'localhost',
         NITRO_PORT: '3000',
       },
     })
 
-    expect(trustedOrigins).toBe(configuredTrustedOrigins)
+    expect(typeof trustedOrigins).toBe('function')
+    if (typeof trustedOrigins !== 'function')
+      throw new Error('trustedOrigins should be a function')
+
+    const resolvedOrigins = await trustedOrigins()
+    expect(resolvedOrigins).toEqual(['https://foo.workers.dev', 'http://localhost:3000'])
+  })
+
+  it('adds loopback request origins regardless of alias order', async () => {
+    const trustedOrigins = withDevTrustedOrigins(undefined, {
+      isDev: true,
+      isPrerender: false,
+      env: {
+        NITRO_HOST: 'localhost',
+        NITRO_PORT: '3000',
+      },
+    })
+
+    expect(typeof trustedOrigins).toBe('function')
+    if (typeof trustedOrigins !== 'function')
+      throw new Error('trustedOrigins should be a function')
+
+    const localhostRequestOrigins = await trustedOrigins(new Request('http://localhost:3000/api/auth/sign-in'))
+    const loopbackRequestOrigins = await trustedOrigins(new Request('http://127.0.0.1:3000/api/auth/sign-in'))
+
+    expect(localhostRequestOrigins).toEqual(['http://localhost:3000'])
+    expect(loopbackRequestOrigins).toEqual(['http://localhost:3000', 'http://127.0.0.1:3000'])
   })
 })


### PR DESCRIPTION
This makes dev trusted-origin expansion request-aware even when `siteUrl` is inferred instead of explicitly configured. That keeps `localhost`/`127.0.0.1` loopback aliases from tripping Better Auth origin checks once cookie-bearing auth requests start flowing.

The test coverage now reflects the intended behavior in the helper-level runtime tests, while the existing dev integration test continues to cover the explicit-`siteUrl` path.