### PR TITLE
fix: skip internal routes for auth route rules

### DIFF
--- a/docs/content/2.core-concepts/3.route-protection.md
+++ b/docs/content/2.core-concepts/3.route-protection.md
@@ -106,6 +106,10 @@ If `auth: { user: { ... } }` complains about missing fields (e.g. `role`), ensur
 These rules are automatically synced to the client-side router, ensuring instant redirects without server roundtrips for navigation.
 ::
 
+::note
+Broad rules such as `'/**': { auth: 'user' }` skip framework and module internals that must stay reachable: `/_nuxt/**`, `/_ipx/**`, `/api/_nuxt_icon/**`, `/api/_better-auth/**`, Better Auth's `/api/auth/**`, and development-only module routes. App-owned pages and `/api/**` handlers still match broad auth rules.
+::
+
 ## 2. Page Meta
 
 For page-specific control, use `definePageMeta` within your Vue components. This overrides global `routeRules`.

--- a/docs/content/2.core-concepts/3.route-protection.md
+++ b/docs/content/2.core-concepts/3.route-protection.md
@@ -107,7 +107,7 @@ These rules are automatically synced to the client-side router, ensuring instant
 ::
 
 ::note
-Broad rules such as `'/**': { auth: 'user' }` skip framework and module internals that must stay reachable: `/_nuxt/**`, `/_ipx/**`, `/api/_nuxt_icon/**`, `/api/_better-auth/**`, Better Auth's `/api/auth/**`, and development-only module routes. App-owned pages and `/api/**` handlers still match broad auth rules.
+Broad rules such as `'/**': { auth: 'user' }` skip framework and module internals that must stay reachable, including `/_nuxt/**`, `/_ipx/**`, `/api/_nuxt_icon/**`, `/api/_better-auth/**`, Better Auth's `/api/auth/**`, and development-only module routes. The module still applies broad auth rules to app-owned pages and `/api/**` handlers.
 ::
 
 ## 2. Page Meta

