### PR TITLE
chore: configure Renovate automerge policy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,47 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "dependencyDashboard": false,
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended"],
+  "dependencyDashboard": true,
+  "automergeType": "pr",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 5am on monday"],
+    "automerge": true
+  },
+  "packageRules": [
+    {
+      "description": "Automerge low-risk dev dependency updates once required checks pass.",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "dev dependencies",
+      "automerge": true
+    },
+    {
+      "description": "Automerge patch updates for regular runtime dependencies once required checks pass.",
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    },
+    {
+      "description": "Keep major updates manual.",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    },
+    {
+      "description": "Keep Nuxt, auth, NuxtHub, and database/runtime-sensitive packages manual.",
+      "matchPackageNames": [
+        "better-auth",
+        "/^@better-auth\\//",
+        "nuxt",
+        "/^@nuxt\\//",
+        "/^@nuxtjs\\//",
+        "/^@nuxthub\\//",
+        "better-sqlite3",
+        "/^drizzle-/",
+        "postgres",
+        "/^@libsql\\//"
+      ],
+      "automerge": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- enable Renovate Dependency Dashboard
- group and automerge low-risk dependency updates after required checks pass
- keep major, Nuxt/auth/NuxtHub, and database/runtime-sensitive updates manual
- enable weekly lockfile maintenance owned by Renovate

## Validation
- node JSON parse check
- npx --package renovate renovate-config-validator renovate.json

Branch protection has also been configured on `main` to require the `ci` and `pkg` checks before merge.