### PR TITLE
fix(runtime): make useUserSession store-forwarding SSR-safe

### DIFF
--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -54,6 +54,10 @@ function getRuntimeFlags(): RuntimeFlags {
   return { client: Boolean(import.meta.client), server: Boolean(import.meta.server) }
 }
 
+function isReactiveProbeKey(prop: PropertyKey): boolean {
+  return typeof prop === 'symbol' || SSR_SAFE_ACTION_METADATA_KEYS.has(prop)
+}
+
 function createServerOnlyActionMethod(path: string) {
   const method = async () => {
     throw new Error(`${path}() can only be called on client-side`)
@@ -61,9 +65,7 @@ function createServerOnlyActionMethod(path: string) {
 
   return new Proxy(method, {
     get(target, prop, receiver) {
-      if (typeof prop === 'symbol')
-        return undefined
-      if (SSR_SAFE_ACTION_METADATA_KEYS.has(prop))
+      if (isReactiveProbeKey(prop))
         return undefined
       return Reflect.get(target, prop, receiver)
     },
@@ -71,16 +73,24 @@ function createServerOnlyActionMethod(path: string) {
 }
 
 function createServerOnlyActionNamespace(path: string) {
+  const cache = new Map<string, ReturnType<typeof createServerOnlyActionMethod>>()
   return new Proxy({}, {
     get(_target, prop) {
-      if (typeof prop === 'symbol')
+      if (isReactiveProbeKey(prop))
         return undefined
-      if (SSR_SAFE_ACTION_METADATA_KEYS.has(prop))
-        return undefined
-      return createServerOnlyActionMethod(`${path}.${prop}`)
+      const key = prop as string
+      let method = cache.get(key)
+      if (!method) {
+        method = createServerOnlyActionMethod(`${path}.${key}`)
+        cache.set(key, method)
+      }
+      return method
     },
   })
 }
+
+const _signInServerOnly = createServerOnlyActionNamespace('signIn')
+const _signUpServerOnly = createServerOnlyActionNamespace('signUp')
 
 function ensureSessionSignalListener(client: AppAuthClient, onSignal: () => Promise<void>) {
   if (_sessionSignalListenerBound)
@@ -304,7 +314,7 @@ export function useUserSession(): UseUserSessionReturn {
           )
         },
       })
-    : createServerOnlyActionNamespace('signIn') as SignIn
+    : _signInServerOnly as SignIn
 
   const signUp: SignUp = client?.signUp
     ? new Proxy(client.signUp, {
@@ -316,7 +326,7 @@ export function useUserSession(): UseUserSessionReturn {
           return wrapAuthMethod((...args: unknown[]) => (targetRecord[prop] as (...a: unknown[]) => Promise<unknown>)(...args), wrapDeps)
         },
       })
-    : createServerOnlyActionNamespace('signUp') as SignUp
+    : _signUpServerOnly as SignUp
 
   if (runtimeFlags.client && client && shouldSkipInitialClientSessionFetch.value) {
     ensureSessionSignalListener(client, () => fetchSession({ force: true }))

--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -13,15 +13,6 @@ interface RuntimeFlags { client: boolean, server: boolean }
 
 let _sessionSignalListenerBound = false
 let _signOutPromise: Promise<void> | null = null
-const SSR_SAFE_ACTION_METADATA_KEYS = new Set([
-  'then',
-  '__v_isRef',
-  '__v_isReactive',
-  '__v_isReadonly',
-  '__v_isShallow',
-  '__v_raw',
-  '__v_skip',
-])
 
 export interface UseUserSessionReturn {
   client: AppAuthClient | null
@@ -55,7 +46,9 @@ function getRuntimeFlags(): RuntimeFlags {
 }
 
 function isReactiveProbeKey(prop: PropertyKey): boolean {
-  return typeof prop === 'symbol' || SSR_SAFE_ACTION_METADATA_KEYS.has(prop)
+  if (typeof prop === 'symbol')
+    return true
+  return prop === 'then' || prop.startsWith('__v')
 }
 
 function createServerOnlyActionMethod(path: string) {

--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -46,38 +46,17 @@ function getRuntimeFlags(): RuntimeFlags {
 }
 
 function isReactiveProbeKey(prop: PropertyKey): boolean {
-  if (typeof prop === 'symbol')
-    return true
-  return prop === 'then' || prop.startsWith('__v')
-}
-
-function createServerOnlyActionMethod(path: string) {
-  const method = async () => {
-    throw new Error(`${path}() can only be called on client-side`)
-  }
-
-  return new Proxy(method, {
-    get(target, prop, receiver) {
-      if (isReactiveProbeKey(prop))
-        return undefined
-      return Reflect.get(target, prop, receiver)
-    },
-  })
+  return typeof prop !== 'string' || prop === 'then' || prop.startsWith('__v')
 }
 
 function createServerOnlyActionNamespace(path: string) {
-  const cache = new Map<string, ReturnType<typeof createServerOnlyActionMethod>>()
   return new Proxy({}, {
     get(_target, prop) {
       if (isReactiveProbeKey(prop))
         return undefined
-      const key = prop as string
-      let method = cache.get(key)
-      if (!method) {
-        method = createServerOnlyActionMethod(`${path}.${key}`)
-        cache.set(key, method)
+      return async () => {
+        throw new Error(`${path}.${prop}() can only be called on client-side`)
       }
-      return method
     },
   })
 }

--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -54,8 +54,9 @@ function createServerOnlyActionNamespace(path: string) {
     get(_target, prop) {
       if (isReactiveProbeKey(prop))
         return undefined
+      const key = prop as string
       return async () => {
-        throw new Error(`${path}.${prop}() can only be called on client-side`)
+        throw new Error(`${path}.${key}() can only be called on client-side`)
       }
     },
   })

--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -13,6 +13,15 @@ interface RuntimeFlags { client: boolean, server: boolean }
 
 let _sessionSignalListenerBound = false
 let _signOutPromise: Promise<void> | null = null
+const SSR_SAFE_ACTION_METADATA_KEYS = new Set([
+  'then',
+  '__v_isRef',
+  '__v_isReactive',
+  '__v_isReadonly',
+  '__v_isShallow',
+  '__v_raw',
+  '__v_skip',
+])
 
 export interface UseUserSessionReturn {
   client: AppAuthClient | null
@@ -43,6 +52,34 @@ function getRuntimeFlags(): RuntimeFlags {
   if (globalFlags)
     return globalFlags
   return { client: Boolean(import.meta.client), server: Boolean(import.meta.server) }
+}
+
+function createServerOnlyActionMethod(path: string) {
+  const method = async () => {
+    throw new Error(`${path}() can only be called on client-side`)
+  }
+
+  return new Proxy(method, {
+    get(target, prop, receiver) {
+      if (typeof prop === 'symbol')
+        return undefined
+      if (SSR_SAFE_ACTION_METADATA_KEYS.has(prop))
+        return undefined
+      return Reflect.get(target, prop, receiver)
+    },
+  })
+}
+
+function createServerOnlyActionNamespace(path: string) {
+  return new Proxy({}, {
+    get(_target, prop) {
+      if (typeof prop === 'symbol')
+        return undefined
+      if (SSR_SAFE_ACTION_METADATA_KEYS.has(prop))
+        return undefined
+      return createServerOnlyActionMethod(`${path}.${prop}`)
+    },
+  })
 }
 
 function ensureSessionSignalListener(client: AppAuthClient, onSignal: () => Promise<void>) {
@@ -267,9 +304,7 @@ export function useUserSession(): UseUserSessionReturn {
           )
         },
       })
-    : new Proxy({} as SignIn, {
-        get: (_, prop) => { throw new Error(`signIn.${String(prop)}() can only be called on client-side`) },
-      })
+    : createServerOnlyActionNamespace('signIn') as SignIn
 
   const signUp: SignUp = client?.signUp
     ? new Proxy(client.signUp, {
@@ -281,9 +316,7 @@ export function useUserSession(): UseUserSessionReturn {
           return wrapAuthMethod((...args: unknown[]) => (targetRecord[prop] as (...a: unknown[]) => Promise<unknown>)(...args), wrapDeps)
         },
       })
-    : new Proxy({} as SignUp, {
-        get: (_, prop) => { throw new Error(`signUp.${String(prop)}() can only be called on client-side`) },
-      })
+    : createServerOnlyActionNamespace('signUp') as SignUp
 
   if (runtimeFlags.client && client && shouldSkipInitialClientSessionFetch.value) {
     ensureSessionSignalListener(client, () => fetchSession({ force: true }))

--- a/test/use-user-session.test.ts
+++ b/test/use-user-session.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref, watch } from 'vue'
+import { isReactive, isRef, ref, watch } from 'vue'
 
 interface SessionState {
   data: { session: Record<string, unknown>, user: Record<string, unknown> } | null
@@ -107,6 +107,11 @@ async function triggerNuxtHook(name: string) {
   const hooks = nuxtHooks.get(name) || []
   for (const hook of hooks)
     await hook()
+}
+
+function isPiniaStateLike(value: unknown) {
+  const isComputedLike = isRef(value) && Boolean((value as { effect?: unknown }).effect)
+  return (isRef(value) && !isComputedLike) || isReactive(value)
 }
 
 function seedHydratedState() {
@@ -438,6 +443,58 @@ describe('useUserSession hydration bootstrap', () => {
     const auth = useUserSession()
 
     expect(auth.client).toBeNull()
+  })
+
+  it('allows SSR metadata introspection on signIn and signUp without throwing', async () => {
+    setRuntimeFlags({ client: false, server: true })
+
+    const useUserSession = await loadUseUserSession()
+    const auth = useUserSession()
+
+    expect(isRef(auth.signIn as unknown)).toBe(false)
+    expect(isReactive(auth.signIn as unknown)).toBe(false)
+    expect(isRef(auth.signUp as unknown)).toBe(false)
+    expect(isReactive(auth.signUp as unknown)).toBe(false)
+    expect((auth.signIn as Record<string, unknown>).__v_isRef).toBeUndefined()
+    expect((auth.signIn as Record<string, unknown>).__v_isReactive).toBeUndefined()
+    expect((auth.signUp as Record<string, unknown>).__v_isRef).toBeUndefined()
+    expect((auth.signUp as Record<string, unknown>).__v_isReactive).toBeUndefined()
+  })
+
+  it('allows server-side auth method reads but still rejects invocation', async () => {
+    setRuntimeFlags({ client: false, server: true })
+
+    const useUserSession = await loadUseUserSession()
+    const auth = useUserSession()
+
+    const signInEmail = (auth.signIn as Record<string, (...args: unknown[]) => Promise<unknown>>).email
+    const signUpEmail = (auth.signUp as Record<string, (...args: unknown[]) => Promise<unknown>>).email
+
+    expect(isRef(signInEmail as unknown)).toBe(false)
+    expect(isReactive(signInEmail as unknown)).toBe(false)
+    expect(isRef(signUpEmail as unknown)).toBe(false)
+    expect(isReactive(signUpEmail as unknown)).toBe(false)
+
+    await expect(signInEmail({ email: 'user@example.com', password: 'password' })).rejects.toThrow('signIn.email() can only be called on client-side')
+    await expect(signUpEmail({ email: 'user@example.com', password: 'password', name: 'User' })).rejects.toThrow('signUp.email() can only be called on client-side')
+  })
+
+  it('keeps forwarded useUserSession actions out of Pinia setup-store state classification during SSR', async () => {
+    setRuntimeFlags({ client: false, server: true })
+
+    const useUserSession = await loadUseUserSession()
+    const { user, client: authClient, fetchSession, ...rest } = useUserSession()
+    const store = {
+      user,
+      authClient,
+      fetchSession,
+      ...rest,
+    }
+
+    expect(isPiniaStateLike(store.signIn as unknown)).toBe(false)
+    expect(isPiniaStateLike(store.signUp as unknown)).toBe(false)
+    expect(isPiniaStateLike((store.signIn as Record<string, unknown>).email)).toBe(false)
+    expect(isPiniaStateLike((store.signUp as Record<string, unknown>).email)).toBe(false)
   })
 
   it('signIn uses auth.redirects.authenticated when no callback is provided', async () => {

--- a/test/use-user-session.test.ts
+++ b/test/use-user-session.test.ts
@@ -109,11 +109,6 @@ async function triggerNuxtHook(name: string) {
     await hook()
 }
 
-function isPiniaStateLike(value: unknown) {
-  const isComputedLike = isRef(value) && Boolean((value as { effect?: unknown }).effect)
-  return (isRef(value) && !isComputedLike) || isReactive(value)
-}
-
 function seedHydratedState() {
   state.set('auth:session', ref({ id: 'session-1' }))
   state.set('auth:user', ref({ id: 'user-1' }))
@@ -490,11 +485,12 @@ describe('useUserSession hydration bootstrap', () => {
       fetchSession,
       ...rest,
     }
+    const isStateLike = (value: unknown) => isRef(value) || isReactive(value)
 
-    expect(isPiniaStateLike(store.signIn as unknown)).toBe(false)
-    expect(isPiniaStateLike(store.signUp as unknown)).toBe(false)
-    expect(isPiniaStateLike((store.signIn as Record<string, unknown>).email)).toBe(false)
-    expect(isPiniaStateLike((store.signUp as Record<string, unknown>).email)).toBe(false)
+    expect(isStateLike(store.signIn)).toBe(false)
+    expect(isStateLike(store.signUp)).toBe(false)
+    expect(isStateLike((store.signIn as Record<string, unknown>).email)).toBe(false)
+    expect(isStateLike((store.signUp as Record<string, unknown>).email)).toBe(false)
   })
 
   it('signIn uses auth.redirects.authenticated when no callback is provided', async () => {


### PR DESCRIPTION
Closes #319

This makes the server-side `signIn` and `signUp` namespaces safe for Vue and Pinia SSR introspection by returning `undefined` for reactivity probe keys while keeping nested auth methods callable and still client-only when invoked.

The regression tests now cover both ref and reactive classification, including the Pinia setup-store condition that was triggering the SSR crash.
