### PR TITLE
refactor: deepen auth config discovery

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -2,11 +2,11 @@ import type { Nuxt } from '@nuxt/schema'
 import type { BetterAuthModuleOptions } from './runtime/config'
 import type { BetterAuthDatabaseProviderSetupContext } from './types/hooks'
 import { mkdir, writeFile } from 'node:fs/promises'
-import { addTemplate, createResolver, defineNuxtModule, getLayerDirectories } from '@nuxt/kit'
+import { addTemplate, createResolver, defineNuxtModule } from '@nuxt/kit'
 import { consola as _consola } from 'consola'
-import { dirname, join, relative } from 'pathe'
+import { dirname, relative } from 'pathe'
 import { version } from '../package.json'
-import { getEffectiveModuleConfigFile, shouldCreateDefaultModuleConfig } from './module/config-paths'
+import { resolveAuthConfigDescriptors } from './module/config-paths'
 import { registerAuthMiddlewareHook, registerDevtools, registerNuxtHubDatabaseExternalHook, registerPrepareTypesHook, registerRouteRulesMetaHook, registerServerRuntime, registerTemplateHmrHook } from './module/hooks'
 import { setupBetterAuthSchema } from './module/schema'
 import { promptForSecret } from './module/secret'
@@ -19,12 +19,7 @@ import './types/hooks'
 const consola = _consola.withTag('nuxt-better-auth')
 
 async function createDefaultAuthConfigFiles(nuxt: Nuxt): Promise<void> {
-  const project = getLayerDirectories(nuxt)[0]!
-  const rootDir = project.root
-  const serverPath = join(project.server, 'auth.config.ts')
-  const clientPath = join(project.app, 'auth.config.ts')
-  const serverConfigFile = getEffectiveModuleConfigFile(nuxt, 'server')
-  const clientConfigFile = getEffectiveModuleConfigFile(nuxt, 'client')
+  const configs = resolveAuthConfigDescriptors(nuxt)
 
   const serverTemplate = `import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 
@@ -38,16 +33,18 @@ export default defineServerAuth({
 export default defineClientAuth({})
 `
 
-  if (shouldCreateDefaultModuleConfig(nuxt, 'server', serverConfigFile)) {
+  if (configs.server.shouldCreateDefaultFile) {
+    const serverPath = `${configs.server.path}.ts`
     await mkdir(dirname(serverPath), { recursive: true })
     await writeFile(serverPath, serverTemplate)
-    consola.success(`Created ${relative(rootDir, serverPath)}`)
+    consola.success(`Created ${relative(configs.server.declaringLayerRoot, serverPath)}`)
   }
 
-  if (shouldCreateDefaultModuleConfig(nuxt, 'client', clientConfigFile)) {
+  if (configs.client.shouldCreateDefaultFile) {
+    const clientPath = `${configs.client.path}.ts`
     await mkdir(dirname(clientPath), { recursive: true })
     await writeFile(clientPath, clientTemplate)
-    consola.success(`Created ${relative(rootDir, clientPath)}`)
+    consola.success(`Created ${relative(configs.client.declaringLayerRoot, clientPath)}`)
   }
 }
 

--- a/src/module/config-paths.ts
+++ b/src/module/config-paths.ts
@@ -6,10 +6,20 @@ import { isAbsolute, join, relative } from 'pathe'
 
 export type ModuleConfigKind = 'server' | 'client'
 
-export interface ResolvedModuleConfigPath {
+export interface AuthConfigDescriptor {
+  kind: ModuleConfigKind
+  configuredFile: string
   file: string
   path: string
+  declaringLayerRoot: string
   isDefault: boolean
+  isExplicit: boolean
+  exists: boolean
+  shouldCreateDefaultFile: boolean
+}
+
+interface ResolveAuthConfigDescriptorDependencies {
+  configExists?: (path: string) => boolean
 }
 
 const CONFIG_EXTENSIONS = ['.ts', '.js']
@@ -27,7 +37,7 @@ function stripConfigExtension(path: string): string {
   return path.replace(CONFIG_EXTENSION_RE, '')
 }
 
-function configExists(path: string): boolean {
+function defaultConfigExists(path: string): boolean {
   return CONFIG_EXTENSIONS.some(ext => existsSync(`${path}${ext}`))
 }
 
@@ -48,14 +58,22 @@ function getDefaultConfigPath(nuxt: Nuxt, kind: ModuleConfigKind): string {
     : join(project.app, 'auth.config')
 }
 
-function getLayerDefaultConfigPath(nuxt: Nuxt, kind: ModuleConfigKind): string | undefined {
+function getLayerDefaultConfigPath(
+  nuxt: Nuxt,
+  kind: ModuleConfigKind,
+  configExists: (path: string) => boolean,
+): { path: string, declaringLayerRoot: string } | undefined {
   for (const { directory } of getLayerDirectoriesWithConfigs(nuxt)) {
     const candidate = kind === 'server'
       ? join(directory.server, 'auth.config')
       : join(directory.app, 'auth.config')
 
-    if (configExists(candidate))
-      return candidate
+    if (configExists(candidate)) {
+      return {
+        path: candidate,
+        declaringLayerRoot: directory.root,
+      }
+    }
   }
 }
 
@@ -75,47 +93,82 @@ function getRelativeConfigFile(nuxt: Nuxt, path: string): string {
   return relative(getProjectDirectory(nuxt).root, path)
 }
 
-export function getEffectiveModuleConfigFile(nuxt: Nuxt, kind: ModuleConfigKind): string {
+function getEffectiveModuleConfigFile(nuxt: Nuxt, kind: ModuleConfigKind): string {
   const optionKey = OPTION_KEY_BY_KIND[kind]
   const authOptions = (nuxt.options as { auth?: BetterAuthModuleOptions }).auth
   return authOptions?.[optionKey] ?? DEFAULT_CONFIG_FILES[kind]
 }
 
-export function shouldCreateDefaultModuleConfig(nuxt: Nuxt, kind: ModuleConfigKind, file = getEffectiveModuleConfigFile(nuxt, kind)): boolean {
-  const normalizedFile = stripConfigExtension(file)
-  if (normalizedFile !== DEFAULT_CONFIG_FILES[kind])
-    return false
+export function resolveAuthConfigDescriptor(
+  nuxt: Nuxt,
+  kind: ModuleConfigKind,
+  file = getEffectiveModuleConfigFile(nuxt, kind),
+  dependencies: ResolveAuthConfigDescriptorDependencies = {},
+): AuthConfigDescriptor {
+  const configExists = dependencies.configExists ?? defaultConfigExists
+  const configuredFile = stripConfigExtension(file)
 
-  const resolved = resolveModuleConfigPath(nuxt, kind, normalizedFile)
-  return !configExists(resolved.path)
-}
+  if (isAbsolute(configuredFile)) {
+    const declaringLayerRoot = resolveDeclaringLayerRoot(nuxt, kind, configuredFile)
+    const exists = configExists(configuredFile)
 
-export function resolveModuleConfigPath(nuxt: Nuxt, kind: ModuleConfigKind, file: string): ResolvedModuleConfigPath {
-  const normalizedFile = stripConfigExtension(file)
-
-  if (isAbsolute(normalizedFile)) {
     return {
-      file: normalizedFile,
-      path: normalizedFile,
+      kind,
+      configuredFile,
+      file: configuredFile,
+      path: configuredFile,
+      declaringLayerRoot,
       isDefault: false,
+      isExplicit: true,
+      exists,
+      shouldCreateDefaultFile: false,
     }
   }
 
-  if (normalizedFile === DEFAULT_CONFIG_FILES[kind]) {
-    const discoveredPath = getLayerDefaultConfigPath(nuxt, kind) ?? getDefaultConfigPath(nuxt, kind)
+  if (configuredFile === DEFAULT_CONFIG_FILES[kind]) {
+    const project = getProjectDirectory(nuxt)
+    const discovered = getLayerDefaultConfigPath(nuxt, kind, configExists)
+    const path = discovered?.path ?? getDefaultConfigPath(nuxt, kind)
+    const declaringLayerRoot = discovered?.declaringLayerRoot ?? project.root
+    const exists = configExists(path)
+
     return {
-      file: getRelativeConfigFile(nuxt, discoveredPath),
-      path: discoveredPath,
+      kind,
+      configuredFile,
+      file: getRelativeConfigFile(nuxt, path),
+      path,
+      declaringLayerRoot,
       isDefault: true,
+      isExplicit: false,
+      exists,
+      shouldCreateDefaultFile: !exists,
     }
   }
 
-  const baseRoot = resolveDeclaringLayerRoot(nuxt, kind, normalizedFile)
-  const path = join(baseRoot, normalizedFile)
+  const declaringLayerRoot = resolveDeclaringLayerRoot(nuxt, kind, configuredFile)
+  const path = join(declaringLayerRoot, configuredFile)
+  const exists = configExists(path)
 
   return {
+    kind,
+    configuredFile,
     file: getRelativeConfigFile(nuxt, path),
     path,
+    declaringLayerRoot,
     isDefault: false,
+    isExplicit: true,
+    exists,
+    shouldCreateDefaultFile: false,
+  }
+}
+
+export function resolveAuthConfigDescriptors(
+  nuxt: Nuxt,
+  files: Partial<Record<ModuleConfigKind, string>> = {},
+  dependencies: ResolveAuthConfigDescriptorDependencies = {},
+): Record<ModuleConfigKind, AuthConfigDescriptor> {
+  return {
+    server: resolveAuthConfigDescriptor(nuxt, 'server', files.server, dependencies),
+    client: resolveAuthConfigDescriptor(nuxt, 'client', files.client, dependencies),
   }
 }

--- a/src/module/setup.ts
+++ b/src/module/setup.ts
@@ -5,23 +5,15 @@ import type {
   BetterAuthDatabaseProviderDefinition,
   BetterAuthDatabaseProviderEnabledContext,
 } from '../types/hooks'
+import type { AuthConfigDescriptor } from './config-paths'
 import type { NuxtHubOptions } from './hub'
-import { existsSync } from 'node:fs'
 import { hasNuxtModule } from '@nuxt/kit'
 import { dirname } from 'pathe'
 import { resolveDatabaseProvider } from '../database-provider'
-import { resolveModuleConfigPath } from './config-paths'
+import { resolveAuthConfigDescriptors } from './config-paths'
 import { getHubCasing, getHubDialect } from './hub'
 import { setupRuntimeConfig } from './runtime'
 import { buildDatabaseCode } from './templates'
-
-export interface AuthConfigDescriptor {
-  kind: 'server' | 'client'
-  file: string
-  path: string
-  isDefault: boolean
-  exists: boolean
-}
 
 export interface ResolvedAuthModuleSetup {
   clientOnly: boolean
@@ -79,25 +71,6 @@ interface ResolveAuthModuleSetupDependencies {
   hasNuxtModule?: typeof hasNuxtModule
 }
 
-function defaultConfigExists(path: string): boolean {
-  return existsSync(`${path}.ts`) || existsSync(`${path}.js`)
-}
-
-function resolveConfigDescriptor(
-  nuxt: Nuxt,
-  kind: 'server' | 'client',
-  file: string,
-  configExists: (path: string) => boolean,
-): AuthConfigDescriptor {
-  const resolved = resolveModuleConfigPath(nuxt, kind, file)
-
-  return {
-    kind,
-    ...resolved,
-    exists: configExists(resolved.path),
-  }
-}
-
 function assertConfigPresence(configs: ResolvedAuthModuleSetup['configs'], clientOnly: boolean): void {
   if (!clientOnly && !configs.server.exists)
     throw new Error(`[nuxt-better-auth] Missing ${configs.server.file}.ts - export default defineServerAuth(...)`)
@@ -150,14 +123,15 @@ export async function resolveAuthModuleSetup(
   dependencies: ResolveAuthModuleSetupDependencies = {},
 ): Promise<ResolvedAuthModuleSetup> {
   const { nuxt, options, runtimeTypesAugmentPath, consola } = input
-  const configExists = dependencies.configExists ?? defaultConfigExists
   const hasNuxtModuleFn = dependencies.hasNuxtModule ?? hasNuxtModule
   const clientOnly = options.clientOnly ?? false
 
-  const configs = {
-    server: resolveConfigDescriptor(nuxt, 'server', options.serverConfig!, configExists),
-    client: resolveConfigDescriptor(nuxt, 'client', options.clientConfig!, configExists),
-  }
+  const configs = resolveAuthConfigDescriptors(nuxt, {
+    server: options.serverConfig,
+    client: options.clientConfig,
+  }, {
+    configExists: dependencies.configExists,
+  })
 
   assertConfigPresence(configs, clientOnly)
 

--- a/test/config-paths.test.ts
+++ b/test/config-paths.test.ts
@@ -2,7 +2,7 @@ import type { Nuxt } from '@nuxt/schema'
 import { fileURLToPath } from 'node:url'
 import { loadNuxt } from '@nuxt/kit'
 import { afterEach, describe, expect, it } from 'vitest'
-import { getEffectiveModuleConfigFile, resolveModuleConfigPath, shouldCreateDefaultModuleConfig } from '../src/module/config-paths'
+import { resolveAuthConfigDescriptor, resolveAuthConfigDescriptors } from '../src/module/config-paths'
 
 const loadedNuxtInstances: Nuxt[] = []
 
@@ -24,86 +24,178 @@ afterEach(async () => {
   }
 })
 
-describe('resolveModuleConfigPath', () => {
+describe('resolveAuthConfigDescriptor', () => {
   it('discovers default configs from an extended layer', async () => {
     const nuxt = await loadCase('layer-default-configs')
+    const configs = resolveAuthConfigDescriptors(nuxt)
 
-    expect(resolveModuleConfigPath(nuxt, 'server', 'server/auth.config')).toMatchObject({
+    expect(configs.server).toMatchObject({
+      kind: 'server',
+      configuredFile: 'server/auth.config',
       file: '../core-auth/server/auth.config',
       path: expect.stringContaining('/test/cases/core-auth/server/auth.config'),
+      declaringLayerRoot: expect.stringContaining('/test/cases/core-auth'),
       isDefault: true,
+      isExplicit: false,
+      exists: true,
+      shouldCreateDefaultFile: false,
     })
-    expect(resolveModuleConfigPath(nuxt, 'client', 'app/auth.config')).toMatchObject({
+    expect(configs.client).toMatchObject({
+      kind: 'client',
+      configuredFile: 'app/auth.config',
       file: '../core-auth/app/auth.config',
       path: expect.stringContaining('/test/cases/core-auth/app/auth.config'),
+      declaringLayerRoot: expect.stringContaining('/test/cases/core-auth'),
       isDefault: true,
+      isExplicit: false,
+      exists: true,
+      shouldCreateDefaultFile: false,
     })
   })
 
   it('resolves inherited explicit relative config paths from the declaring layer', async () => {
     const nuxt = await loadCase('layer-explicit-configs')
-    const serverConfigFile = getEffectiveModuleConfigFile(nuxt, 'server')
-    const clientConfigFile = getEffectiveModuleConfigFile(nuxt, 'client')
+    const configs = resolveAuthConfigDescriptors(nuxt)
 
-    expect(resolveModuleConfigPath(nuxt, 'server', serverConfigFile)).toMatchObject({
+    expect(configs.server).toMatchObject({
+      kind: 'server',
+      configuredFile: 'custom/server-auth',
       file: '../layer-explicit-configs-base/custom/server-auth',
       path: expect.stringContaining('/test/cases/layer-explicit-configs-base/custom/server-auth'),
+      declaringLayerRoot: expect.stringContaining('/test/cases/layer-explicit-configs-base'),
       isDefault: false,
+      isExplicit: true,
+      exists: true,
+      shouldCreateDefaultFile: false,
     })
-    expect(resolveModuleConfigPath(nuxt, 'client', clientConfigFile)).toMatchObject({
+    expect(configs.client).toMatchObject({
+      kind: 'client',
+      configuredFile: 'custom/client-auth',
       file: '../layer-explicit-configs-base/custom/client-auth',
       path: expect.stringContaining('/test/cases/layer-explicit-configs-base/custom/client-auth'),
+      declaringLayerRoot: expect.stringContaining('/test/cases/layer-explicit-configs-base'),
       isDefault: false,
+      isExplicit: true,
+      exists: true,
+      shouldCreateDefaultFile: false,
     })
   })
 
   it('resolves project-defined explicit relative config paths from the project root', async () => {
     const nuxt = await loadCase('project-explicit-configs')
-    const serverConfigFile = getEffectiveModuleConfigFile(nuxt, 'server')
-    const clientConfigFile = getEffectiveModuleConfigFile(nuxt, 'client')
+    const configs = resolveAuthConfigDescriptors(nuxt)
 
-    expect(resolveModuleConfigPath(nuxt, 'server', serverConfigFile)).toMatchObject({
+    expect(configs.server).toMatchObject({
+      kind: 'server',
+      configuredFile: 'custom/server-auth',
       file: 'custom/server-auth',
       path: expect.stringContaining('/test/cases/project-explicit-configs/custom/server-auth'),
+      declaringLayerRoot: expect.stringContaining('/test/cases/project-explicit-configs'),
       isDefault: false,
+      isExplicit: true,
+      exists: true,
+      shouldCreateDefaultFile: false,
     })
-    expect(resolveModuleConfigPath(nuxt, 'client', clientConfigFile)).toMatchObject({
+    expect(configs.client).toMatchObject({
+      kind: 'client',
+      configuredFile: 'custom/client-auth',
       file: 'custom/client-auth',
       path: expect.stringContaining('/test/cases/project-explicit-configs/custom/client-auth'),
+      declaringLayerRoot: expect.stringContaining('/test/cases/project-explicit-configs'),
       isDefault: false,
+      isExplicit: true,
+      exists: true,
+      shouldCreateDefaultFile: false,
     })
   })
 
   it('passes through absolute config paths unchanged', async () => {
     const nuxt = await loadCase('database-less')
-    const serverConfigFile = getEffectiveModuleConfigFile(nuxt, 'server')
-    const clientConfigFile = getEffectiveModuleConfigFile(nuxt, 'client')
+    const serverConfigFile = ((nuxt.options as { auth: { serverConfig: string } }).auth).serverConfig
+    const clientConfigFile = ((nuxt.options as { auth: { clientConfig: string } }).auth).clientConfig
 
-    expect(resolveModuleConfigPath(nuxt, 'server', serverConfigFile)).toEqual({
+    expect(resolveAuthConfigDescriptor(nuxt, 'server')).toMatchObject({
+      kind: 'server',
+      configuredFile: serverConfigFile,
       file: serverConfigFile,
       path: serverConfigFile,
+      declaringLayerRoot: expect.stringContaining('/test/cases/_base-module'),
       isDefault: false,
+      isExplicit: true,
+      exists: true,
+      shouldCreateDefaultFile: false,
     })
-    expect(resolveModuleConfigPath(nuxt, 'client', clientConfigFile)).toEqual({
+    expect(resolveAuthConfigDescriptor(nuxt, 'client')).toMatchObject({
+      kind: 'client',
+      configuredFile: clientConfigFile,
       file: clientConfigFile,
       path: clientConfigFile,
+      declaringLayerRoot: expect.stringContaining('/test/cases/_base-module'),
       isDefault: false,
+      isExplicit: true,
+      exists: true,
+      shouldCreateDefaultFile: false,
     })
   })
-})
 
-describe('shouldCreateDefaultModuleConfig', () => {
-  it('does not scaffold defaults when an extended layer already provides default config files', async () => {
-    const nuxt = await loadCase('layer-default-configs')
+  it('allows default file creation when default configs are missing from all layers', async () => {
+    const nuxt = await loadCase('without-nuxthub')
+    const configExists = () => false
+    const configs = resolveAuthConfigDescriptors(nuxt, {
+      server: 'server/auth.config',
+      client: 'app/auth.config',
+    }, { configExists })
 
-    expect(shouldCreateDefaultModuleConfig(nuxt, 'server')).toBe(false)
-    expect(shouldCreateDefaultModuleConfig(nuxt, 'client')).toBe(false)
+    expect(configs.server).toMatchObject({
+      kind: 'server',
+      configuredFile: 'server/auth.config',
+      file: 'server/auth.config',
+      path: expect.stringContaining('/test/cases/without-nuxthub/server/auth.config'),
+      declaringLayerRoot: expect.stringContaining('/test/cases/without-nuxthub'),
+      isDefault: true,
+      isExplicit: false,
+      exists: false,
+      shouldCreateDefaultFile: true,
+    })
+    expect(configs.client).toMatchObject({
+      kind: 'client',
+      configuredFile: 'app/auth.config',
+      file: 'app/auth.config',
+      path: expect.stringContaining('/test/cases/without-nuxthub/app/auth.config'),
+      declaringLayerRoot: expect.stringContaining('/test/cases/without-nuxthub'),
+      isDefault: true,
+      isExplicit: false,
+      exists: false,
+      shouldCreateDefaultFile: true,
+    })
   })
 
-  it('does not scaffold defaults when effective config paths are explicit custom files from an extended layer', async () => {
-    const nuxt = await loadCase('layer-explicit-configs')
+  it('does not allow default file creation for missing explicit config paths', async () => {
+    const nuxt = await loadCase('project-explicit-configs')
+    const configExists = () => false
+    const configs = resolveAuthConfigDescriptors(nuxt, {}, { configExists })
 
-    expect(shouldCreateDefaultModuleConfig(nuxt, 'server')).toBe(false)
-    expect(shouldCreateDefaultModuleConfig(nuxt, 'client')).toBe(false)
+    expect(configs.server).toMatchObject({
+      kind: 'server',
+      configuredFile: 'custom/server-auth',
+      file: 'custom/server-auth',
+      path: expect.stringContaining('/test/cases/project-explicit-configs/custom/server-auth'),
+      declaringLayerRoot: expect.stringContaining('/test/cases/project-explicit-configs'),
+      isDefault: false,
+      isExplicit: true,
+      exists: false,
+      shouldCreateDefaultFile: false,
+    })
+    expect(configs.client).toMatchObject({
+      kind: 'client',
+      configuredFile: 'custom/client-auth',
+      file: 'custom/client-auth',
+      path: expect.stringContaining('/test/cases/project-explicit-configs/custom/client-auth'),
+      declaringLayerRoot: expect.stringContaining('/test/cases/project-explicit-configs'),
+      isDefault: false,
+      isExplicit: true,
+      exists: false,
+      shouldCreateDefaultFile: false,
+    })
   })
 })


### PR DESCRIPTION
Deepens auth config discovery by moving setup-time and install-time path policy behind one descriptor interface. `src/module/config-paths.ts` now owns default discovery, explicit layer-relative resolution, absolute paths, existence, and default-file creation policy.

This keeps public options and generated config behavior unchanged while making `src/module.ts` and `src/module/setup.ts` consume the same normalized config descriptors.

Checks run locally:
- `pnpm exec vitest run test/config-paths.test.ts test/module-setup.test.ts`
- `pnpm exec eslint src/module.ts src/module/config-paths.ts src/module/setup.ts test/config-paths.test.ts`
- `pnpm typecheck`
- `pnpm typecheck:runtime-server`
- Targeted integration set passed
- Full `pnpm test` hit two parallel Nuxt port startup timeouts; both affected suites passed when rerun directly