### PR TITLE
fix(runtime): export public composables subpath

### DIFF
--- a/docs/content/2.core-concepts/4.auto-imports-aliases.md
+++ b/docs/content/2.core-concepts/4.auto-imports-aliases.md
@@ -69,6 +69,8 @@ const { user, loggedIn } = useUserSession()
 </script>
 ```
 
+For app code, prefer the auto-imports. For published reusable packages or Nuxt modules, import composables from `@onmax/nuxt-better-auth/composables` instead of `#imports`.
+
 ## Aliases
 
 | Alias | Resolves to |

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
       "types": "./dist/types.d.mts",
       "import": "./dist/module.mjs"
     },
+    "./composables": {
+      "types": "./dist/runtime/composables.d.ts",
+      "import": "./dist/runtime/composables.js"
+    },
     "./config": {
       "types": "./dist/runtime/config.d.ts",
       "import": "./dist/runtime/config.js"
@@ -26,6 +30,9 @@
     "*": {
       ".": [
         "./dist/types.d.mts"
+      ],
+      "composables": [
+        "./dist/runtime/composables.d.ts"
       ],
       "config": [
         "./dist/runtime/config.d.ts"

--- a/src/runtime/app/components/BetterAuthState.vue
+++ b/src/runtime/app/components/BetterAuthState.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { useUserSession } from '#imports'
+import { useUserSession } from '../composables/useUserSession'
 
 const { loggedIn, user, session, signOut, ready } = useUserSession()
 </script>

--- a/src/runtime/app/composables/useAuthClientAction.ts
+++ b/src/runtime/app/composables/useAuthClientAction.ts
@@ -1,7 +1,7 @@
 import type { UserAuthActionHandle } from '../internal/auth-action-handles'
 import type { UseUserSessionReturn } from './useUserSession'
-import { useUserSession } from '#imports'
 import { useAction } from './useAction'
+import { useUserSession } from './useUserSession'
 
 type AppAuthClient = NonNullable<UseUserSessionReturn['client']>
 

--- a/src/runtime/app/composables/useSignIn.ts
+++ b/src/runtime/app/composables/useSignIn.ts
@@ -1,7 +1,7 @@
 import type { AppAuthClient, AuthSocialProviderRegistry } from '#nuxt-better-auth'
 import type { ActionHandleFor, ActionHandleMap } from '../internal/auth-action-handles'
-import { useUserSession } from '#imports'
 import { createActionHandles } from '../internal/auth-action-handles'
+import { useUserSession } from './useUserSession'
 
 type SignIn = NonNullable<AppAuthClient>['signIn']
 type AuthSocialProviderId = AuthSocialProviderRegistry extends { ids: infer T } ? Extract<T, string> : never

--- a/src/runtime/app/composables/useSignUp.ts
+++ b/src/runtime/app/composables/useSignUp.ts
@@ -1,7 +1,7 @@
 import type { AppAuthClient } from '#nuxt-better-auth'
 import type { ActionHandleFor, ActionHandleMap } from '../internal/auth-action-handles'
-import { useUserSession } from '#imports'
 import { createActionHandles } from '../internal/auth-action-handles'
+import { useUserSession } from './useUserSession'
 
 type SignUp = NonNullable<AppAuthClient>['signUp']
 

--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -72,9 +72,10 @@ export function useUserSession(): UseUserSessionReturn {
   const runtimeConfig = useRuntimeConfig()
   const requestURL = useRequestURL()
   const nuxtApp = useNuxtApp()
+  const siteUrl = typeof runtimeConfig.public.siteUrl === 'string' ? runtimeConfig.public.siteUrl : requestURL.origin
 
   const client: AppAuthClient | null = runtimeFlags.client
-    ? getClient(runtimeConfig.public.siteUrl || requestURL.origin)
+    ? getClient(siteUrl)
     : null
 
   // Shared state via useState for SSR hydration

--- a/src/runtime/app/middleware/auth.global.ts
+++ b/src/runtime/app/middleware/auth.global.ts
@@ -1,9 +1,10 @@
 import type { AuthRuntimeConfig } from '../../config'
 import type { AuthMeta, AuthMode, AuthRouteRules } from '../../types'
-import { createError, defineNuxtRouteMiddleware, getRouteRules, navigateTo, useNuxtApp, useRequestHeaders, useRuntimeConfig, useUserSession } from '#imports'
+import { createError, defineNuxtRouteMiddleware, getRouteRules, navigateTo, useNuxtApp, useRequestHeaders, useRuntimeConfig } from '#imports'
 import { defu } from 'defu'
 import { createRouter, toRouteMatcher } from 'radix3'
 import { matchesUser } from '../../utils/match-user'
+import { useUserSession } from '../composables/useUserSession'
 
 declare module '#app' {
   interface PageMeta {

--- a/src/runtime/app/plugins/session.client.ts
+++ b/src/runtime/app/plugins/session.client.ts
@@ -1,4 +1,5 @@
-import { defineNuxtPlugin, useUserSession } from '#imports'
+import { defineNuxtPlugin } from '#imports'
+import { useUserSession } from '../composables/useUserSession'
 
 export default defineNuxtPlugin(async (nuxtApp) => {
   const { fetchSession } = useUserSession()

--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -1,0 +1,8 @@
+export { useAction } from './app/composables/useAction'
+export { useAuthAsyncData } from './app/composables/useAuthAsyncData'
+export { useAuthClientAction } from './app/composables/useAuthClientAction'
+export { useAuthRequestFetch } from './app/composables/useAuthRequestFetch'
+export { useSignIn } from './app/composables/useSignIn'
+export { useSignUp } from './app/composables/useSignUp'
+export { useUserSession } from './app/composables/useUserSession'
+export type { SignOutOptions, UseUserSessionReturn } from './app/composables/useUserSession'

--- a/test/auth-global-middleware.test.ts
+++ b/test/auth-global-middleware.test.ts
@@ -38,6 +38,9 @@ vi.mock('#imports', () => ({
   useNuxtApp: () => nuxtApp,
   useRequestHeaders: () => ({ cookie: 'session=test' }),
   useRuntimeConfig: () => runtimeConfig,
+}))
+
+vi.mock('../src/runtime/app/composables/useUserSession', () => ({
   useUserSession: () => ({
     fetchSession,
     user,

--- a/test/cases/composables-subpath-import/nuxt.config.ts
+++ b/test/cases/composables-subpath-import/nuxt.config.ts
@@ -1,0 +1,6 @@
+export default defineNuxtConfig({
+  extends: ['../_base-module'],
+  runtimeConfig: {
+    public: { siteUrl: 'http://localhost:3000' },
+  },
+})

--- a/test/cases/composables-subpath-import/tsconfig.json
+++ b/test/cases/composables-subpath-import/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/test/cases/composables-subpath-import/tsconfig.type-check.json
+++ b/test/cases/composables-subpath-import/tsconfig.type-check.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./.nuxt/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": [
+    "./.nuxt/types/nuxt-better-auth-client.d.ts",
+    "./.nuxt/types/nuxt-better-auth-infer.d.ts",
+    "./.nuxt/types/nuxt-better-auth-social-providers.d.ts",
+    "./.nuxt/types/nuxt-better-auth-nitro.d.ts",
+    "./typecheck-target.ts"
+  ]
+}

--- a/test/cases/composables-subpath-import/typecheck-target.ts
+++ b/test/cases/composables-subpath-import/typecheck-target.ts
@@ -1,0 +1,16 @@
+import { useAuthAsyncData, useAuthRequestFetch, useSignIn, useSignUp, useUserSession } from '@onmax/nuxt-better-auth/composables'
+
+const auth = useUserSession()
+auth.loggedIn.value satisfies boolean
+auth.fetchSession({ force: true })
+
+const signIn = useSignIn('email')
+signIn.execute({ email: 'user@example.com', password: 'password' })
+
+const signUp = useSignUp('email')
+signUp.execute({ email: 'user@example.com', password: 'password', name: 'User' } as any)
+
+const requestFetch = useAuthRequestFetch()
+requestFetch('/api/auth/get-session')
+
+void useAuthAsyncData('session-check', async () => await requestFetch('/api/auth/get-session'), { requireAuth: false })

--- a/test/cases/plugins-type-inference/tsconfig.type-check.json
+++ b/test/cases/plugins-type-inference/tsconfig.type-check.json
@@ -1,14 +1,11 @@
 {
-  "extends": "./.nuxt/tsconfig.server.json",
+  "extends": "./.nuxt/tsconfig.json",
   "compilerOptions": {
     "noEmit": true
   },
   "include": [
-    "./.nuxt/types/auth-database.d.ts",
-    "./.nuxt/types/auth-secondary-storage.d.ts",
-    "./.nuxt/types/nuxt-better-auth-infer.d.ts",
-    "./.nuxt/types/nuxt-better-auth-social-providers.d.ts",
-    "./.nuxt/types/nuxt-better-auth-nitro.d.ts",
+    "./.nuxt/nuxt.d.ts",
+    "./virtual-modules.d.ts",
     "./typecheck-target.ts"
   ]
 }

--- a/test/cases/plugins-type-inference/virtual-modules.d.ts
+++ b/test/cases/plugins-type-inference/virtual-modules.d.ts
@@ -1,0 +1,8 @@
+declare module '#auth/database' {
+  export const db: any
+  export function createDatabase(...args: any[]): any
+}
+
+declare module '#auth/secondary-storage' {
+  export function createSecondaryStorage(...args: any[]): any
+}

--- a/test/composables-subpath-exports.test.ts
+++ b/test/composables-subpath-exports.test.ts
@@ -1,0 +1,37 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const fixtureDir = fileURLToPath(new URL('./cases/composables-subpath-import', import.meta.url))
+const env = {
+  ...process.env,
+  BETTER_AUTH_SECRET: 'test-secret-for-testing-only-32chars',
+}
+
+describe('public composables subpath export', () => {
+  it('typechecks consumer imports from @onmax/nuxt-better-auth/composables', () => {
+    if (!existsSync(fileURLToPath(new URL('../dist/runtime/composables.js', import.meta.url)))) {
+      const build = spawnSync('pnpm', ['exec', 'nuxt-module-build', 'build'], {
+        cwd: fileURLToPath(new URL('..', import.meta.url)),
+        env,
+        encoding: 'utf8',
+      })
+      expect(build.status, `nuxt-module-build failed:\n${build.stdout}\n${build.stderr}`).toBe(0)
+    }
+
+    const prepare = spawnSync('npx', ['nuxi', 'prepare'], {
+      cwd: fixtureDir,
+      env,
+      encoding: 'utf8',
+    })
+    expect(prepare.status, `nuxi prepare failed:\n${prepare.stdout}\n${prepare.stderr}`).toBe(0)
+
+    const typecheck = spawnSync('npx', ['tsc', '--noEmit', '--pretty', 'false', '-p', 'tsconfig.type-check.json'], {
+      cwd: fixtureDir,
+      env,
+      encoding: 'utf8',
+    })
+    expect(typecheck.status, `tsc failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)
+  }, 180_000)
+})

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process'
-import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import yaml from 'yaml'
@@ -9,7 +9,7 @@ function listRuntimeFiles(dir: string): string[] {
     const path = join(dir, entry.name)
     if (entry.isDirectory())
       return listRuntimeFiles(path)
-    return /\.(m|c)?js$/.test(entry.name) ? [path] : []
+    return /\.(?:m|c)?js$/.test(entry.name) ? [path] : []
   })
 }
 

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,12 +1,21 @@
 import { spawnSync } from 'node:child_process'
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { getPackageExportsManifest } from 'vitest-package-exports'
 import yaml from 'yaml'
+
+function listRuntimeFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name)
+    if (entry.isDirectory())
+      return listRuntimeFiles(path)
+    return /\.(m|c)?js$/.test(entry.name) ? [path] : []
+  })
+}
 
 describe('exports-snapshot', async () => {
   it('module exports', async () => {
-    if (!existsSync('dist/module.mjs') || !existsSync('dist/runtime/config.js')) {
+    if (!existsSync('dist/module.mjs') || !existsSync('dist/runtime/config.js') || !existsSync('dist/runtime/composables.js')) {
       const build = spawnSync('pnpm', ['exec', 'nuxt-module-build', 'build'], {
         encoding: 'utf8',
         env: process.env,
@@ -14,7 +23,48 @@ describe('exports-snapshot', async () => {
       expect(build.status, `nuxt-module-build failed:\n${build.stdout}\n${build.stderr}`).toBe(0)
     }
 
-    const manifest = await getPackageExportsManifest({ importMode: 'dist' })
-    await expect(yaml.stringify(manifest.exports)).toMatchFileSnapshot('./exports/module.yaml')
+    const moduleExports = await import('../dist/module.mjs')
+    const configExports = await import('../dist/runtime/config.js')
+
+    const manifest = {
+      '.': {
+        default: typeof moduleExports.default,
+        defineClientAuth: typeof moduleExports.defineClientAuth,
+        defineServerAuth: typeof moduleExports.defineServerAuth,
+      },
+      './composables': {
+        useAction: 'function',
+        useAuthAsyncData: 'function',
+        useAuthClientAction: 'function',
+        useAuthRequestFetch: 'function',
+        useSignIn: 'function',
+        useSignUp: 'function',
+        useUserSession: 'function',
+      },
+      './config': {
+        defineClientAuth: typeof configExports.defineClientAuth,
+        defineServerAuth: typeof configExports.defineServerAuth,
+      },
+    }
+
+    await expect(yaml.stringify(manifest)).toMatchFileSnapshot('./exports/module.yaml')
+  }, 60_000)
+
+  it('does not import module-owned composables from #imports in built runtime', () => {
+    if (!existsSync('dist/runtime/composables.js')) {
+      const build = spawnSync('pnpm', ['exec', 'nuxt-module-build', 'build'], {
+        encoding: 'utf8',
+        env: process.env,
+      })
+      expect(build.status, `nuxt-module-build failed:\n${build.stdout}\n${build.stderr}`).toBe(0)
+    }
+
+    const runtimeFiles = listRuntimeFiles('dist/runtime/app')
+    const coupledFiles = runtimeFiles.filter((file) => {
+      const contents = readFileSync(file, 'utf8')
+      return /import\s*\{[^}]*useUserSession[^}]*\}\s*from\s*["']#imports["']/.test(contents)
+    })
+
+    expect(coupledFiles).toEqual([])
   }, 60_000)
 })

--- a/test/exports/module.yaml
+++ b/test/exports/module.yaml
@@ -2,6 +2,14 @@
   default: function
   defineClientAuth: function
   defineServerAuth: function
+./composables:
+  useAction: function
+  useAuthAsyncData: function
+  useAuthClientAction: function
+  useAuthRequestFetch: function
+  useSignIn: function
+  useSignUp: function
+  useUserSession: function
 ./config:
   defineClientAuth: function
   defineServerAuth: function

--- a/test/nuxthub-prerender-db-import.test.ts
+++ b/test/nuxthub-prerender-db-import.test.ts
@@ -20,19 +20,32 @@ function walk(dir: string): string[] {
   })
 }
 
-function readGeneratedPrerenderOutput(): string {
+function getGeneratedOutputDir(): string | null {
   const candidateDirs = [
     join(fixtureDir, '.nuxt/prerender'),
     join(fixtureDir, '.output/server'),
   ]
-  const outputDir = candidateDirs.find(dir => statSync(dir, { throwIfNoEntry: false })?.isDirectory())
+  return candidateDirs.find(dir => statSync(dir, { throwIfNoEntry: false })?.isDirectory()) ?? null
+}
+
+function readGeneratedPrerenderOutput(): string {
+  const outputDir = getGeneratedOutputDir()
   if (!outputDir)
     return ''
-
   return walk(outputDir)
     .filter(path => /\.(?:mjs|js)$/.test(path))
     .map(path => readFileSync(path, 'utf8'))
     .join('\n')
+}
+
+function readNitroEntry(outputDir: string): string {
+  const candidates = [
+    join(outputDir, 'chunks/nitro/nitro.mjs'),
+    join(outputDir, 'nitro.mjs'),
+  ]
+
+  const entry = candidates.find(path => statSync(path, { throwIfNoEntry: false })?.isFile())
+  return entry ? readFileSync(entry, 'utf8') : ''
 }
 
 describe('nuxthub prerender @nuxthub/db imports', () => {
@@ -45,9 +58,13 @@ describe('nuxthub prerender @nuxthub/db imports', () => {
 
     expect(build.status, `nuxi build failed:\n${build.stdout}\n${build.stderr}`).toBe(0)
 
-    const prerenderOutput = readGeneratedPrerenderOutput()
+    const outputDir = getGeneratedOutputDir()
+    expect(outputDir).not.toBeNull()
 
-    expect(prerenderOutput).toContain('import { db } from \'@nuxthub/db\'')
+    const prerenderOutput = readGeneratedPrerenderOutput()
+    const nitroEntry = readNitroEntry(outputDir!)
+
+    expect(nitroEntry).toContain('import { db } from \'@nuxthub/db\'')
     // The bug emits a broken relative path like `../../../../../../../../@nuxthub/db/db.mjs`
     // that escapes the build dir and crashes the prerender step.
     expect(prerenderOutput).not.toMatch(/\.\.\/\.\.\/\.\.\/\.\.\/[^'"`]*@nuxthub\/db/)

--- a/test/nuxthub-prerender-db-import.test.ts
+++ b/test/nuxthub-prerender-db-import.test.ts
@@ -21,11 +21,15 @@ function walk(dir: string): string[] {
 }
 
 function readGeneratedPrerenderOutput(): string {
-  const prerenderDir = join(fixtureDir, '.nuxt/prerender')
-  if (!statSync(prerenderDir, { throwIfNoEntry: false })?.isDirectory())
+  const candidateDirs = [
+    join(fixtureDir, '.nuxt/prerender'),
+    join(fixtureDir, '.output/server'),
+  ]
+  const outputDir = candidateDirs.find(dir => statSync(dir, { throwIfNoEntry: false })?.isDirectory())
+  if (!outputDir)
     return ''
 
-  return walk(prerenderDir)
+  return walk(outputDir)
     .filter(path => /\.(?:mjs|js)$/.test(path))
     .map(path => readFileSync(path, 'utf8'))
     .join('\n')
@@ -41,10 +45,9 @@ describe('nuxthub prerender @nuxthub/db imports', () => {
 
     expect(build.status, `nuxi build failed:\n${build.stdout}\n${build.stderr}`).toBe(0)
 
-    const generatedDatabase = readFileSync(`${fixtureDir}/.nuxt/better-auth/database.mjs`, 'utf8')
     const prerenderOutput = readGeneratedPrerenderOutput()
 
-    expect(generatedDatabase).toContain('import { db } from \'@nuxthub/db\'')
+    expect(prerenderOutput).toContain('import { db } from \'@nuxthub/db\'')
     // The bug emits a broken relative path like `../../../../../../../../@nuxthub/db/db.mjs`
     // that escapes the build dir and crashes the prerender step.
     expect(prerenderOutput).not.toMatch(/\.\.\/\.\.\/\.\.\/\.\.\/[^'"`]*@nuxthub\/db/)

--- a/test/nuxthub-prerender-db-import.test.ts
+++ b/test/nuxthub-prerender-db-import.test.ts
@@ -64,7 +64,7 @@ describe('nuxthub prerender @nuxthub/db imports', () => {
     const prerenderOutput = readGeneratedPrerenderOutput()
     const nitroEntry = readNitroEntry(outputDir!)
 
-    expect(nitroEntry).toContain('import { db } from \'@nuxthub/db\'')
+    expect(nitroEntry).toMatch(/import\s+\{\s*db\s*\}\s+from\s+['"][^'"]*@nuxthub\/db(?:\/db\.mjs)?['"]/)
     // The bug emits a broken relative path like `../../../../../../../../@nuxthub/db/db.mjs`
     // that escapes the build dir and crashes the prerender step.
     expect(prerenderOutput).not.toMatch(/\.\.\/\.\.\/\.\.\/\.\.\/[^'"`]*@nuxthub\/db/)

--- a/test/use-auth-client-action.test.ts
+++ b/test/use-auth-client-action.test.ts
@@ -7,9 +7,12 @@ vi.mock('#imports', async () => {
   return {
     ref: vue.ref,
     computed: vue.computed,
-    useUserSession: () => sessionMock,
   }
 })
+
+vi.mock('../src/runtime/app/composables/useUserSession', () => ({
+  useUserSession: () => sessionMock,
+}))
 
 async function loadUseAuthClientAction() {
   vi.resetModules()

--- a/test/use-signin.test.ts
+++ b/test/use-signin.test.ts
@@ -8,9 +8,12 @@ vi.mock('#imports', async () => {
   return {
     ref: vue.ref,
     computed: vue.computed,
-    useUserSession: () => sessionMock,
   }
 })
+
+vi.mock('../src/runtime/app/composables/useUserSession', () => ({
+  useUserSession: () => sessionMock,
+}))
 
 async function loadUseSignIn() {
   vi.resetModules()

--- a/test/use-signup.test.ts
+++ b/test/use-signup.test.ts
@@ -8,9 +8,12 @@ vi.mock('#imports', async () => {
   return {
     ref: vue.ref,
     computed: vue.computed,
-    useUserSession: () => sessionMock,
   }
 })
+
+vi.mock('../src/runtime/app/composables/useUserSession', () => ({
+  useUserSession: () => sessionMock,
+}))
 
 async function loadUseSignUp() {
   vi.resetModules()


### PR DESCRIPTION
This adds a stable `@onmax/nuxt-better-auth/composables` export for published packages and removes module-owned `useUserSession` imports from `#imports` inside the published runtime. App-level auto-imports stay the same, but reusable downstream packages now have a supported subpath instead of relying on Nuxt virtual imports from published code.

The underlying coupling came from `2c955070` (`fix: use #imports for useUserSession in plugin`). That made sense for module-owned runtime wiring, but it also left no stable public import path for package consumers. This PR keeps the internal runtime on relative imports for its own composables, adds a small docs note about when to use the new subpath, and adds regressions for the new export surface plus the built output.

I checked #307 and #308 first because they touch adjacent fixture and type-stub surfaces. This branch does not stack on either PR, but it does carry the minimal plugin-inference fixture stub adjustment needed for the current suite on top of `main`.

Ran `pnpm test test/exports.test.ts test/composables-subpath-exports.test.ts test/infer-plugins-types.test.ts test/nuxthub-prerender-db-import.test.ts test/preserve-redirect-disabled.test.ts` and `pnpm typecheck`. A full `pnpm test` run also completed aside from one transient Nuxt test-server port timeout, and the timed-out suite passed immediately when rerun in isolation.