### PR TITLE
fix: allow semver trust policy exception

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ shellEmulator: true
 trustPolicy: no-downgrade
 trustPolicyExclude:
   - chokidar@4.0.3
+  - semver@6.3.1
 
 allowBuilds:
   '@parcel/watcher': true


### PR DESCRIPTION
## Summary
- add a targeted pnpm trustPolicyExclude for semver@6.3.1
- keep trustPolicy: no-downgrade enabled for every other package
- unblock Renovate artifact regeneration on the remaining dependency PRs

## Test Plan
- CI=true fnm exec --using=24.13.0 pnpm install --frozen-lockfile