### PR TITLE
feat: add custom auth action session refresh helper

### DIFF
--- a/docs/content/2.core-concepts/2.sessions.md
+++ b/docs/content/2.core-concepts/2.sessions.md
@@ -144,9 +144,9 @@ const { fetchSession, ready } = useUserSession()
 </template>
 ```
 
-For a custom Better Auth endpoint that creates or changes the current session, wrap the action so the Nuxt session state refreshes after a successful response:
+When a custom Better Auth endpoint creates or changes the current session, wrap the action so Nuxt refreshes session state after a successful response:
 
-```ts
+```ts [pages/login.vue]
 await runWithSessionRefresh(() =>
   $fetch('/api/auth/sign-in/custom', { method: 'POST', body }),
 )

--- a/docs/content/2.core-concepts/2.sessions.md
+++ b/docs/content/2.core-concepts/2.sessions.md
@@ -15,6 +15,7 @@ Handle sessions with @onmax/nuxt-better-auth using useUserSession().
 - Configure session lifetime in `server/auth.config.ts` via `session.expiresIn` and `session.cookieCache`
 - Use `<BetterAuthState>` or `ready` ref to avoid loading flashes
 - Force refresh: `fetchSession({ force: true })`
+- Custom auth action sync: `runWithSessionRefresh(() => $fetch('/api/auth/...'))`
 ```
 
 ::
@@ -141,6 +142,14 @@ const { fetchSession, ready } = useUserSession()
     Refresh session
   </button>
 </template>
+```
+
+For a custom Better Auth endpoint that creates or changes the current session, wrap the action so the Nuxt session state refreshes after a successful response:
+
+```ts
+await runWithSessionRefresh(() =>
+  $fetch('/api/auth/sign-in/custom', { method: 'POST', body }),
+)
 ```
 
 ## Session Lifetime

--- a/docs/content/2.core-concepts/4.auto-imports-aliases.md
+++ b/docs/content/2.core-concepts/4.auto-imports-aliases.md
@@ -8,7 +8,7 @@ description: What the module registers for you.
 ```txt [Prompt]
 Use auto-imported utilities from @onmax/nuxt-better-auth.
 
-- Client (auto-imported in Vue): `useUserSession()`, `useUserSessionState()`, `useAuthClient()`, `useSignIn()`, `useSignUp()`, `useAuthClientAction()`
+- Client (auto-imported in Vue): `useUserSession()`, `useUserSessionState()`, `useAuthClient()`, `useSignIn()`, `useSignUp()`, `useAuthClientAction()`, `runWithSessionRefresh()`
 - Server (auto-imported in `server/`): `serverAuth(event?)`, `getRequestSession(event)`, `getUserSession(event)`, `createSession(event, userId)`, `setSessionCookie(event, token)`, `requireUserSession(event, options?)`
 - Component: `<BetterAuthState>` for auth-ready rendering
 - Alias `#nuxt-better-auth` exports types: `AuthUser`, `AuthSession`, `AuthSocialProviderId`
@@ -29,6 +29,7 @@ Use this page when you want a quick inventory of what the module registers for y
 - `useSignIn()`
 - `useSignUp()`
 - `useAuthClientAction()`
+- `runWithSessionRefresh()`
 
 **Server**
 

--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -34,6 +34,7 @@ const { user, loggedIn, signOut } = useUserSession()
 | Sign-in forms that need loading, error, and success state | `useSignIn()` |
 | Sign-up forms that need loading, error, and success state | `useSignUp()` |
 | Better Auth plugin/client methods that need loading, error, and success state | `useAuthClientAction()` |
+| Custom auth endpoints that create or change the current session | `runWithSessionRefresh()` |
 
 ## useUserSession
 
