### PR TITLE
refactor(auth)!: split session state from client actions

### DIFF
--- a/docs/app/components/content/landing/hero.yml
+++ b/docs/app/components/content/landing/hero.yml
@@ -34,11 +34,11 @@ tabs:
   - name: pages/login.vue
     code: |
       <script setup lang="ts">
-      const { signIn } = useUserSession()
+      const signInSocial = useSignIn('social')
       </script>
 
       <template>
-        <button @click="signIn.social({ provider: 'github' })">
+        <button @click="signInSocial.execute({ provider: 'github' })">
           Sign in with GitHub
         </button>
       </template>

--- a/docs/content/1.getting-started/3.client-setup.md
+++ b/docs/content/1.getting-started/3.client-setup.md
@@ -13,7 +13,8 @@ Set up the client auth config for @onmax/nuxt-better-auth.
 - Object syntax: `defineClientAuth({})` or function syntax: `defineClientAuth(({ siteUrl }) => ({}))`
 - Add client plugin equivalents for every server plugin (e.g. `adminClient()` from `better-auth/client/plugins`)
 - The module calls the factory with the correct `baseURL` at runtime
-- `useUserSession()` is auto-imported and provides `user`, `session`, `loggedIn`, `ready`, `signIn`, `signUp`, `signOut`
+- `useUserSession()` is auto-imported and provides `user`, `session`, `loggedIn`, `ready`, `signOut`
+- `useSignIn()`, `useSignUp()`, and `useAuthClient()` are auto-imported for auth actions and direct client access
 ```
 
 ::
@@ -80,10 +81,10 @@ export default defineClientAuth({
 <script setup lang="ts">
 definePageMeta({ auth: 'guest' })
 
-const { signIn } = useUserSession()
+const signInEmail = useSignIn('email')
 
 async function login(email: string, password: string) {
-  await signIn.email(
+  await signInEmail.execute(
     { email, password },
     { onSuccess: () => navigateTo('/app') },
   )
@@ -96,6 +97,6 @@ async function login(email: string, password: string) {
 Confirm all of the following:
 
 - `useUserSession()` is available without a manual import
-- `client` is available on the browser after hydration
+- `useAuthClient()` returns the Better Auth client on the browser after hydration
 - client plugins are registered on both server and client when required by Better Auth
 - sign-in and sign-out update `user`, `session`, and `loggedIn`

--- a/docs/content/2.core-concepts/2.sessions.md
+++ b/docs/content/2.core-concepts/2.sessions.md
@@ -8,9 +8,9 @@ description: Access reactive session state with SSR support using `useUserSessio
 ```txt [Prompt]
 Handle sessions with @onmax/nuxt-better-auth using useUserSession().
 
-- `useUserSession()` is auto-imported and returns: user, session, loggedIn, ready, signIn, signUp, signOut, fetchSession
+- `useUserSession()` is auto-imported and returns: user, session, loggedIn, ready, signOut, fetchSession
 - SSR: session is fetched server-side via cookies and hydrated — `ready` is `true` after hydration
-- Client: `.client` is `null` during SSR, available after hydration
+- Client: use `useSignIn()`, `useSignUp()`, or `useAuthClient()` for Better Auth client methods
 - Split model: use `useUserSession()` in pages/components, use `requireUserSession(event)` in server handlers
 - Configure session lifetime in `server/auth.config.ts` via `session.expiresIn` and `session.cookieCache`
 - Use `<BetterAuthState>` or `ready` ref to avoid loading flashes
@@ -27,8 +27,6 @@ const {
   session,
   loggedIn,
   ready,
-  signIn,
-  signUp,
   signOut,
   fetchSession,
 } = useUserSession()
@@ -39,7 +37,7 @@ const {
 During server-side rendering (SSR), the module fetches the session using incoming request cookies and populates state before rendering. A client plugin then keeps the state in sync after hydration.
 
 - **Server render:** `user` and `session` are set when a valid session cookie exists, and `ready` is `true`.
-- **Server runtime client access:** `useUserSession().client` is `null` during SSR.
+- **Server runtime client access:** `useAuthClient()` returns `null` during SSR.
 - **After hydration:** State stays in sync with client-side updates.
 
 Use a split model:

--- a/docs/content/2.core-concepts/3.route-protection.md
+++ b/docs/content/2.core-concepts/3.route-protection.md
@@ -196,6 +196,7 @@ When preserving the original URL for post-login redirects, validate it to preven
 
 ```ts [pages/login.vue]
 const route = useRoute()
