### PR TITLE
fix(auth): scope hyperdrive postgres adapters per request

### DIFF
--- a/src/module/templates.ts
+++ b/src/module/templates.ts
@@ -23,6 +23,92 @@ interface BuildDatabaseCodeInput {
 
 export function buildDatabaseCode(input: BuildDatabaseCodeInput): string {
   if (input.provider === 'nuxthub') {
+    if (input.hubDialect === 'postgresql') {
+      return `import { db } from '@nuxthub/db'
+import * as schema from './schema.${input.hubDialect}.mjs'
+import { drizzleAdapter } from 'better-auth/adapters/drizzle'
+import { drizzle } from 'drizzle-orm/postgres-js'
+import postgres from 'postgres'
+
+const dialect = 'pg'
+const requestDatabaseKey = Symbol.for('nuxt-better-auth.requestDatabase')
+const fallbackRequestDatabaseContext = new WeakMap()
+
+function getRequestDatabaseContext(event) {
+  const eventWithContext = event
+  if (eventWithContext?.context && typeof eventWithContext.context === 'object')
+    return eventWithContext.context
+
+  let context = fallbackRequestDatabaseContext.get(event)
+  if (!context) {
+    context = {}
+    fallbackRequestDatabaseContext.set(event, context)
+  }
+  return context
+}
+
+function createHyperdriveAdapter(client) {
+  return drizzleAdapter(drizzle({ client, schema }), { provider: dialect, schema, usePlural: ${input.usePlural}, camelCase: ${input.camelCase} })
+}
+
+function registerClientCleanup(event, client) {
+  const response = event?.node?.res
+  if (!response || typeof response.once !== 'function')
+    return
+
+  let closed = false
+
+  const cleanup = () => {
+    if (closed)
+      return
+
+    closed = true
+    const close = client.end({ timeout: 0 }).catch(() => {})
+    const waitUntil = event?.waitUntil || event?.req?.waitUntil || event?.node?.req?.waitUntil
+    if (typeof waitUntil === 'function')
+      waitUntil.call(event?.req || event?.node?.req || event, close)
+    else
+      void close
+  }
+
+  response.once('finish', cleanup)
+  response.once('close', cleanup)
+}
+
+export function createDatabase(event) {
+  const hyperdrive = process.env.POSTGRES || globalThis.__env__?.POSTGRES || globalThis.POSTGRES
+  if (!hyperdrive?.connectionString)
+    return drizzleAdapter(db, { provider: dialect, schema, usePlural: ${input.usePlural}, camelCase: ${input.camelCase} })
+
+  if (event) {
+    const context = getRequestDatabaseContext(event)
+    const cached = context[requestDatabaseKey]
+    if (cached)
+      return cached
+
+    const client = postgres(hyperdrive.connectionString, {
+      prepare: false,
+      onnotice: () => {},
+      max: 1,
+    })
+    const database = createHyperdriveAdapter(client)
+
+    context[requestDatabaseKey] = database
+    registerClientCleanup(event, client)
+    return database
+  }
+
+  const client = postgres(hyperdrive.connectionString, {
+    prepare: false,
+    onnotice: () => {},
+    max: 1,
+  })
+
+  return createHyperdriveAdapter(client)
+}
+export { db }`
+    }
+
     return `import { db } from '@nuxthub/db'
 import * as schema from './schema.${input.hubDialect}.mjs'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'

--- a/test/nuxthub-hyperdrive-database-template.test.ts
+++ b/test/nuxthub-hyperdrive-database-template.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { buildDatabaseCode } from '../src/module/templates'
+
+describe('buildDatabaseCode', () => {
+  it('uses request-scoped hyperdrive clients with cleanup for nuxthub postgresql', () => {
+    const code = buildDatabaseCode({
+      provider: 'nuxthub',
+      hubDialect: 'postgresql',
+      usePlural: false,
+      camelCase: true,
+    })
+
+    expect(code).not.toContain('from \'#imports\'')
+    expect(code).not.toContain('from \'nitropack/runtime\'')
+    expect(code).toContain('const requestDatabaseKey = Symbol.for(\'nuxt-better-auth.requestDatabase\')')
+    expect(code).toContain('const response = event?.node?.res')
+    expect(code).toContain('response.once(\'finish\', cleanup)')
+    expect(code).toContain('response.once(\'close\', cleanup)')
+    expect(code).toContain('client.end({ timeout: 0 })')
+    expect(code).toContain('event?.waitUntil || event?.req?.waitUntil || event?.node?.req?.waitUntil')
+    expect(code).toContain('waitUntil.call(event?.req || event?.node?.req || event, close)')
+    expect(code).toContain('prepare: false')
+    expect(code).toContain('max: 1')
+    expect(code).toContain('export function createDatabase(event)')
+    expect(code).not.toContain('function resolveBetterAuthDb()')
+  })
+
+  it('keeps the existing generated adapter path for non-postgresql nuxthub databases', () => {
+    const code = buildDatabaseCode({
+      provider: 'nuxthub',
+      hubDialect: 'sqlite',
+      usePlural: false,
+      camelCase: true,
+    })
+
+    expect(code).toContain('import { db } from \'@nuxthub/db\'')
+    expect(code).toContain('drizzleAdapter(db, { provider: dialect')
+    expect(code).not.toContain('import postgres from \'postgres\'')
+    expect(code).not.toContain('response.once(\'finish\'')
+  })
+})

--- a/test/server-auth-database-cache.test.ts
+++ b/test/server-auth-database-cache.test.ts
@@ -1,0 +1,119 @@
+import type { H3Event } from 'h3'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const betterAuthMock = vi.fn()
+const createDatabaseMock = vi.fn()
+const createServerAuthMock = vi.fn()
+const useRuntimeConfigMock = vi.fn()
+
+vi.mock('#auth/database', () => ({
+  createDatabase: createDatabaseMock,
+  db: { query: {} },
+}))
+
+vi.mock('#auth/secondary-storage', () => ({
+  createSecondaryStorage: vi.fn(() => undefined),
+}))
+
+vi.mock('#auth/server', () => ({
+  default: createServerAuthMock,
+}))
+
+vi.mock('better-auth', () => ({
+  betterAuth: betterAuthMock,
+}))
+
+vi.mock('nitropack/runtime', () => ({
+  useRuntimeConfig: useRuntimeConfigMock,
+}))
+
+type MockEvent = H3Event & {
+  context: Record<string | symbol, unknown>
+}
+
+function createEvent(): MockEvent {
+  return {
+    context: {},
+    node: {
+      req: { headers: { host: 'example.com' }, socket: { encrypted: true } },
+      res: { getHeader: () => undefined, setHeader: () => undefined },
+    },
+  } as unknown as MockEvent
+}
+
+describe('serverAuth database cache behavior', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+
+    useRuntimeConfigMock.mockReturnValue({
+      public: {
+        siteUrl: 'https://example.com',
+      },
+      auth: {},
+      betterAuthSecret: 'test-secret',
+    })
+
+    createServerAuthMock.mockReturnValue({
+      trustedOrigins: undefined,
+    })
+
+    betterAuthMock.mockImplementation((options: Record<string, unknown>) => ({
+      options,
+      marker: Symbol('auth-instance'),
+    }))
+  })
+
+  it('reuses the same auth instance within a request when a database adapter is active', async () => {
+    createDatabaseMock.mockReturnValue({ kind: 'database-adapter' })
+
+    const { serverAuth } = await import('../src/runtime/server/utils/auth')
+    const event = createEvent()
+
+    const first = serverAuth(event)
+    const second = serverAuth(event)
+
+    expect(first).toBe(second)
+    expect(createDatabaseMock).toHaveBeenCalledTimes(1)
+    expect(betterAuthMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('creates a fresh auth instance for each request when a database adapter is active', async () => {
+    createDatabaseMock.mockReturnValue({ kind: 'database-adapter' })
+
+    const { serverAuth } = await import('../src/runtime/server/utils/auth')
+
+    const first = serverAuth(createEvent())
+    const second = serverAuth(createEvent())
+
+    expect(first).not.toBe(second)
+    expect(createDatabaseMock).toHaveBeenCalledTimes(2)
+    expect(betterAuthMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('creates a fresh auth instance without request context when a database adapter is active', async () => {
+    createDatabaseMock.mockReturnValue({ kind: 'database-adapter' })
+
+    const { serverAuth } = await import('../src/runtime/server/utils/auth')
+
+    const first = serverAuth()
+    const second = serverAuth()
+
+    expect(first).not.toBe(second)
+    expect(createDatabaseMock).toHaveBeenCalledTimes(2)
+    expect(betterAuthMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps caching auth instances when no database adapter is configured', async () => {
+    createDatabaseMock.mockReturnValue(undefined)
+
+    const { serverAuth } = await import('../src/runtime/server/utils/auth')
+
+    const first = serverAuth()
+    const second = serverAuth()
+
+    expect(first).toBe(second)
+    expect(createDatabaseMock).toHaveBeenCalledTimes(2)
+    expect(betterAuthMock).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
Closes #294

This extracts the Hyperdrive PostgreSQL adapter fix from #295 into a focused PR. It keeps the request-scoped adapter creation and cleanup logic plus the direct regression tests, while leaving the server-auth type/reference cleanup in #295 for later follow-up review.