@@ -274,12 +275,6 @@ const saveProfile = useAction(async (payload: { name: string }) => {
 
 await saveProfile.execute({ name: 'Max' })
 
-## Related pages
-
-- [Sessions](/core-concepts/sessions)
-- [Server utilities](/api/server-utils)
-- [Components](/api/components)
-
 if (saveProfile.status.value === 'error') {
   console.error(saveProfile.error.value?.message)
 }
@@ -301,6 +296,22 @@ if (saveProfile.status.value === 'error') {
     Normalized error from thrown errors or `{ error }` responses.
   ::
 ::
+
+## runWithSessionRefresh
+
+Runs a custom auth action, then forces `useUserSession()` state to refresh after the action succeeds.
+
+```ts [pages/login.vue]
+const submitCustomLogin = useAction((body: { token: string }) =>
+  runWithSessionRefresh(() =>
+    $fetch('/api/auth/sign-in/custom', { method: 'POST', body }),
+  ),
+)
+
+await submitCustomLogin.execute({ token })
+```
+
+The helper returns the callback result. It skips the session refresh when the callback throws or returns a Better Auth `{ error }` result.
 
 ## useAuthClientAction
 
@@ -449,3 +460,9 @@ await execute(
 `useSignUp` returns the same action handle shape (`execute`, `status`, `data`, `error`) and follows the same error normalization semantics as `useSignIn`.
 
 :read-more{to="/guides/oauth-providers" title="OAuth Providers guide"}
+
+## Related pages
+
+- [Sessions](/core-concepts/sessions)
+- [Server utilities](/api/server-utils)
+- [Components](/api/components)

--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -299,7 +299,7 @@ if (saveProfile.status.value === 'error') {
 
 ## runWithSessionRefresh
 
-Runs a custom auth action, then forces `useUserSession()` state to refresh after the action succeeds.
+Runs a custom auth action, then refreshes `useUserSession()` state after the action succeeds. Use it for custom Better Auth endpoints that create, replace, or update the current session outside `useSignIn()` and `useSignUp()`.
 
 ```ts [pages/login.vue]
 const submitCustomLogin = useAction((body: { token: string }) =>

--- a/src/runtime/app/composables/runWithSessionRefresh.ts
+++ b/src/runtime/app/composables/runWithSessionRefresh.ts
@@ -1,0 +1,16 @@
+import { isAuthActionErrorResult } from '../internal/auth-action-handles'
+import { refreshSessionAfterAuthAction } from '../internal/wrap-auth-method'
+import { useUserSession } from './useUserSession'
+
+export async function runWithSessionRefresh<TResult>(runner: () => Promise<TResult>): Promise<TResult> {
+  if (typeof runner !== 'function')
+    throw new TypeError('runWithSessionRefresh(runner) requires an async function')
+
+  const auth = useUserSession()
+  const result = await runner()
+
+  if (!isAuthActionErrorResult(result))
+    await refreshSessionAfterAuthAction(auth.fetchSession, auth.loggedIn, auth.waitForSession)
+
+  return result
+}

--- a/src/runtime/app/internal/auth-action-handles.ts
+++ b/src/runtime/app/internal/auth-action-handles.ts
@@ -25,7 +25,7 @@ export type ActionHandleMap<T> = {
   [K in keyof T]: ActionHandleFor<T[K]>
 }
 
-function isErrorResult(value: unknown): value is { error: unknown } {
+export function isAuthActionErrorResult(value: unknown): value is { error: unknown } {
   if (!isRecord(value))
     return false
   if (!('error' in value))
@@ -73,7 +73,7 @@ export function createActionHandle<TArgs extends unknown[], TResult>(
 
     try {
       const result = await getMethod()(...args)
-      if (isErrorResult(result as unknown)) {
+      if (isAuthActionErrorResult(result as unknown)) {
         const normalizedError = normalizeAuthActionError((result as unknown as { error: unknown }).error)
         if (callId === latestCallId) {
           status.value = 'error'

--- a/src/runtime/app/internal/wrap-auth-method.ts
+++ b/src/runtime/app/internal/wrap-auth-method.ts
@@ -2,6 +2,17 @@ import type { ComputedRef } from 'vue'
 import { nextTick } from '#imports'
 import { isRecord } from './utils'
 
+export async function refreshSessionAfterAuthAction(
+  fetchSession: (options?: { force?: boolean }) => Promise<void>,
+  loggedIn: ComputedRef<boolean>,
+  waitForSession: () => Promise<void>,
+) {
+  await fetchSession({ force: true })
+  if (!loggedIn.value)
+    await waitForSession()
+  await nextTick()
+}
+
 export function wrapOnSuccess(
   fetchSession: (options?: { force?: boolean }) => Promise<void>,
   loggedIn: ComputedRef<boolean>,
@@ -9,10 +20,7 @@ export function wrapOnSuccess(
   cb: (ctx: unknown) => void | Promise<void>,
 ) {
   return async (ctx: unknown) => {
-    await fetchSession({ force: true })
-    if (!loggedIn.value)
-      await waitForSession()
-    await nextTick()
+    await refreshSessionAfterAuthAction(fetchSession, loggedIn, waitForSession)
     await cb(ctx)
   }
 }

--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -1,3 +1,4 @@
+export { runWithSessionRefresh } from './app/composables/runWithSessionRefresh'
 export { useAction } from './app/composables/useAction'
 export { useAuthAsyncData } from './app/composables/useAuthAsyncData'
 export { useAuthClient } from './app/composables/useAuthClient'

--- a/test/cases/composables-subpath-import/typecheck-target.ts
+++ b/test/cases/composables-subpath-import/typecheck-target.ts
@@ -1,5 +1,5 @@
 import type { UseUserSessionStateReturn } from '@onmax/nuxt-better-auth/composables'
-import { useAuthAsyncData, useAuthClient, useAuthRequestFetch, useSignIn, useSignUp, useUserSession, useUserSessionState } from '@onmax/nuxt-better-auth/composables'
+import { runWithSessionRefresh, useAuthAsyncData, useAuthClient, useAuthRequestFetch, useSignIn, useSignUp, useUserSession, useUserSessionState } from '@onmax/nuxt-better-auth/composables'
 
 const auth = useUserSession()
 auth.loggedIn.value satisfies boolean
@@ -23,3 +23,5 @@ const requestFetch = useAuthRequestFetch()
 requestFetch('/api/auth/get-session')
 
 void useAuthAsyncData('session-check', async () => await requestFetch('/api/auth/get-session'), { requireAuth: false })
+
+runWithSessionRefresh(async () => ({ ok: true })).then(result => result.ok satisfies boolean)

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -33,6 +33,7 @@ describe('exports-snapshot', async () => {
         defineServerAuth: typeof moduleExports.defineServerAuth,
       },
       './composables': {
+        runWithSessionRefresh: 'function',
         useAction: 'function',
         useAuthAsyncData: 'function',
         useAuthClient: 'function',

--- a/test/exports/module.yaml
+++ b/test/exports/module.yaml
@@ -3,6 +3,7 @@
   defineClientAuth: function
   defineServerAuth: function
 ./composables:
+  runWithSessionRefresh: function
   useAction: function
   useAuthAsyncData: function
   useAuthClient: function

--- a/test/run-with-session-refresh.test.ts
+++ b/test/run-with-session-refresh.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  fetchSession: vi.fn(async () => {}),
+  nextTick: vi.fn(async () => {}),
+  waitForSession: vi.fn(async () => {}),
+  loggedIn: { value: true },
+}))
+
+vi.mock('#imports', () => ({
+  nextTick: mocks.nextTick,
+}))
+
+vi.mock('../src/runtime/app/composables/useUserSession', () => ({
+  useUserSession: () => ({
+    fetchSession: mocks.fetchSession,
+    loggedIn: mocks.loggedIn,
+    waitForSession: mocks.waitForSession,
+  }),
+}))
+
+async function loadRunWithSessionRefresh() {
+  vi.resetModules()
+  const mod = await import('../src/runtime/app/composables/runWithSessionRefresh')
+  return mod.runWithSessionRefresh
+}
+
+describe('runWithSessionRefresh', () => {
+  beforeEach(() => {
+    mocks.fetchSession.mockClear()
+    mocks.nextTick.mockClear()
+    mocks.waitForSession.mockClear()
+    mocks.loggedIn.value = true
+  })
+
+  it('runs the action, refreshes the session, and returns the action result', async () => {
+    const runWithSessionRefresh = await loadRunWithSessionRefresh()
+    const runner = vi.fn(async () => ({ ok: true }))
+
+    await expect(runWithSessionRefresh(runner)).resolves.toEqual({ ok: true })
+
+    expect(runner).toHaveBeenCalledOnce()
+    expect(mocks.fetchSession).toHaveBeenCalledWith({ force: true })
+    expect(mocks.waitForSession).not.toHaveBeenCalled()
+    expect(mocks.nextTick).toHaveBeenCalledOnce()
+  })
+
+  it('waits when the forced refresh has not produced a logged-in session yet', async () => {
+    mocks.loggedIn.value = false
+    const runWithSessionRefresh = await loadRunWithSessionRefresh()
+
+    await runWithSessionRefresh(async () => ({ ok: true }))
+
+    expect(mocks.fetchSession).toHaveBeenCalledWith({ force: true })
+    expect(mocks.waitForSession).toHaveBeenCalledOnce()
+    expect(mocks.nextTick).toHaveBeenCalledOnce()
+  })
+
+  it('does not refresh after rejected actions', async () => {
+    const runWithSessionRefresh = await loadRunWithSessionRefresh()
+    const error = new Error('boom')
+
+    await expect(runWithSessionRefresh(async () => {
+      throw error
+    })).rejects.toThrow('boom')
+
+    expect(mocks.fetchSession).not.toHaveBeenCalled()
+  })
+
+  it('does not refresh Better Auth error results', async () => {
+    const runWithSessionRefresh = await loadRunWithSessionRefresh()
+    const result = { error: { message: 'nope' } }
+
+    await expect(runWithSessionRefresh(async () => result)).resolves.toBe(result)
+
+    expect(mocks.fetchSession).not.toHaveBeenCalled()
+  })
+
+  it('requires a runner function', async () => {
+    const runWithSessionRefresh = await loadRunWithSessionRefresh()
+
+    await expect(runWithSessionRefresh(null as never)).rejects.toThrow('runWithSessionRefresh(runner) requires an async function')
+  })
+})


### PR DESCRIPTION
Adds `runWithSessionRefresh` so custom Better Auth endpoints can opt into the same forced session refresh, wait, and next-tick sync path used by built-in auth actions. The helper returns the callback result and skips the refresh when the callback throws or returns a Better Auth `{ error }` result.\n\nExports the helper from the composables subpath and documents the custom auth action pattern.