+const signInEmail = useSignIn('email')
 
 function getSafeRedirect() {
   const redirect = route.query.redirect as string
@@ -206,7 +207,7 @@ function getSafeRedirect() {
 }
 
 async function login(email: string, password: string) {
-  await signIn.email(
+  await signInEmail.execute(
     { email, password },
     { onSuccess: () => navigateTo(getSafeRedirect()) },
   )
@@ -248,7 +249,7 @@ Better Auth includes CSRF protection by default. Always use the auth client meth
 
 ```ts
 // ✓ Correct: uses auth client
-await signIn.email({ email, password })
+await useSignIn('email').execute({ email, password })
 
 // ✗ Incorrect: bypasses CSRF protection
 await fetch('/api/auth/sign-in/email', { method: 'POST', body: JSON.stringify({ email, password }) })

--- a/docs/content/2.core-concepts/4.auto-imports-aliases.md
+++ b/docs/content/2.core-concepts/4.auto-imports-aliases.md
@@ -8,7 +8,7 @@ description: What the module registers for you.
 ```txt [Prompt]
 Use auto-imported utilities from @onmax/nuxt-better-auth.
 
-- Client (auto-imported in Vue): `useUserSession()`, `useUserSessionState()`, `useSignIn()`, `useSignUp()`
+- Client (auto-imported in Vue): `useUserSession()`, `useUserSessionState()`, `useAuthClient()`, `useSignIn()`, `useSignUp()`, `useAuthClientAction()`
 - Server (auto-imported in `server/`): `serverAuth(event?)`, `getRequestSession(event)`, `getUserSession(event)`, `createSession(event, userId)`, `setSessionCookie(event, token)`, `requireUserSession(event, options?)`
 - Component: `<BetterAuthState>` for auth-ready rendering
 - Alias `#nuxt-better-auth` exports types: `AuthUser`, `AuthSession`, `AuthSocialProviderId`
@@ -25,8 +25,10 @@ Use this page when you want a quick inventory of what the module registers for y
 
 - `useUserSession()`
 - `useUserSessionState()`
+- `useAuthClient()`
 - `useSignIn()`
 - `useSignUp()`
+- `useAuthClientAction()`
 
 **Server**
 

--- a/docs/content/3.guides/2.oauth-providers.md
+++ b/docs/content/3.guides/2.oauth-providers.md
@@ -1,6 +1,6 @@
 ---
 title: OAuth Providers
-description: Configure OAuth providers and sign in with `signIn.social()`.
+description: Configure OAuth providers and sign in with `useSignIn('social')`.
 ---
 
 Use this guide when you want to add a social provider to a full-mode Nuxt Better Auth setup.
@@ -50,13 +50,13 @@ export default defineServerAuth({
 ```vue [pages/login.vue]
 <script setup lang="ts">
 definePageMeta({ auth: 'guest' })
-const { signIn } = useUserSession()
+const signInSocial = useSignIn('social')
 </script>
 
 <template>
   <button
     type="button"
-    @click="signIn.social({ provider: 'google' })"
+    @click="signInSocial.execute({ provider: 'google' })"
   >
     Continue with Google
   </button>
@@ -64,7 +64,7 @@ const { signIn } = useUserSession()
 ```
 
 ::tip
-For OAuth flows (`signIn.social`), Better Auth handles the browser redirect to the provider.
+For OAuth flows (`useSignIn('social')`), Better Auth handles the browser redirect to the provider.
 No manual `fetchSession`/`waitForSession` step is needed before that redirect.
 `callbackURL` is optional. When your app configures `auth.redirects.authenticated` (or has a safe `?redirect=` query), the module can use that as the fallback callback URL.
 ::
@@ -87,6 +87,6 @@ Better Auth supports 20+ providers (Apple, Discord, Facebook, etc). The pattern 
 1. Create OAuth app, get client ID/secret
 2. Add `{PROVIDER}_CLIENT_ID` and `{PROVIDER}_CLIENT_SECRET` to `.env`
 3. Reference credentials in `server/auth.config.ts`
-4. Call `signIn.social({ provider: 'providerId' })`
+4. Call `useSignIn('social').execute({ provider: 'providerId' })`
 
 :read-more{to="https://www.better-auth.com/docs/authentication/other-social-providers" title="Full provider list"}

--- a/docs/content/3.guides/6.migrate-from-nuxt-auth-utils.md
+++ b/docs/content/3.guides/6.migrate-from-nuxt-auth-utils.md
@@ -40,7 +40,9 @@ This module is a **Nuxt wrapper** around [Better Auth](https://www.better-auth.c
 const { user, loggedIn, ready, fetch, clear } = useUserSession()
 
 // nuxt-better-auth
-const { user, session, loggedIn, ready, signIn, signUp, signOut, fetchSession, client } = useUserSession()
+const { user, session, loggedIn, ready, signOut, fetchSession } = useUserSession()
+const signInEmail = useSignIn('email')
+const client = useAuthClient()
 ```
 
 ### OAuth Handling

--- a/docs/content/3.guides/7.two-factor-auth.md
+++ b/docs/content/3.guides/7.two-factor-auth.md
@@ -49,7 +49,7 @@ export default defineClientAuth({
 ```ts [pages/two-factor.vue]
 <script setup lang="ts">
 definePageMeta({ auth: 'user' })
-const { client } = useUserSession()
+const client = useAuthClient()
 const password = ref('')
 const qr = ref<string | null>(null)
 const backupCodes = ref<string[] | null>(null)

--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -11,7 +11,7 @@ These composables are auto-imported in Vue files. No import statement is needed 
 
 ## Quick Start
 
-Use `useUserSession()` in pages and components to access the current session and auth methods.
+Use `useUserSession()` in pages and components to access the current session and session lifecycle actions.
 
 ```vue [pages/app.vue]
 <script setup lang="ts">
@@ -29,17 +29,18 @@ const { user, loggedIn, signOut } = useUserSession()
 
 | Use case | Composable |
 |----------|------------|
-| Pages and components that need auth state, auth methods, or direct Better Auth client access | `useUserSession()` |
+| Pages, components, and setup stores that need auth state and session lifecycle actions | `useUserSession()` |
+| Direct Better Auth client access | `useAuthClient()` |
 | Sign-in forms that need loading, error, and success state | `useSignIn()` |
 | Sign-up forms that need loading, error, and success state | `useSignUp()` |
 | Better Auth plugin/client methods that need loading, error, and success state | `useAuthClientAction()` |
 
 ## useUserSession
 
-The primary composable for accessing authentication state. Returns reactive user, session, and auth client.
+The primary composable for accessing authentication state. It is safe to return directly from Pinia setup stores because it only exposes session state and session lifecycle actions.
 
 ```ts [pages/login.vue]
-const { loggedIn, user, session, client, signIn, signOut } = useUserSession()
+const { loggedIn, user, session, signOut } = useUserSession()
 ```
 
 ::field-group
@@ -55,14 +56,12 @@ const { loggedIn, user, session, client, signIn, signOut } = useUserSession()
   ::field{name="ready" type="ComputedRef<boolean>"}
     `true` when initial session resolution is complete (from SSR hydration or client fetch).
   ::
-  ::field{name="client" type="AuthClient | null"}
-    Direct access to the Better Auth client instance. Available on client runtime; `null` during SSR/server runtime.
+  ::field{name="signOut" type="(options?: SignOutOptions) => Promise<void>"}
+    Signs out and clears local session state.
   ::
 ::
 
 ::note
-`useUserSession().client` is browser-only. During SSR/server runtime it is `null`.
-
 For SSR-safe auth access:
 - Use `user`, `session`, `loggedIn`, `ready`, and `fetchSession` from `useUserSession()`.
 - Use `useAuthRequestFetch()` or `useAuthAsyncData()` for auth-bound data in pages.
@@ -71,7 +70,7 @@ For SSR-safe auth access:
 
 ## Pinia setup stores
 
-Use `useUserSessionState()` when you want auth state in a Pinia setup store or another shared state container. It exposes the session state and session actions from `useUserSession()` without exposing the Better Auth client namespaces.
+Return `useUserSession()` directly when you want auth state in a Pinia setup store or another shared state container.
 
 It returns:
 - `user`
@@ -85,11 +84,11 @@ It returns:
 
 It does not return `client`, `signIn`, or `signUp`. Those values are runtime Better Auth client namespaces, not auth state. Keep them in components or action composables instead of storing them in hydrated state.
 
-Return `useUserSessionState()` directly from a setup store when the store only needs session state and session actions:
+`useUserSessionState()` remains as a deprecated alias for the same store-safe shape.
 
 ```ts [app/stores/user.ts]
 export const useUserStore = defineStore('user', () => {
-  return useUserSessionState()
+  return useUserSession()
 })
 ```
 
@@ -105,28 +104,18 @@ async function submit(email: string, password: string) {
 </script>
 ```
 
-::note
-If a Pinia store intentionally exposes `useUserSession().client`, keep it out of hydrated state with Pinia's `skipHydrate()` and Vue's `shallowRef()` / `markRaw()`.
+## useAuthClient
 
-Most stores should use `useUserSessionState()` instead.
-::
-
-### Methods
-
-#### `signIn`
-
-Proxies Better Auth `signIn`.
+Returns the Vue-safe Better Auth client on the client runtime and `null` on the server runtime. Use this for direct client/plugin method access when you do not need action state.
 
 ```ts
-await signIn.email({
-  email: 'user@example.com',
-  password: 'password'
-})
+const client = useAuthClient()
+await client?.sendVerificationEmail({ email })
 ```
 
 ### Promise Behavior
 
-Methods like `signIn` return a promise that resolves when the **server responds**, not when local state updates.
+Raw Better Auth client methods return a promise that resolves when the **server responds**, not when local state updates.
 
 ```ts
 // This awaits the server response
@@ -140,30 +129,23 @@ await client.signIn.email(
 )
 ```
 
-If no `onSuccess` callback is provided in method options, `signIn` will:
+For form flows, prefer `useSignIn()` and `useSignUp()` because they normalize errors, sync session state, and apply configured redirects.
+
+## useSignIn / useSignUp redirects
+
+If no `onSuccess` callback is provided in method options, `useSignIn()` will:
 - navigate to `route.query.redirect` (or custom `auth.redirectQueryKey`) when it is a local path
 - otherwise fallback to `auth.redirects.authenticated` when configured and an authenticated session is established
 - otherwise no automatic navigation
 
 ```ts
-await signIn.email({ email, password }) // redirects to safe `?redirect=...` or auth.redirects.authenticated
+await useSignIn('email').execute({ email, password }) // redirects to safe `?redirect=...` or auth.redirects.authenticated
 ```
 
-#### `signUp`
-
-Proxies Better Auth `signUp` with the same `onSuccess` behavior as `signIn`.
-
-```ts
-await signUp.email({
-  email: 'user@example.com',
-  password: 'password'
-})
-```
-
-Like `signIn`, if no callback is provided, `signUp` follows the same redirect precedence:
+`useSignUp()` follows the same redirect precedence:
 query redirect > `auth.redirects.authenticated` (only when authenticated) > no auto-redirect.
 
-#### `signOut`
+### `signOut`
 
 Signs the user out and clears the local session state.
 
@@ -322,7 +304,7 @@ if (saveProfile.status.value === 'error') {
 
 ## useAuthClientAction
 
-Wraps plugin/client methods from `useUserSession().client` in the same action handle pattern.
+Wraps plugin/client methods from `useAuthClient()` in the same action handle pattern.
 
 ```ts [pages/pricing.vue]
 const checkout = useAuthClientAction((client) => client.checkout)
@@ -343,7 +325,7 @@ await openPortal.execute()
 
 ## useSignIn
 
-Returns a keyed action handle for `useUserSession().signIn.*`. Each method handle exposes template-friendly async state, similar to composables like `useFetch`.
+Returns a keyed action handle for Better Auth `signIn.*`. Each method handle exposes template-friendly async state, similar to composables like `useFetch`.
 
 ```ts [pages/login.vue]
 const { execute, data, status, error } = useSignIn('email')
@@ -450,7 +432,7 @@ If you relied on raw payloads, use `error.raw`.
 
 ## useSignUp
 
-Same API as `useSignIn`, but wraps `useUserSession().signUp.*`.
+Same API as `useSignIn`, but wraps Better Auth `signUp.*`.
 
 ```ts [pages/signup.vue]
 const { execute, data, status, error } = useSignUp('email')

--- a/src/runtime/app/composables/useAuthClient.ts
+++ b/src/runtime/app/composables/useAuthClient.ts
@@ -1,0 +1,44 @@
+import type { AppAuthClient } from '#nuxt-better-auth'
+import createAppAuthClient from '#auth/client'
+import { useRequestURL, useRuntimeConfig } from '#imports'
+import { createVueSafeAuthProxy } from '../internal/vue-safe-auth-proxy'
+
+interface RuntimeFlags { client: boolean, server: boolean }
+
+let _client: AppAuthClient | null = null
+let _clientFacade: AppAuthClient | null = null
+
+export function getAuthRuntimeFlags(): RuntimeFlags {
+  const globalFlags = (globalThis as { __NUXT_BETTER_AUTH_TEST_FLAGS__?: RuntimeFlags }).__NUXT_BETTER_AUTH_TEST_FLAGS__
+  if (globalFlags)
+    return globalFlags
+  return { client: Boolean(import.meta.client), server: Boolean(import.meta.server) }
+}
+
+function getClient(baseURL: string): AppAuthClient {
+  if (!_client)
+    _client = createAppAuthClient(baseURL)
+  return _client
+}
+
+function getClientFacade(client: AppAuthClient): AppAuthClient {
+  if (!_clientFacade)
+    _clientFacade = createVueSafeAuthProxy(client)
+  return _clientFacade
+}
+
+export function useRawAuthClient(): AppAuthClient | null {
+  const runtimeFlags = getAuthRuntimeFlags()
+  if (!runtimeFlags.client)
+    return null
+
+  const runtimeConfig = useRuntimeConfig()
+  const requestURL = useRequestURL()
+  const siteUrl = typeof runtimeConfig.public.siteUrl === 'string' ? runtimeConfig.public.siteUrl : requestURL.origin
+  return getClient(siteUrl)
+}
+
+export function useAuthClient(): AppAuthClient | null {
+  const rawClient = useRawAuthClient()
+  return rawClient ? getClientFacade(rawClient) : null
+}

--- a/src/runtime/app/composables/useAuthClientAction.ts
+++ b/src/runtime/app/composables/useAuthClientAction.ts
@@ -1,9 +1,7 @@
+import type { AppAuthClient } from '#nuxt-better-auth'
 import type { UserAuthActionHandle } from '../internal/auth-action-handles'
-import type { UseUserSessionReturn } from './useUserSession'
 import { useAction } from './useAction'
-import { useUserSession } from './useUserSession'
-
-type AppAuthClient = NonNullable<UseUserSessionReturn['client']>
+import { useAuthClient } from './useAuthClient'
 
 export function useAuthClientAction<TArgs extends unknown[], TResult>(
   select: (client: AppAuthClient) => (...args: TArgs) => Promise<TResult>,
@@ -12,7 +10,7 @@ export function useAuthClientAction<TArgs extends unknown[], TResult>(
     throw new TypeError('useAuthClientAction(select) requires a selector function')
 
   return useAction(async (...args: TArgs) => {
-    const { client } = useUserSession()
+    const client = useAuthClient()
     if (!client)
       throw new Error('Auth client is unavailable. This action can only run on client-side.')
 

--- a/src/runtime/app/composables/useSignIn.ts
+++ b/src/runtime/app/composables/useSignIn.ts
@@ -1,7 +1,7 @@
 import type { AppAuthClient, AuthSocialProviderRegistry } from '#nuxt-better-auth'
 import type { ActionHandleFor, ActionHandleMap } from '../internal/auth-action-handles'
 import { createActionHandles } from '../internal/auth-action-handles'
-import { useUserSession } from './useUserSession'
+import { useAuthActionNamespaces } from './useUserSession'
 
 type SignIn = NonNullable<AppAuthClient>['signIn']
 type AuthSocialProviderId = AuthSocialProviderRegistry extends { ids: infer T } ? Extract<T, string> : never
@@ -16,7 +16,7 @@ export function useSignIn<MethodKey extends keyof SignInWithTypedSocial>(method:
   if (method === undefined || method === null)
     throw new TypeError('useSignIn(method) requires a sign-in method key')
 
-  const handles = createActionHandles(() => useUserSession().signIn as SignInWithTypedSocial, 'signIn') as ActionHandleMap<SignInWithTypedSocial>
+  const handles = createActionHandles(() => useAuthActionNamespaces().signIn as SignInWithTypedSocial, 'signIn') as ActionHandleMap<SignInWithTypedSocial>
 
   return handles[method] as ActionHandleFor<SignInWithTypedSocial[MethodKey]>
 }

--- a/src/runtime/app/composables/useSignUp.ts
+++ b/src/runtime/app/composables/useSignUp.ts
@@ -1,7 +1,7 @@
 import type { AppAuthClient } from '#nuxt-better-auth'
 import type { ActionHandleFor, ActionHandleMap } from '../internal/auth-action-handles'
 import { createActionHandles } from '../internal/auth-action-handles'
-import { useUserSession } from './useUserSession'
+import { useAuthActionNamespaces } from './useUserSession'
 
 type SignUp = NonNullable<AppAuthClient>['signUp']
 
@@ -9,6 +9,6 @@ export function useSignUp<MethodKey extends keyof SignUp>(method: MethodKey): Ac
   if (method === undefined || method === null)
     throw new TypeError('useSignUp(method) requires a sign-up method key')
 
-  const handles = createActionHandles(() => useUserSession().signUp, 'signUp') as ActionHandleMap<SignUp>
+  const handles = createActionHandles(() => useAuthActionNamespaces().signUp, 'signUp') as ActionHandleMap<SignUp>
   return handles[method] as ActionHandleFor<SignUp[MethodKey]>
 }

--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -1,57 +1,31 @@
 import type { AppAuthClient, AuthSession, AuthUser } from '#nuxt-better-auth'
 import type { ComputedRef, Ref } from 'vue'
-import createAppAuthClient from '#auth/client'
 import { computed, navigateTo, nextTick, useNuxtApp, useRequestURL, useRuntimeConfig, useState, watch } from '#imports'
 import { normalizeAuthActionError } from '../internal/auth-action-error'
 import { resolvePostAuthSuccessRedirect, withFallbackSocialCallbackURL } from '../internal/redirect-helpers'
 import { fetchSessionClient, fetchSessionServer, stripToken } from '../internal/session-fetch'
 import { isRecord } from '../internal/utils'
-import { createVueSafeAuthProxy, isAuthProxyProbeKey } from '../internal/vue-safe-auth-proxy'
+import { createVueSafeAuthFacade, isAuthProxyProbeKey } from '../internal/vue-safe-auth-proxy'
 import { wrapAuthMethod } from '../internal/wrap-auth-method'
+import { getAuthRuntimeFlags, useRawAuthClient } from './useAuthClient'
 
 export interface SignOutOptions { onSuccess?: () => void | Promise<void> }
-interface RuntimeFlags { client: boolean, server: boolean }
 
 let _sessionSignalListenerBound = false
 let _signOutPromise: Promise<void> | null = null
 
 export interface UseUserSessionReturn {
-  client: AppAuthClient | null
   session: Ref<AuthSession | null>
   user: Ref<AuthUser | null>
   loggedIn: ComputedRef<boolean>
   ready: ComputedRef<boolean>
-  signIn: NonNullable<AppAuthClient>['signIn']
-  signUp: NonNullable<AppAuthClient>['signUp']
   signOut: (options?: SignOutOptions) => Promise<void>
   waitForSession: () => Promise<void>
   fetchSession: (options?: { headers?: HeadersInit, force?: boolean }) => Promise<void>
   updateUser: (updates: Partial<AuthUser>) => Promise<void>
 }
 
-// Singleton client instance to ensure consistent state across all useUserSession calls
-let _client: AppAuthClient | null = null
-let _clientFacade: AppAuthClient | null = null
 interface UpdateUserResponse { error?: unknown }
-
-function getClient(baseURL: string): AppAuthClient {
-  if (!_client)
-    _client = createAppAuthClient(baseURL)
-  return _client
-}
-
-function getClientFacade(client: AppAuthClient): AppAuthClient {
-  if (!_clientFacade)
-    _clientFacade = createVueSafeAuthProxy(client)
-  return _clientFacade
-}
-
-function getRuntimeFlags(): RuntimeFlags {
-  const globalFlags = (globalThis as { __NUXT_BETTER_AUTH_TEST_FLAGS__?: RuntimeFlags }).__NUXT_BETTER_AUTH_TEST_FLAGS__
-  if (globalFlags)
-    return globalFlags
-  return { client: Boolean(import.meta.client), server: Boolean(import.meta.server) }
-}
 
 function createServerOnlyActionNamespace(path: string) {
   return new Proxy({}, {
@@ -92,18 +66,10 @@ function ensureSessionSignalListener(client: AppAuthClient, onSignal: () => Prom
 }
 
 export function useUserSession(): UseUserSessionReturn {
-  const runtimeFlags = getRuntimeFlags()
+  const runtimeFlags = getAuthRuntimeFlags()
   const runtimeConfig = useRuntimeConfig()
-  const requestURL = useRequestURL()
   const nuxtApp = useNuxtApp()
-  const siteUrl = typeof runtimeConfig.public.siteUrl === 'string' ? runtimeConfig.public.siteUrl : requestURL.origin
-
-  const rawClient: AppAuthClient | null = runtimeFlags.client
-    ? getClient(siteUrl)
-    : null
-  const client: AppAuthClient | null = rawClient
-    ? getClientFacade(rawClient)
-    : null
+  const rawClient = useRawAuthClient()
 
   // Shared state via useState for SSR hydration
   const session = useState<AuthSession | null>('auth:session', () => null)
@@ -262,56 +228,6 @@ export function useUserSession(): UseUserSessionReturn {
     })
   }
 
-  // Wrap signIn/signUp methods to sync session before executing onSuccess
-  type SignIn = NonNullable<AppAuthClient>['signIn']
-  type SignUp = NonNullable<AppAuthClient>['signUp']
-
-  const wrapDeps = {
-    fetchSession,
-    loggedIn,
-    waitForSession,
-    resolvePostAuthSuccessRedirect: () => resolvePostAuthSuccessRedirect(requestURL),
-  }
-
-  const signIn: SignIn = rawClient?.signIn
-    ? new Proxy(rawClient.signIn, {
-        get(target, prop) {
-          if (isAuthProxyProbeKey(prop))
-            return undefined
-          const targetRecord = target as Record<string | symbol, unknown>
-          const method = targetRecord[prop]
-          if (typeof method !== 'function')
-            return method
-          const shouldSkipSessionSync = prop === 'social'
-            ? (data: unknown) => {
-                const socialData = isRecord(data) ? data : undefined
-                return socialData?.disableRedirect !== true
-              }
-            : undefined
-          const transformData = prop === 'social' ? (data: unknown) => withFallbackSocialCallbackURL(data, requestURL) : undefined
-          return wrapAuthMethod(
-            (...args: unknown[]) => (targetRecord[prop] as (...a: unknown[]) => Promise<unknown>)(...args),
-            wrapDeps,
-            { shouldSkipSessionSync, transformData },
-          )
-        },
-      })
-    : _signInServerOnly as SignIn
-
-  const signUp: SignUp = rawClient?.signUp
-    ? new Proxy(rawClient.signUp, {
-        get(target, prop) {
-          if (isAuthProxyProbeKey(prop))
-            return undefined
-          const targetRecord = target as Record<string | symbol, unknown>
-          const method = targetRecord[prop]
-          if (typeof method !== 'function')
-            return method
-          return wrapAuthMethod((...args: unknown[]) => (targetRecord[prop] as (...a: unknown[]) => Promise<unknown>)(...args), wrapDeps)
-        },
-      })
-    : _signUpServerOnly as SignUp
-
   if (runtimeFlags.client && rawClient && shouldSkipInitialClientSessionFetch.value) {
     ensureSessionSignalListener(rawClient, () => fetchSession({ force: true }))
   }
@@ -348,16 +264,61 @@ export function useUserSession(): UseUserSessionReturn {
   }
 
   return {
-    client,
     session,
     user,
     loggedIn,
     ready,
-    signIn,
-    signUp,
     signOut,
     waitForSession,
     fetchSession,
     updateUser,
   }
+}
+
+export function useAuthActionNamespaces() {
+  const rawClient = useRawAuthClient()
+  const auth = useUserSession()
+  const requestURL = useRequestURL()
+  type SignIn = NonNullable<AppAuthClient>['signIn']
+  type SignUp = NonNullable<AppAuthClient>['signUp']
+
+  const wrapDeps = {
+    fetchSession: auth.fetchSession,
+    loggedIn: auth.loggedIn,
+    waitForSession: auth.waitForSession,
+    resolvePostAuthSuccessRedirect: () => resolvePostAuthSuccessRedirect(requestURL),
+  }
+
+  const signIn: SignIn = rawClient?.signIn
+    ? createVueSafeAuthFacade((prop) => {
+        const targetRecord = rawClient.signIn as Record<string | symbol, unknown>
+        const method = targetRecord[prop]
+        if (typeof method !== 'function')
+          return method
+        const shouldSkipSessionSync = prop === 'social'
+          ? (data: unknown) => {
+              const socialData = isRecord(data) ? data : undefined
+              return socialData?.disableRedirect !== true
+            }
+          : undefined
+        const transformData = prop === 'social' ? (data: unknown) => withFallbackSocialCallbackURL(data, requestURL) : undefined
+        return wrapAuthMethod(
+          (...args: unknown[]) => (targetRecord[prop] as (...a: unknown[]) => Promise<unknown>)(...args),
+          wrapDeps,
+          { shouldSkipSessionSync, transformData },
+        )
+      })
+    : _signInServerOnly as SignIn
+
+  const signUp: SignUp = rawClient?.signUp
+    ? createVueSafeAuthFacade((prop) => {
+        const targetRecord = rawClient.signUp as Record<string | symbol, unknown>
+        const method = targetRecord[prop]
+        if (typeof method !== 'function')
+          return method
+        return wrapAuthMethod((...args: unknown[]) => (targetRecord[prop] as (...a: unknown[]) => Promise<unknown>)(...args), wrapDeps)
+      })
+    : _signUpServerOnly as SignUp
+
+  return { signIn, signUp }
 }

--- a/src/runtime/app/composables/useUserSessionState.ts
+++ b/src/runtime/app/composables/useUserSessionState.ts
@@ -1,19 +1,8 @@
 import type { UseUserSessionReturn } from './useUserSession'
 import { useUserSession } from './useUserSession'
 
-export type UseUserSessionStateReturn = Pick<UseUserSessionReturn, 'session' | 'user' | 'loggedIn' | 'ready' | 'signOut' | 'waitForSession' | 'fetchSession' | 'updateUser'>
+export type UseUserSessionStateReturn = UseUserSessionReturn
 
 export function useUserSessionState(): UseUserSessionStateReturn {
-  const auth = useUserSession()
-
-  return {
-    session: auth.session,
-    user: auth.user,
-    loggedIn: auth.loggedIn,
-    ready: auth.ready,
-    signOut: auth.signOut,
-    waitForSession: auth.waitForSession,
-    fetchSession: auth.fetchSession,
-    updateUser: auth.updateUser,
-  }
+  return useUserSession()
 }

--- a/src/runtime/app/internal/vue-safe-auth-proxy.ts
+++ b/src/runtime/app/internal/vue-safe-auth-proxy.ts
@@ -8,6 +8,31 @@ function isObjectLike(value: unknown): value is object {
   return (typeof value === 'object' && value !== null) || typeof value === 'function'
 }
 
+export function createVueSafeAuthFacade<T extends object>(
+  resolve: (prop: PropertyKey, receiver: object) => unknown,
+): T {
+  const propertyCache = new Map<PropertyKey, unknown>()
+  const facadeTarget = {}
+  Object.defineProperty(facadeTarget, '__v_skip', {
+    value: true,
+    configurable: true,
+  })
+
+  return new Proxy(facadeTarget, {
+    get(_target, prop, receiver) {
+      if (prop === '__v_skip')
+        return true
+      if (isAuthProxyProbeKey(prop))
+        return undefined
+      if (propertyCache.has(prop))
+        return propertyCache.get(prop)
+      const value = resolve(prop, receiver)
+      propertyCache.set(prop, value)
+      return value
+    },
+  }) as T
+}
+
 export function createVueSafeAuthProxy<T>(target: T): T {
   if (!isObjectLike(target))
     return target
@@ -25,6 +50,8 @@ export function createVueSafeAuthProxy<T>(target: T): T {
     const propertyCache = new Map<PropertyKey, unknown>()
     const handler: ProxyHandler<object> = {
       get(target, prop, receiver) {
+        if (prop === '__v_skip')
+          return true
         if (isAuthProxyProbeKey(prop))
           return undefined
         if (propertyCache.has(prop))
@@ -48,26 +75,7 @@ export function createVueSafeAuthProxy<T>(target: T): T {
     if (!isObjectLike(value))
       return value
 
-    const propertyCache = new Map<PropertyKey, unknown>()
-    const facadeTarget = {}
-    Object.defineProperty(facadeTarget, '__v_skip', {
-      value: true,
-      configurable: true,
-    })
-
-    const proxy = new Proxy(facadeTarget, {
-      get(_target, prop, receiver) {
-        if (prop === '__v_skip')
-          return true
-        if (isAuthProxyProbeKey(prop))
-          return undefined
-        if (propertyCache.has(prop))
-          return propertyCache.get(prop)
-        const wrapped = wrap(Reflect.get(value, prop, receiver))
-        propertyCache.set(prop, wrapped)
-        return wrapped
-      },
-    })
+    const proxy = createVueSafeAuthFacade<object>((prop, receiver) => wrap(Reflect.get(value, prop, receiver)))
     cache.set(value, proxy)
     return proxy as V
   }

--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -1,5 +1,6 @@
 export { useAction } from './app/composables/useAction'
 export { useAuthAsyncData } from './app/composables/useAuthAsyncData'
+export { useAuthClient } from './app/composables/useAuthClient'
 export { useAuthClientAction } from './app/composables/useAuthClientAction'
 export { useAuthRequestFetch } from './app/composables/useAuthRequestFetch'
 export { useSignIn } from './app/composables/useSignIn'

--- a/src/runtime/types/augment.ts
+++ b/src/runtime/types/augment.ts
@@ -38,13 +38,10 @@ export interface AuthSocialProviderRegistry {}
 
 // Composable return type
 export interface UserSessionComposable {
-  client: unknown
   user: Ref<AuthUser | null>
   session: Ref<AuthSession | null>
   loggedIn: ComputedRef<boolean>
   ready: ComputedRef<boolean>
-  signIn: unknown
-  signUp: unknown
   fetchSession: (options?: { headers?: HeadersInit, force?: boolean }) => Promise<void>
   waitForSession: () => Promise<void>
   signOut: (options?: { onSuccess?: () => void | Promise<void> }) => Promise<void>

--- a/test/cases/composables-subpath-import/typecheck-target.ts
+++ b/test/cases/composables-subpath-import/typecheck-target.ts
@@ -1,5 +1,5 @@
 import type { UseUserSessionStateReturn } from '@onmax/nuxt-better-auth/composables'
-import { useAuthAsyncData, useAuthRequestFetch, useSignIn, useSignUp, useUserSession, useUserSessionState } from '@onmax/nuxt-better-auth/composables'
+import { useAuthAsyncData, useAuthClient, useAuthRequestFetch, useSignIn, useSignUp, useUserSession, useUserSessionState } from '@onmax/nuxt-better-auth/composables'
 
 const auth = useUserSession()
 auth.loggedIn.value satisfies boolean
@@ -9,6 +9,9 @@ const authState = useUserSessionState()
 authState satisfies UseUserSessionStateReturn
 authState.loggedIn.value satisfies boolean
 authState.fetchSession({ force: true })
+
+const client = useAuthClient()
+client?.signOut()
 
 const signIn = useSignIn('email')
 signIn.execute({ email: 'user@example.com', password: 'password' })

--- a/test/cases/pinia-setup-store/app/pages/index.vue
+++ b/test/cases/pinia-setup-store/app/pages/index.vue
@@ -18,11 +18,5 @@ const sessionState = useSessionStateStore()
     <p data-testid="full-actions">
       Full actions: {{ typeof fullAuth.signOut }}
     </p>
-    <p data-testid="client-type">
-      Client type: {{ typeof fullAuth.authClient }}
-    </p>
-    <p data-testid="verification-type">
-      Verification type: {{ typeof fullAuth.authClient?.sendVerificationEmail }}
-    </p>
   </main>
 </template>

--- a/test/cases/pinia-setup-store/app/stores/full-auth.ts
+++ b/test/cases/pinia-setup-store/app/stores/full-auth.ts
@@ -1,7 +1,5 @@
 import { defineStore } from 'pinia'
 
 export const useFullAuthStore = defineStore('full-auth', () => {
-  const { client: authClient, ...auth } = useUserSession()
-
-  return { authClient, ...auth }
+  return useUserSession()
 })

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -35,6 +35,7 @@ describe('exports-snapshot', async () => {
       './composables': {
         useAction: 'function',
         useAuthAsyncData: 'function',
+        useAuthClient: 'function',
         useAuthClientAction: 'function',
         useAuthRequestFetch: 'function',
         useSignIn: 'function',

--- a/test/exports/module.yaml
+++ b/test/exports/module.yaml
@@ -5,6 +5,7 @@
 ./composables:
   useAction: function
   useAuthAsyncData: function
+  useAuthClient: function
   useAuthClientAction: function
   useAuthRequestFetch: function
   useSignIn: function

--- a/test/pinia-setup-store.test.ts
+++ b/test/pinia-setup-store.test.ts
@@ -7,7 +7,7 @@ describe('pinia setup store auth regression', async () => {
     rootDir: fileURLToPath(new URL('./cases/pinia-setup-store', import.meta.url)),
   })
 
-  it('renders setup stores that expose auth state and client facades', async () => {
+  it('renders setup stores that expose auth state directly', async () => {
     await expect($fetch('/')).resolves.toContain('Pinia Auth Store')
   })
 })

--- a/test/use-auth-client-action.test.ts
+++ b/test/use-auth-client-action.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-let sessionMock: any
+let clientMock: any
 
 vi.mock('#imports', async () => {
   const vue = await import('vue')
@@ -10,8 +10,8 @@ vi.mock('#imports', async () => {
   }
 })
 
-vi.mock('../src/runtime/app/composables/useUserSession', () => ({
-  useUserSession: () => sessionMock,
+vi.mock('../src/runtime/app/composables/useAuthClient', () => ({
+  useAuthClient: () => clientMock,
 }))
 
 async function loadUseAuthClientAction() {
@@ -23,9 +23,7 @@ async function loadUseAuthClientAction() {
 describe('useAuthClientAction', () => {
   it('executes selected top-level client method', async () => {
     const checkout = vi.fn(async () => ({ ok: true }))
-    sessionMock = {
-      client: { checkout },
-    }
+    clientMock = { checkout }
 
     const useAuthClientAction = await loadUseAuthClientAction()
     const action = useAuthClientAction(client => client.checkout as any)
@@ -38,9 +36,7 @@ describe('useAuthClientAction', () => {
 
   it('executes selected nested client method', async () => {
     const portal = vi.fn(async () => ({ opened: true }))
-    sessionMock = {
-      client: { customer: { portal } },
-    }
+    clientMock = { customer: { portal } }
 
     const useAuthClientAction = await loadUseAuthClientAction()
     const action = useAuthClientAction(client => client.customer.portal as any)
@@ -51,7 +47,7 @@ describe('useAuthClientAction', () => {
   })
 
   it('sets normalized error when client is unavailable', async () => {
-    sessionMock = { client: null }
+    clientMock = null
 
     const useAuthClientAction = await loadUseAuthClientAction()
     const action = useAuthClientAction(client => client.checkout as any)
@@ -62,7 +58,7 @@ describe('useAuthClientAction', () => {
   })
 
   it('sets normalized error when selector does not resolve to a function', async () => {
-    sessionMock = { client: { customer: {} } }
+    clientMock = { customer: {} }
 
     const useAuthClientAction = await loadUseAuthClientAction()
     const action = useAuthClientAction(client => (client as any).customer.portal)

--- a/test/use-auth-client.test.ts
+++ b/test/use-auth-client.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest'
+import { isReactive, isRef } from 'vue'
+
+const runtimeConfig = {
+  public: {
+    siteUrl: 'http://localhost:3000',
+  },
+}
+const requestURL = {
+  origin: 'http://request-origin.test',
+}
+const rawClient = {
+  signIn: {
+    email: vi.fn(async () => ({ ok: true })),
+  },
+  sendVerificationEmail: vi.fn(async () => ({ ok: true })),
+}
+const createAppAuthClient = vi.fn(() => rawClient)
+
+vi.mock('#auth/client', () => ({
+  default: createAppAuthClient,
+}))
+
+vi.mock('#imports', () => ({
+  useRequestURL: () => requestURL,
+  useRuntimeConfig: () => runtimeConfig,
+}))
+
+function setRuntimeFlags(flags: { client: boolean, server: boolean }) {
+  const state = globalThis as { __NUXT_BETTER_AUTH_TEST_FLAGS__?: { client: boolean, server: boolean } }
+  state.__NUXT_BETTER_AUTH_TEST_FLAGS__ = flags
+}
+
+async function loadUseAuthClient() {
+  vi.resetModules()
+  const mod = await import('../src/runtime/app/composables/useAuthClient')
+  return mod.useAuthClient
+}
+
+describe('useAuthClient', () => {
+  it('returns null on server runtime', async () => {
+    setRuntimeFlags({ client: false, server: true })
+
+    const useAuthClient = await loadUseAuthClient()
+
+    expect(useAuthClient()).toBeNull()
+    expect(createAppAuthClient).not.toHaveBeenCalled()
+  })
+
+  it('returns a Vue-safe client facade on client runtime', async () => {
+    setRuntimeFlags({ client: true, server: false })
+
+    const useAuthClient = await loadUseAuthClient()
+    const client = useAuthClient()
+
+    expect(createAppAuthClient).toHaveBeenCalledWith('http://localhost:3000')
+    expect(client).not.toBeNull()
+    expect(isRef(client!.signIn.email)).toBe(false)
+    expect(isReactive(client!.signIn.email)).toBe(false)
+    await expect(client!.signIn.email({ email: 'user@example.com', password: 'password' })).resolves.toEqual({ ok: true })
+  })
+})

--- a/test/use-signin.test.ts
+++ b/test/use-signin.test.ts
@@ -13,6 +13,7 @@ vi.mock('#imports', async () => {
 
 vi.mock('../src/runtime/app/composables/useUserSession', () => ({
   useUserSession: () => sessionMock,
+  useAuthActionNamespaces: () => sessionMock,
 }))
 
 async function loadUseSignIn() {

--- a/test/use-signup.test.ts
+++ b/test/use-signup.test.ts
@@ -13,6 +13,7 @@ vi.mock('#imports', async () => {
 
 vi.mock('../src/runtime/app/composables/useUserSession', () => ({
   useUserSession: () => sessionMock,
+  useAuthActionNamespaces: () => sessionMock,
 }))
 
 async function loadUseSignUp() {

--- a/test/use-user-session-state.test.ts
+++ b/test/use-user-session-state.test.ts
@@ -10,14 +10,6 @@ vi.mock('../src/runtime/app/composables/useUserSession', () => ({
   useUserSession: authMock.useUserSession,
 }))
 
-function createRecursiveProxy(): any {
-  return new Proxy({}, {
-    get() {
-      return createRecursiveProxy()
-    },
-  })
-}
-
 function expectPiniaInspectionSafe(value: unknown) {
   expect(() => isRef(value)).not.toThrow()
   expect(() => isReadonly(value)).not.toThrow()
@@ -28,9 +20,6 @@ function expectPiniaInspectionSafe(value: unknown) {
 describe('useUserSessionState', () => {
   beforeEach(() => {
     authMock.useUserSession.mockReturnValue({
-      client: createRecursiveProxy(),
-      signIn: createRecursiveProxy(),
-      signUp: createRecursiveProxy(),
       session: ref(null),
       user: ref(null),
       loggedIn: computed(() => false),

--- a/test/use-user-session.test.ts
+++ b/test/use-user-session.test.ts
@@ -1,6 +1,6 @@
 import { createPinia, defineStore, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { isReactive, isReadonly, isRef, reactive, ref, watch } from 'vue'
+import { isReactive, isRef, ref, watch } from 'vue'
 
 interface SessionState {
   data: { session: Record<string, unknown>, user: Record<string, unknown> } | null
@@ -100,6 +100,11 @@ async function loadUseUserSession() {
   return mod.useUserSession
 }
 
+async function loadAuthComposables() {
+  vi.resetModules()
+  return import('../src/runtime/app/composables/useUserSession')
+}
+
 async function flushPromises() {
   await Promise.resolve()
   await Promise.resolve()
@@ -133,16 +138,6 @@ function createDynamicAuthProxy(routes: Record<string, unknown> = {}, calls: str
       return Promise.resolve({})
     },
   })
-}
-
-function expectVueInspectionSafe(value: unknown) {
-  expect(() => isRef(value)).not.toThrow()
-  expect(() => isReadonly(value)).not.toThrow()
-  expect(() => isReactive(value)).not.toThrow()
-  expect(() => reactive({ value })).not.toThrow()
-  expect(isRef(value)).toBe(false)
-  expect(isReadonly(value)).toBe(false)
-  expect(isReactive(value)).toBe(false)
 }
 
 describe('useUserSession hydration bootstrap', () => {
@@ -228,9 +223,9 @@ describe('useUserSession hydration bootstrap', () => {
     runtimeConfig.public.auth.session.skipHydratedSsrGetSession = true
 
     const useUserSession = await loadUseUserSession()
-    const auth = useUserSession()
+    useUserSession()
 
-    expect(auth.client).not.toBeNull()
+    expect(mockClient.useSession).toHaveBeenCalledOnce()
   })
 
   it('bootstraps client session for prerendered/cached payloads', async () => {
@@ -240,9 +235,9 @@ describe('useUserSession hydration bootstrap', () => {
     seedHydratedState()
 
     const useUserSession = await loadUseUserSession()
-    const auth = useUserSession()
+    useUserSession()
 
-    expect(auth.client).not.toBeNull()
+    expect(mockClient.useSession).toHaveBeenCalledOnce()
   })
 
   it('defers ready reset until suspense resolves during prerender hydration empty snapshot', async () => {
@@ -307,9 +302,9 @@ describe('useUserSession hydration bootstrap', () => {
     seedHydratedState()
 
     const useUserSession = await loadUseUserSession()
-    const auth = useUserSession()
+    useUserSession()
 
-    expect(auth.client).not.toBeNull()
+    expect(mockClient.useSession).toHaveBeenCalledOnce()
   })
 
   it('reconciles hydrated SSR auth state before clearing it', async () => {
@@ -462,32 +457,28 @@ describe('useUserSession hydration bootstrap', () => {
     expect(auth.ready.value).toBe(true)
   })
 
-  it('exposes client as null on server runtime', async () => {
+  it('returns only store-safe session state and actions', async () => {
     setRuntimeFlags({ client: false, server: true })
 
     const useUserSession = await loadUseUserSession()
     const auth = useUserSession()
 
-    expect(auth.client).toBeNull()
+    expect(Object.keys(auth).sort()).toEqual([
+      'fetchSession',
+      'loggedIn',
+      'ready',
+      'session',
+      'signOut',
+      'updateUser',
+      'user',
+      'waitForSession',
+    ])
+    expect('client' in auth).toBe(false)
+    expect('signIn' in auth).toBe(false)
+    expect('signUp' in auth).toBe(false)
   })
 
-  it('allows SSR metadata introspection on signIn and signUp without throwing', async () => {
-    setRuntimeFlags({ client: false, server: true })
-
-    const useUserSession = await loadUseUserSession()
-    const auth = useUserSession()
-
-    expect(isRef(auth.signIn as unknown)).toBe(false)
-    expect(isReactive(auth.signIn as unknown)).toBe(false)
-    expect(isRef(auth.signUp as unknown)).toBe(false)
-    expect(isReactive(auth.signUp as unknown)).toBe(false)
-    expect((auth.signIn as Record<string, unknown>).__v_isRef).toBeUndefined()
-    expect((auth.signIn as Record<string, unknown>).__v_isReactive).toBeUndefined()
-    expect((auth.signUp as Record<string, unknown>).__v_isRef).toBeUndefined()
-    expect((auth.signUp as Record<string, unknown>).__v_isReactive).toBeUndefined()
-  })
-
-  it('allows client-side metadata introspection on the Better Auth client facade', async () => {
+  it('keeps useUserSession safe for Pinia setup-store forwarding on client', async () => {
     const rawClient = createDynamicAuthProxy({
       useSession: mockClient.useSession,
       getSession: mockClient.getSession,
@@ -499,88 +490,35 @@ describe('useUserSession hydration bootstrap', () => {
     activeClient = rawClient
 
     const useUserSession = await loadUseUserSession()
-    const auth = useUserSession()
-    const secondAuth = useUserSession()
-
-    expect(auth.client).not.toBe(rawClient)
-    expect(typeof auth.client).toBe('object')
-    expect(secondAuth.client).toBe(auth.client)
-    expect(secondAuth.client!.signIn).toBe(auth.client!.signIn)
-    expect(secondAuth.client!.signIn.email).toBe(auth.client!.signIn.email)
-    expect(typeof (auth.client as Record<string, unknown>).sendVerificationEmail).toBe('function')
-    expectVueInspectionSafe(auth.client)
-    expectVueInspectionSafe(auth.client!.signIn)
-    expectVueInspectionSafe(auth.client!.signIn.email)
-    expectVueInspectionSafe(auth.client!.signUp)
-    expectVueInspectionSafe(auth.client!.signUp.email)
-    expectVueInspectionSafe((auth.client as Record<string, any>).sendVerificationEmail)
-    expectVueInspectionSafe(auth.client!.admin.impersonateUser)
-  })
-
-  it('keeps forwarded useUserSession actions out of Pinia setup-store state classification on client', async () => {
-    const rawClient = createDynamicAuthProxy({
-      useSession: mockClient.useSession,
-      getSession: mockClient.getSession,
-      signOut: mockClient.signOut,
-      signIn: createDynamicAuthProxy(),
-      signUp: createDynamicAuthProxy(),
-      $store: mockClient.$store,
-    })
-    activeClient = rawClient
-
-    const useUserSession = await loadUseUserSession()
-    const { user, client: authClient, fetchSession, ...rest } = useUserSession()
-    const store = {
-      user,
-      authClient,
-      fetchSession,
-      ...rest,
-    }
+    const store = { ...useUserSession() }
     const isStateLike = (value: unknown) => isRef(value) || isReactive(value)
 
-    expect(isStateLike(store.authClient)).toBe(false)
-    expect(isStateLike(store.signIn)).toBe(false)
-    expect(isStateLike(store.signUp)).toBe(false)
-    expect(typeof store.authClient).toBe('object')
-    expect(typeof (store.authClient as Record<string, unknown>).sendVerificationEmail).toBe('function')
-    expect(isStateLike((store.authClient as Record<string, unknown>).signIn)).toBe(false)
-    expect(isStateLike((store.authClient as Record<string, unknown>).admin)).toBe(false)
-    expect(isStateLike((store.authClient as Record<string, unknown>).sendVerificationEmail)).toBe(false)
-    expect(isStateLike((store.signIn as Record<string, unknown>).email)).toBe(false)
-    expect(isStateLike((store.signUp as Record<string, unknown>).email)).toBe(false)
+    expect('client' in store).toBe(false)
+    expect('signIn' in store).toBe(false)
+    expect('signUp' in store).toBe(false)
+    expect(isStateLike(store.signOut)).toBe(false)
+    expect(isStateLike(store.fetchSession)).toBe(false)
   })
 
-  it('keeps forwarded authClient methods callable in an actual Pinia setup store', async () => {
-    const rawClient = createDynamicAuthProxy({
-      useSession: mockClient.useSession,
-      getSession: mockClient.getSession,
-      signOut: mockClient.signOut,
-      signIn: createDynamicAuthProxy(),
-      signUp: createDynamicAuthProxy(),
-      $store: mockClient.$store,
-    })
-    activeClient = rawClient
+  it('can return useUserSession directly from an actual Pinia setup store', async () => {
     setActivePinia(createPinia())
 
     const useUserSession = await loadUseUserSession()
-    const useAuthStore = defineStore('auth-client-forwarding', () => {
-      const { client: authClient, ...auth } = useUserSession()
-      return { authClient, ...auth }
-    })
+    const useAuthStore = defineStore('auth-session-forwarding', () => useUserSession())
     const store = useAuthStore()
 
-    expect(typeof store.authClient).toBe('object')
-    expect(typeof (store.authClient as Record<string, unknown>).sendVerificationEmail).toBe('function')
-    expect(isRef(store.authClient as unknown)).toBe(false)
-    expect(isReactive(store.authClient as unknown)).toBe(false)
-    expect(isReactive((store.authClient as Record<string, unknown>).sendVerificationEmail)).toBe(false)
+    expect('client' in store).toBe(false)
+    expect('signIn' in store).toBe(false)
+    expect('signUp' in store).toBe(false)
+    expect(isReactive(store.signOut)).toBe(false)
+    expect(isReactive(store.fetchSession)).toBe(false)
   })
 
-  it('allows server-side auth method reads but still rejects invocation', async () => {
+  it('allows server-side auth method reads through action namespaces but still rejects invocation', async () => {
     setRuntimeFlags({ client: false, server: true })
 
-    const useUserSession = await loadUseUserSession()
-    const auth = useUserSession()
+    const { useAuthActionNamespaces } = await loadAuthComposables()
+    const auth = useAuthActionNamespaces()
 
     const signInEmail = (auth.signIn as Record<string, (...args: unknown[]) => Promise<unknown>>).email
     const signUpEmail = (auth.signUp as Record<string, (...args: unknown[]) => Promise<unknown>>).email
@@ -594,23 +532,18 @@ describe('useUserSession hydration bootstrap', () => {
     await expect(signUpEmail({ email: 'user@example.com', password: 'password', name: 'User' })).rejects.toThrow('signUp.email() can only be called on client-side')
   })
 
-  it('keeps forwarded useUserSession actions out of Pinia setup-store state classification during SSR', async () => {
+  it('keeps useUserSession safe for Pinia setup-store forwarding during SSR', async () => {
     setRuntimeFlags({ client: false, server: true })
 
     const useUserSession = await loadUseUserSession()
-    const { user, client: authClient, fetchSession, ...rest } = useUserSession()
-    const store = {
-      user,
-      authClient,
-      fetchSession,
-      ...rest,
-    }
+    const store = { ...useUserSession() }
     const isStateLike = (value: unknown) => isRef(value) || isReactive(value)
 
-    expect(isStateLike(store.signIn)).toBe(false)
-    expect(isStateLike(store.signUp)).toBe(false)
-    expect(isStateLike((store.signIn as Record<string, unknown>).email)).toBe(false)
-    expect(isStateLike((store.signUp as Record<string, unknown>).email)).toBe(false)
+    expect('client' in store).toBe(false)
+    expect('signIn' in store).toBe(false)
+    expect('signUp' in store).toBe(false)
+    expect(isStateLike(store.signOut)).toBe(false)
+    expect(isStateLike(store.fetchSession)).toBe(false)
   })
 
   it('signIn uses auth.redirects.authenticated when no callback is provided', async () => {
@@ -625,8 +558,8 @@ describe('useUserSession hydration bootstrap', () => {
       await opts?.onSuccess?.('ctx')
     })
 
-    const useUserSession = await loadUseUserSession()
-    const auth = useUserSession()
+    const { useAuthActionNamespaces } = await loadAuthComposables()
+    const auth = useAuthActionNamespaces()
 
     await auth.signIn.email({ email: 'user@example.com', password: 'password' })
     expect(navigateTo).toHaveBeenCalledWith('/app')
@@ -645,8 +578,8 @@ describe('useUserSession hydration bootstrap', () => {
       await opts?.onSuccess?.('ctx')
     })
 
-    const useUserSession = await loadUseUserSession()
-    const auth = useUserSession()
+    const { useAuthActionNamespaces } = await loadAuthComposables()
+    const auth = useAuthActionNamespaces()
 
     await auth.signIn.email({ email: 'user@example.com', password: 'password' })
     expect(navigateTo).toHaveBeenCalledWith('/app/billing')
@@ -665,8 +598,8 @@ describe('useUserSession hydration bootstrap', () => {
       await opts?.onSuccess?.('ctx')
     })
 
-    const useUserSession = await loadUseUserSession()
-    const auth = useUserSession()
+    const { useAuthActionNamespaces } = await loadAuthComposables()
+    const auth = useAuthActionNamespaces()
 
     await auth.signIn.email({ email: 'user@example.com', password: 'password' })
     expect(navigateTo).toHaveBeenCalledWith('/app')
@@ -683,8 +616,8 @@ describe('useUserSession hydration bootstrap', () => {
       await opts?.onSuccess?.('ctx')
     })
 
-    const useUserSession = await loadUseUserSession()
-    const auth = useUserSession()
+    const { useAuthActionNamespaces } = await loadAuthComposables()
+    const auth = useAuthActionNamespaces()
 
     await auth.signIn.email({ email: 'user@example.com', password: 'password' })
     expect(navigateTo).not.toHaveBeenCalled()
@@ -694,8 +627,8 @@ describe('useUserSession hydration bootstrap', () => {
     runtimeConfig.public.auth.redirects = { authenticated: '/app' }
     mockClient.signIn.social.mockResolvedValueOnce({ url: 'https://github.com/login/oauth/authorize', redirect: true })
 
-    const useUserSession = await loadUseUserSession()
-    const auth = useUserSession()
+    const { useAuthActionNamespaces } = await loadAuthComposables()
+    const auth = useAuthActionNamespaces()
 
     await auth.signIn.social({ provider: 'github' } as never)
 
@@ -709,8 +642,8 @@ describe('useUserSession hydration bootstrap', () => {
     requestURL.searchParams = new URLSearchParams({ redirect: '/app/billing' })
     mockClient.signIn.social.mockResolvedValueOnce({ url: 'https://github.com/login/oauth/authorize', redirect: true })
 
-    const useUserSession = await loadUseUserSession()
-    const auth = useUserSession()
+    const { useAuthActionNamespaces } = await loadAuthComposables()
+    const auth = useAuthActionNamespaces()
 
     await auth.signIn.social({ provider: 'github' } as never)
 
@@ -722,8 +655,8 @@ describe('useUserSession hydration bootstrap', () => {
     requestURL.searchParams = new URLSearchParams({ redirect: 'https://evil.com/phish' })
     mockClient.signIn.social.mockResolvedValueOnce({ url: 'https://github.com/login/oauth/authorize', redirect: true })
 
-    const useUserSession = await loadUseUserSession()
-    const auth = useUserSession()
+    const { useAuthActionNamespaces } = await loadAuthComposables()
+    const auth = useAuthActionNamespaces()
 
     await auth.signIn.social({ provider: 'github' } as never)
 
@@ -735,8 +668,8 @@ describe('useUserSession hydration bootstrap', () => {
     requestURL.searchParams = new URLSearchParams({ redirect: '/app/billing' })
     mockClient.signIn.social.mockResolvedValueOnce({ url: 'https://github.com/login/oauth/authorize', redirect: true })
 
-    const useUserSession = await loadUseUserSession()
-    const auth = useUserSession()
+    const { useAuthActionNamespaces } = await loadAuthComposables()
+    const auth = useAuthActionNamespaces()
 
     await auth.signIn.social({ provider: 'github', callbackURL: '/custom' } as never)
 
@@ -749,8 +682,8 @@ describe('useUserSession hydration bootstrap', () => {
       await opts?.onSuccess?.('ctx')
     })
 
-    const useUserSession = await loadUseUserSession()
-    const auth = useUserSession()
+    const { useAuthActionNamespaces } = await loadAuthComposables()
+    const auth = useAuthActionNamespaces()
 
     await auth.signIn.social({ provider: 'github' } as never, { onSuccess } as never)
 
@@ -759,10 +692,10 @@ describe('useUserSession hydration bootstrap', () => {
   })
 
   it('signIn.social with disableRedirect wraps explicit onSuccess with session sync', async () => {
-    let auth!: ReturnType<Awaited<ReturnType<typeof loadUseUserSession>>>
+    let sessionAuth!: ReturnType<Awaited<ReturnType<typeof loadUseUserSession>>>
     let sessionAtCallback: unknown
     const onSuccess = vi.fn(() => {
-      sessionAtCallback = auth.session.value
+      sessionAtCallback = sessionAuth.session.value
     })
     mockClient.getSession.mockResolvedValueOnce({
       data: {
@@ -774,8 +707,9 @@ describe('useUserSession hydration bootstrap', () => {
       await opts?.onSuccess?.('ctx')
     })
 
-    const useUserSession = await loadUseUserSession()
-    auth = useUserSession()
+    const { useAuthActionNamespaces, useUserSession } = await loadAuthComposables()
+    sessionAuth = useUserSession()
+    const auth = useAuthActionNamespaces()
 
     await auth.signIn.social({ provider: 'github', disableRedirect: true } as never, { onSuccess } as never)
 
@@ -795,8 +729,8 @@ describe('useUserSession hydration bootstrap', () => {
       await opts?.onSuccess?.('ctx')
     })
 
-    const useUserSession = await loadUseUserSession()
-    const auth = useUserSession()
+    const { useAuthActionNamespaces } = await loadAuthComposables()
+    const auth = useAuthActionNamespaces()
 
     await auth.signIn.social({ provider: 'github', disableRedirect: true } as never)
 
@@ -811,8 +745,8 @@ describe('useUserSession hydration bootstrap', () => {
       await opts?.onSuccess?.('ctx')
     })
 
-    const useUserSession = await loadUseUserSession()
-    const auth = useUserSession()
+    const { useAuthActionNamespaces } = await loadAuthComposables()
+    const auth = useAuthActionNamespaces()
 
     await auth.signUp.email({ email: 'user@example.com', password: 'password', name: 'User' })
 
@@ -831,8 +765,8 @@ describe('useUserSession hydration bootstrap', () => {
       await opts?.onSuccess?.('ctx')
     })
 
-    const useUserSession = await loadUseUserSession()
-    const auth = useUserSession()
+    const { useAuthActionNamespaces } = await loadAuthComposables()
+    const auth = useAuthActionNamespaces()
 
     await auth.signUp.email({ email: 'user@example.com', password: 'password', name: 'User' })
     expect(navigateTo).toHaveBeenCalledWith('/app')
@@ -851,8 +785,8 @@ describe('useUserSession hydration bootstrap', () => {
       await opts?.onSuccess?.('ctx')
     })
 
-    const useUserSession = await loadUseUserSession()
-    const auth = useUserSession()
+    const { useAuthActionNamespaces } = await loadAuthComposables()
+    const auth = useAuthActionNamespaces()
 
     await auth.signUp.email({ email: 'user@example.com', password: 'password', name: 'User' })
     expect(navigateTo).toHaveBeenCalledWith('/welcome')

--- a/test/vue-safe-auth-proxy.test.ts
+++ b/test/vue-safe-auth-proxy.test.ts
@@ -35,6 +35,18 @@ describe('createVueSafeAuthProxy', () => {
     expect(fetch).not.toHaveBeenCalled()
   })
 
+  it('keeps nested namespaces out of Vue reactive wrapping', () => {
+    const client = createAuthClient({
+      baseURL: 'http://localhost:3000/api/auth',
+      fetchOptions: { customFetchImpl: vi.fn() },
+    })
+    const safeClient = createVueSafeAuthProxy(client)
+    const store = reactive({ signIn: safeClient.signIn })
+
+    expect(isReactive(store.signIn)).toBe(false)
+    expect((store.signIn as Record<string, unknown>).__v_skip).toBe(true)
+  })
+
   it('preserves call results and does not wrap returned promises', async () => {
     const fetch = vi.fn(async () => new Response('{}', {
       headers: { 'content-type': 'application/json' },


### PR DESCRIPTION
This is a breaking cleanup for the Pinia issue found while testing #295.

`useUserSession()` now returns only session state and session lifecycle actions, so it can be returned directly from Pinia setup stores without forwarding Better Auth's dynamic client proxies through store state.

Auth calls move to explicit composables (which is much better dx overall!):

```ts
const signInEmail = useSignIn('email')
const signUpEmail = useSignUp('email')
const client = useAuthClient()
const sendVerificationEmail = useAuthClientAction(client => client.sendVerificationEmail)
```

Old patterns like these no longer work:

```ts
const { signIn, signUp, client } = useUserSession()
userStore.signIn.email(...)
userStore.authClient.sendVerificationEmail(...)
```


