### PR TITLE
fix: pass runtime config to schema auth factory

### DIFF
--- a/src/module/schema.ts
+++ b/src/module/schema.ts
@@ -73,7 +73,7 @@ async function loadAuthOptions(context: SchemaContext) {
       .filter(([, value]) => typeof value === 'string')
       .map(([key, value]) => [key, value as string]),
   )
-  const userConfig = await loadUserAuthConfig(configFile, isProduction, alias)
+  const userConfig = await loadUserAuthConfig(configFile, isProduction, alias, context.nuxt.options.runtimeConfig)
 
   const extendedConfig: { plugins?: BetterAuthPlugin[] } = {}
   await context.nuxt.callHook('better-auth:config:extend', extendedConfig)

--- a/src/schema-generator.ts
+++ b/src/schema-generator.ts
@@ -68,6 +68,7 @@ export async function loadUserAuthConfig(
   configPath: string,
   throwOnError = false,
   alias?: Record<string, string>,
+  runtimeConfig: unknown = {},
 ): Promise<Partial<BetterAuthOptions>> {
   const { createJiti } = await import('jiti')
   const { defineServerAuth: runtimeDefineServerAuth } = await import('./runtime/config')
@@ -87,7 +88,7 @@ export async function loadUserAuthConfig(
     const mod = await jiti.import(configPath) as { default?: unknown }
     const configFn = mod.default
     if (typeof configFn === 'function') {
-      return configFn({ runtimeConfig: {}, db: null })
+      return configFn({ runtimeConfig, db: null })
     }
     consola.warn('[@onmax/nuxt-better-auth] auth.config.ts does not export default. Expected: export default defineServerAuth(...)')
     if (throwOnError) {

--- a/test/cases/auth-schema-export/nuxt.config.ts
+++ b/test/cases/auth-schema-export/nuxt.config.ts
@@ -5,6 +5,9 @@ export default defineNuxtConfig({
 
   runtimeConfig: {
     betterAuthSecret: 'test-secret-for-testing-only-32chars!',
-    public: { siteUrl: 'http://localhost:3000' },
+    public: {
+      app: { routes: { signUp: '/auth/sign-up' } },
+      siteUrl: 'http://localhost:3000',
+    },
   },
 })

--- a/test/cases/auth-schema-export/server/auth.config.ts
+++ b/test/cases/auth-schema-export/server/auth.config.ts
@@ -1,6 +1,6 @@
 import { defineServerAuth } from '../../../../src/runtime/config'
 
-export default defineServerAuth({
-  appName: 'Auth Schema Export Test',
+export default defineServerAuth(({ runtimeConfig }) => ({
+  appName: runtimeConfig.public.app.routes.signUp,
   emailAndPassword: { enabled: true },
-})
+}))

--- a/test/schema-generator.test.ts
+++ b/test/schema-generator.test.ts
@@ -149,6 +149,17 @@ describe('loadUserAuthConfig', () => {
 
     expect(result).toEqual({ plugins: [] })
   })
+
+  it('passes runtime config to function syntax during schema generation', async () => {
+    const configPath = join(TEST_DIR, 'runtime-config.ts')
+    writeFileSync(configPath, `export default defineServerAuth(({ runtimeConfig }) => ({ appName: runtimeConfig.public.app.routes.signUp }))`)
+
+    const result = await loadUserAuthConfig(configPath, false, undefined, {
+      public: { app: { routes: { signUp: '/auth/sign-up' } } },
+    })
+
+    expect(result).toEqual({ appName: '/auth/sign-up' })
+  })
 })
 
 describe('defineServerAuth', () => {


### PR DESCRIPTION
Passes the resolved Nuxt runtime config into the schema-generation `defineServerAuth` factory instead of calling it with an empty object. This keeps eager `runtimeConfig` reads consistent with the runtime request path while preserving the empty fallback for direct `loadUserAuthConfig` callers.

The regression coverage now includes both the helper path and the NuxtHub schema-export fixture, where `server/auth.config.ts` eagerly reads `runtimeConfig.public.app.routes.signUp` during schema generation.

Closes #364