--- a/docs/content/2.core-concepts/5.security-caveats.md
+++ b/docs/content/2.core-concepts/5.security-caveats.md
@@ -31,7 +31,7 @@ If you deploy preview environments, you must include the preview origin in `trus
 
 ## API enforcement behavior
 
-The built-in Nitro middleware only checks `routeRules.auth` for app-owned `/api/**` routes. It skips Better Auth's `/api/auth/**` handler and known framework or module internals such as `/api/_nuxt_icon/**` and `/api/_better-auth/**`, so broad route rules do not break auth, icons, or module tooling.
+The built-in Nitro middleware checks `routeRules.auth` for app-owned `/api/**` routes. It skips Better Auth's `/api/auth/**` handler and known framework or module internals such as `/api/_nuxt_icon/**` and `/api/_better-auth/**`, so broad route rules do not break auth, icons, or module tooling.
 
 ### Customizing Unauthorized Behavior
 

--- a/docs/content/2.core-concepts/5.security-caveats.md
+++ b/docs/content/2.core-concepts/5.security-caveats.md
@@ -31,7 +31,7 @@ If you deploy preview environments, you must include the preview origin in `trus
 
 ## API enforcement behavior
 
-The built-in Nitro middleware only checks `routeRules.auth` for `/api/**`.
+The built-in Nitro middleware only checks `routeRules.auth` for app-owned `/api/**` routes. It skips Better Auth's `/api/auth/**` handler and known framework or module internals such as `/api/_nuxt_icon/**` and `/api/_better-auth/**`, so broad route rules do not break auth, icons, or module tooling.
 
 ### Customizing Unauthorized Behavior
 

--- a/src/runtime/app/middleware/auth.global.ts
+++ b/src/runtime/app/middleware/auth.global.ts
@@ -3,6 +3,7 @@ import type { AuthMeta, AuthMode, AuthRouteRules } from '../../types'
 import { defu } from 'defu'
 import { createRouter, toRouteMatcher } from 'radix3'
 import { createError, defineNuxtRouteMiddleware, getRouteRules, navigateTo, useNuxtApp, useRequestHeaders, useRuntimeConfig } from '#imports'
+import { shouldSkipAuthRouteRules } from '../../internal/auth-route-rules'
 import { matchesUser } from '../../utils/match-user'
 import { useUserSession } from '../composables/useUserSession'
 
@@ -22,6 +23,9 @@ let authRouteRulesPromise: Promise<Record<string, AuthRouteRules>> | null = null
 let routeRulesMatcherPromise: Promise<ReturnType<typeof toRouteMatcher> | null> | null = null
 
 export default defineNuxtRouteMiddleware(async (to) => {
+  if (shouldSkipAuthRouteRules(to.path))
+    return
+
   const nuxtApp = useNuxtApp()
 
   // Runtime fallback: resolve auth from module-known route rules if not set at build-time.

--- a/src/runtime/internal/auth-route-rules.ts
+++ b/src/runtime/internal/auth-route-rules.ts
@@ -1,0 +1,26 @@
+const internalRouteRuleAuthPaths = new Set([
+  '/_ipx',
+  '/_nuxt',
+  '/__better-auth-devtools',
+  '/__nuxt_devtools__',
+  '/__nuxt_error',
+  '/__nuxt_vite_node__',
+  '/api/_better-auth',
+  '/api/_nuxt_icon',
+  '/api/auth',
+])
+
+const internalRouteRuleAuthPrefixes = [
+  '/_ipx/',
+  '/_nuxt/',
+  '/__nuxt_devtools__/',
+  '/__nuxt_vite_node__/',
+  '/api/_better-auth/',
+  '/api/_nuxt_icon/',
+  '/api/auth/',
+]
+
+export function shouldSkipAuthRouteRules(path: string): boolean {
+  const pathname = path.split(/[?#]/, 1)[0] || '/'
+  return internalRouteRuleAuthPaths.has(pathname) || internalRouteRuleAuthPrefixes.some(prefix => pathname.startsWith(prefix))
+}

--- a/src/runtime/server/middleware/route-access.ts
+++ b/src/runtime/server/middleware/route-access.ts
@@ -1,6 +1,7 @@
 import type { AuthMeta, AuthMode, AuthRouteRules } from '../../types'
 import { createError, defineEventHandler, getRequestURL } from 'h3'
 import { getRouteRules } from '#imports'
+import { shouldSkipAuthRouteRules } from '../../internal/auth-route-rules'
 import { matchesUser } from '../../utils/match-user'
 import { getUserSession, requireUserSession } from '../utils/session'
 
@@ -10,7 +11,7 @@ export default defineEventHandler(async (event) => {
   if (!path.startsWith('/api/'))
     return
 
-  if (path.startsWith('/api/auth/'))
+  if (shouldSkipAuthRouteRules(path))
     return
 
   const rules = getRouteRules(event) as AuthRouteRules

--- a/test/auth-global-middleware.test.ts
+++ b/test/auth-global-middleware.test.ts
@@ -133,6 +133,19 @@ describe('auth.global middleware', () => {
     expect(navigateTo).toHaveBeenCalledTimes(1)
   })
 
+  it('ignores internal module routes even when broad route rules set page meta', async () => {
+    const middleware = await loadMiddleware()
+    await middleware({
+      path: '/__better-auth-devtools',
+      fullPath: '/__better-auth-devtools',
+      meta: { auth: 'user' },
+    })
+
+    expect(getRouteRules).not.toHaveBeenCalled()
+    expect(fetchSession).not.toHaveBeenCalled()
+    expect(navigateTo).not.toHaveBeenCalled()
+  })
+
   it('forces a fresh session check during prerender hydration for protected routes', async () => {
     payload.prerenderedAt = Date.now()
     nuxtApp.isHydrating = true

--- a/test/auth-route-rules-internal.test.ts
+++ b/test/auth-route-rules-internal.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { shouldSkipAuthRouteRules } from '../src/runtime/internal/auth-route-rules'
+
+describe('internal auth route rule defaults', () => {
+  it('skips framework and module internals', () => {
+    expect(shouldSkipAuthRouteRules('/_nuxt/app.js')).toBe(true)
+    expect(shouldSkipAuthRouteRules('/_ipx/w_64/icon.png')).toBe(true)
+    expect(shouldSkipAuthRouteRules('/api/_nuxt_icon/lucide:home.svg')).toBe(true)
+    expect(shouldSkipAuthRouteRules('/api/_better-auth/config')).toBe(true)
+    expect(shouldSkipAuthRouteRules('/api/auth/get-session')).toBe(true)
+  })
+
+  it('keeps app routes and app APIs protectable', () => {
+    expect(shouldSkipAuthRouteRules('/app')).toBe(false)
+    expect(shouldSkipAuthRouteRules('/_app')).toBe(false)
+    expect(shouldSkipAuthRouteRules('/api/test/me')).toBe(false)
+    expect(shouldSkipAuthRouteRules('/api/authenticate')).toBe(false)
+  })
+})

--- a/test/route-access-middleware.test.ts
+++ b/test/route-access-middleware.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getRouteRules = vi.fn(() => ({}))
+const getUserSession = vi.fn()
+const requireUserSession = vi.fn()
+
+vi.mock('h3', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('h3')>()
+  return {
+    ...actual,
+    createError: (error: unknown) => error,
+    defineEventHandler: (handler: unknown) => handler,
+    getRequestURL: (event: { path: string }) => new URL(event.path, 'https://example.test'),
+  }
+})
+
+vi.mock('#imports', () => ({ getRouteRules }))
+
+vi.mock('../src/runtime/server/utils/session', () => ({
+  getUserSession,
+  requireUserSession,
+}))
+
+async function loadMiddleware() {
+  vi.resetModules()
+  const mod = await import('../src/runtime/server/middleware/route-access')
+  return mod.default as (event: { path: string }) => Promise<void>
+}
+
+describe('route-access middleware', () => {
+  beforeEach(() => {
+    getRouteRules.mockReset()
+    getUserSession.mockReset()
+    requireUserSession.mockReset()
+    getRouteRules.mockReturnValue({})
+  })
+
+  it('ignores internal API routes before auth route rules are read', async () => {
+    getRouteRules.mockReturnValue({ auth: 'user' })
+    const middleware = await loadMiddleware()
+
+    await middleware({ path: '/api/auth/get-session' })
+    await middleware({ path: '/api/_better-auth/config' })
+    await middleware({ path: '/api/_nuxt_icon/lucide:home.svg' })
+
+    expect(getRouteRules).not.toHaveBeenCalled()
+    expect(getUserSession).not.toHaveBeenCalled()
+    expect(requireUserSession).not.toHaveBeenCalled()
+  })
+
+  it('still protects app API routes matched by broad route rules', async () => {
+    getRouteRules.mockReturnValue({ auth: 'user' })
+    requireUserSession.mockResolvedValue({ user: { id: 'user-1' } })
+
+    const middleware = await loadMiddleware()
+    await middleware({ path: '/api/test/me' })
+
+    expect(getRouteRules).toHaveBeenCalledTimes(1)
+    expect(requireUserSession).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
Exempts Nuxt and module internal routes from auth route-rule handling by default, so broad rules like `'/**': { auth: 'user' }` no longer block framework assets, the Better Auth handler, Nuxt icon endpoints, or module devtools endpoints.

App-owned pages and app `/api/**` routes still participate in route-rule auth. The docs now call out that sensitive API handlers should keep using `requireUserSession(event)` as the real security boundary.