### PR TITLE
fix: stabilize lint rules for dependency updates

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,9 @@ export default antfu(
   },
   {
     rules: {
+      'e18e/prefer-static-regex': 'off',
       'node/prefer-global/process': 'off',
+      'perfectionist/sort-imports': 'off',
     },
   },
   // Enforce no explicit `any` in shipped code, but keep .d.ts/tests/playground flexible.

--- a/playground/app/auth.config.ts
+++ b/playground/app/auth.config.ts
@@ -1,6 +1,6 @@
-import { navigateTo } from '#imports'
 import { passkeyClient } from '@better-auth/passkey/client'
 import { adminClient, lastLoginMethodClient, multiSessionClient, twoFactorClient } from 'better-auth/client/plugins'
+import { navigateTo } from '#imports'
 import { defineClientAuth } from '../../src/runtime/config'
 
 export default defineClientAuth({

--- a/src/module.ts
+++ b/src/module.ts
@@ -18,6 +18,13 @@ import { registerServerTypeTemplates, registerSharedTypeTemplates } from './modu
 import './types/hooks'
 
 const consola = _consola.withTag('nuxt-better-auth')
+const serverAliasImportRE = /from\s+['"]#server/
+const layersAliasImportRE = /from\s+['"]#layers\//
+const rootAliasImportRE = /from\s+['"]~~/
+const workspaceAliasImportRE = /from\s+['"]@@/
+const dbIdentifierRE = /\bdb\b/
+const sessionHookAfterIdentifierRE = /\bsessionHookAfter\b/
+const nuxtHubDbImportRE = /@nuxthub\/db/
 
 function isServerConfigSharedTypeSafe(serverConfigPath: string): boolean {
   const resolvedPath = [
@@ -36,13 +43,13 @@ function isServerConfigSharedTypeSafe(serverConfigPath: string): boolean {
   const contents = readFileSync(resolvedPath, 'utf8')
 
   return !(
-    /from\s+['"]#server/.test(contents)
-    || /from\s+['"]#layers\//.test(contents)
-    || /from\s+['"]~~/.test(contents)
-    || /from\s+['"]@@/.test(contents)
-    || /\bdb\b/.test(contents)
-    || /\bsessionHookAfter\b/.test(contents)
-    || /@nuxthub\/db/.test(contents)
+    serverAliasImportRE.test(contents)
+    || layersAliasImportRE.test(contents)
+    || rootAliasImportRE.test(contents)
+    || workspaceAliasImportRE.test(contents)
+    || dbIdentifierRE.test(contents)
+    || sessionHookAfterIdentifierRE.test(contents)
+    || nuxtHubDbImportRE.test(contents)
   )
 }
 

--- a/src/runtime/app/composables/useAuthRequestFetch.ts
+++ b/src/runtime/app/composables/useAuthRequestFetch.ts
@@ -1,5 +1,5 @@
-import type { AuthApiEndpointMethod, AuthApiEndpointPath, AuthApiEndpointResponse } from '#nuxt-better-auth'
 import type { NitroFetchOptions } from 'nitropack/types'
+import type { AuthApiEndpointMethod, AuthApiEndpointPath, AuthApiEndpointResponse } from '#nuxt-better-auth'
 import { useRequestFetch } from '#imports'
 
 type AuthRequestFetchExtractedMethod<Options> = Options extends undefined

--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -1,5 +1,5 @@
-import type { AppAuthClient, AuthSession, AuthUser } from '#nuxt-better-auth'
 import type { ComputedRef, Ref } from 'vue'
+import type { AppAuthClient, AuthSession, AuthUser } from '#nuxt-better-auth'
 import { computed, navigateTo, nextTick, useNuxtApp, useRequestURL, useRuntimeConfig, useState, watch } from '#imports'
 import { normalizeAuthActionError } from '../internal/auth-action-error'
 import { resolvePostAuthSuccessRedirect, withFallbackSocialCallbackURL } from '../internal/redirect-helpers'

--- a/src/runtime/app/internal/session-fetch.ts
+++ b/src/runtime/app/internal/session-fetch.ts
@@ -1,5 +1,5 @@
-import type { AppAuthClient, AuthSession, AuthUser } from '#nuxt-better-auth'
 import type { Ref } from 'vue'
+import type { AppAuthClient, AuthSession, AuthUser } from '#nuxt-better-auth'
 import { useRequestFetch, useRequestHeaders } from '#imports'
 import { normalizeAuthActionError } from './auth-action-error'
 

--- a/src/runtime/app/middleware/auth.global.ts
+++ b/src/runtime/app/middleware/auth.global.ts
@@ -1,8 +1,8 @@
 import type { AuthRuntimeConfig } from '../../config'
 import type { AuthMeta, AuthMode, AuthRouteRules } from '../../types'
-import { createError, defineNuxtRouteMiddleware, getRouteRules, navigateTo, useNuxtApp, useRequestHeaders, useRuntimeConfig } from '#imports'
 import { defu } from 'defu'
 import { createRouter, toRouteMatcher } from 'radix3'
+import { createError, defineNuxtRouteMiddleware, getRouteRules, navigateTo, useNuxtApp, useRequestHeaders, useRuntimeConfig } from '#imports'
 import { matchesUser } from '../../utils/match-user'
 import { useUserSession } from '../composables/useUserSession'
 

--- a/src/runtime/server/api/_better-auth/config.get.ts
+++ b/src/runtime/server/api/_better-auth/config.get.ts
@@ -1,5 +1,5 @@
-import { useRuntimeConfig } from '#imports'
 import { defineEventHandler } from 'h3'
+import { useRuntimeConfig } from '#imports'
 import { serverAuth } from '../../utils/auth'
 
 export default defineEventHandler(async (event) => {

--- a/src/runtime/server/middleware/route-access.ts
+++ b/src/runtime/server/middleware/route-access.ts
@@ -1,6 +1,6 @@
 import type { AuthMeta, AuthMode, AuthRouteRules } from '../../types'
-import { getRouteRules } from '#imports'
 import { createError, defineEventHandler, getRequestURL } from 'h3'
+import { getRouteRules } from '#imports'
 import { matchesUser } from '../../utils/match-user'
 import { getUserSession, requireUserSession } from '../utils/session'
 

--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -1,12 +1,12 @@
 import type { BetterAuthOptions } from 'better-auth'
 import type { H3Event } from 'h3'
-import { createDatabase, db } from '#auth/database'
-import { createSecondaryStorage } from '#auth/secondary-storage'
-import createServerAuth from '#auth/server'
 import { betterAuth } from 'better-auth'
 import { getRequestHost, getRequestProtocol } from 'h3'
 import { useRuntimeConfig } from 'nitropack/runtime'
 import { withoutProtocol } from 'ufo'
+import { createDatabase, db } from '#auth/database'
+import { createSecondaryStorage } from '#auth/secondary-storage'
+import createServerAuth from '#auth/server'
 import { resolveCustomSecondaryStorageRequirement } from './custom-secondary-storage'
 
 type AuthOptions = ReturnType<typeof createServerAuth>

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -1,11 +1,12 @@
-import type { AppSession, AuthSession, RequireSessionOptions } from '#nuxt-better-auth'
 import type { H3Event } from 'h3'
+import type { AppSession, AuthSession, RequireSessionOptions } from '#nuxt-better-auth'
 import { createError } from 'h3'
 import { matchesUser } from '../../utils/match-user'
 import { serverAuth } from './auth'
 
 const requestSessionLoadKey = Symbol.for('nuxt-better-auth.requestSessionLoad')
 const signingAlgorithm: HmacImportParams = { name: 'HMAC', hash: 'SHA-256' }
+const cookiePairSeparatorRE = /;\s*/
 
 interface CookieOptions {
   domain?: string
@@ -195,7 +196,7 @@ function parseRequestCookies(cookieHeader: string | null): Map<string, string> {
   if (!cookieHeader)
     return cookies
 
-  for (const pair of cookieHeader.split(/;\s*/)) {
+  for (const pair of cookieHeader.split(cookiePairSeparatorRE)) {
     if (!pair)
       continue
 

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,5 +1,5 @@
-import type { AuthSocialProviderRegistry, AuthUser, UserMatch } from '#nuxt-better-auth'
 import type { NitroRouteRules } from 'nitropack/types'
+import type { AuthSocialProviderRegistry, AuthUser, UserMatch } from '#nuxt-better-auth'
 
 // Re-export augmentable types
 export type { AppSession, AuthSession, AuthSocialProviderRegistry, AuthUser, RequireSessionOptions, ServerAuthContext, UserMatch, UserSessionComposable } from './types/augment'

--- a/test/cases/nitro-endpoints-type-inference/typecheck-target.ts
+++ b/test/cases/nitro-endpoints-type-inference/typecheck-target.ts
@@ -1,5 +1,5 @@
-import type { AuthApiEndpointPath, AuthApiEndpointResponse } from '#nuxt-better-auth'
 import type { Base$Fetch } from 'nitropack/types'
+import type { AuthApiEndpointPath, AuthApiEndpointResponse } from '#nuxt-better-auth'
 
 declare const requestFetch: Base$Fetch
 

--- a/test/cases/plugins-type-inference/typecheck-target.ts
+++ b/test/cases/plugins-type-inference/typecheck-target.ts
@@ -1,5 +1,5 @@
-import type { AuthSession, AuthUser } from '#nuxt-better-auth'
 import type { NitroRouteRules } from 'nitropack/types'
+import type { AuthSession, AuthUser } from '#nuxt-better-auth'
 import type { AuthSocialProviderId } from '../../../src/runtime/types'
 
 declare const serverAuth: typeof import('../../../src/runtime/server/utils/auth').serverAuth

--- a/test/cases/server-auth-alias-typecheck/server/auth.config.ts
+++ b/test/cases/server-auth-alias-typecheck/server/auth.config.ts
@@ -1,5 +1,5 @@
-import { sessionHookAfter } from '#server/utils/hooks'
 import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
+import { sessionHookAfter } from '#server/utils/hooks'
 
 export default defineServerAuth(({ db: _db }) => {
   type _DbSelect = typeof _db.select


### PR DESCRIPTION
## Summary
- disable volatile lint rules that changed behavior in Renovate dependency updates
- hoist repeated regex literals out of hot paths
- normalize imports touched by the lint compatibility work

## Validation
- pnpm lint
- pnpm typecheck

This targets the Renovate PR failures caused by updated lint/tooling rules. It does not bypass real runtime/type compatibility failures from major dependency updates.