### PR TITLE
fix: allow chokidar trust policy exception

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 shellEmulator: true
 
 trustPolicy: no-downgrade
+trustPolicyExclude:
+  - chokidar@4.0.3
 
 allowBuilds:
   '@parcel/watcher': true


### PR DESCRIPTION
## Summary
- add a targeted pnpm trustPolicyExclude for chokidar@4.0.3
- keep trustPolicy: no-downgrade enabled for all other packages
- unblock Renovate lockfile artifact regeneration for current dependency PRs

## Context
Renovate cannot refresh pnpm-lock.yaml on the remaining dependency branches because docus/@nuxtjs/i18n pulls chokidar@4.0.3 and pnpm blocks it as a trust downgrade. pnpm documents trustPolicyExclude as the narrow override for specific packages or versions.

## Test Plan
- CI=true fnm exec --using=24.13.0 pnpm install --frozen-lockfile
- CI=true fnm exec --using=24.13.0 corepack pnpm@11.0.0 install --frozen-lockfile