### PR TITLE
feat: add session cookie cache refresh helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ This changelog is incomplete for alpha releases. Use the GitHub Releases page fo
 - Added strict provider typing for `useSignIn('social').execute()` from configured `socialProviders` keys.
 - Added social `callbackURL` auto-fill when omitted: safe `?redirect=` first, then `auth.redirects.authenticated`.
 - Added `AuthSocialProviderId` to `#nuxt-better-auth` exports for direct provider-id typing in Nuxt apps.
+- Added `refreshSessionCookieCache(event)` to refresh Better Auth's cached session cookie after server-side session data changes.
 
 ### Fixed
 

--- a/docs/content/2.core-concepts/1.server-auth.md
+++ b/docs/content/2.core-concepts/1.server-auth.md
@@ -12,6 +12,7 @@ Use server-side auth utilities in @onmax/nuxt-better-auth.
 - `getUserSession(event)` — get current session (auto-imported in `server/`)
 - `requireUserSession(event, options?)` — throws 401 if not authenticated, supports role matching
 - `getRequestSession(event)` — request-cached session, preferred over repeated `getUserSession` in same request
+- `refreshSessionCookieCache(event)` — refresh Better Auth's cached session cookie after server-side session data changes
 - All server utils are auto-imported, no import statements needed
 ```
 
@@ -27,8 +28,11 @@ Use this page when you need authentication state or Better Auth APIs inside Nitr
 |------|-----|---------|
 | Get request-cached session context | `getRequestSession(event)` | Cache once per request with context-backed storage when available |
 | Get current session | `getUserSession(event)` | Check if user is logged in |
+| Refresh cached session cookie | `refreshSessionCookieCache(event)` | Use after updating data returned by Better Auth session helpers |
 | Require authentication | `requireUserSession(event)` | Protect an API route |
 | Access Better Auth API | `serverAuth(event)` | Call `auth.api.listSessions()` |
 | Get session with options | `requireUserSession(event, { user: { role: 'admin' } })` | Role-based protection |
+
+`refreshSessionCookieCache(event)` refreshes the cached session cookie. It does not update the session or user record; perform that update first.
 
 :read-more{to="/api/server-utils"}

--- a/docs/content/2.core-concepts/4.auto-imports-aliases.md
+++ b/docs/content/2.core-concepts/4.auto-imports-aliases.md
@@ -9,7 +9,7 @@ description: What the module registers for you.
 Use auto-imported utilities from @onmax/nuxt-better-auth.
 
 - Client (auto-imported in Vue): `useUserSession()`, `useUserSessionState()`, `useAuthClient()`, `useSignIn()`, `useSignUp()`, `useAuthClientAction()`
-- Server (auto-imported in `server/`): `serverAuth(event?)`, `getRequestSession(event)`, `getUserSession(event)`, `createSession(event, userId)`, `setSessionCookie(event, token)`, `requireUserSession(event, options?)`
+- Server (auto-imported in `server/`): `serverAuth(event?)`, `getRequestSession(event)`, `getUserSession(event)`, `refreshSessionCookieCache(event)`, `createSession(event, userId)`, `setSessionCookie(event, token)`, `requireUserSession(event, options?)`
 - Component: `<BetterAuthState>` for auth-ready rendering
 - Alias `#nuxt-better-auth` exports types: `AuthUser`, `AuthSession`, `AuthSocialProviderId`
 - Use `getRequestSession(event)` over repeated `getUserSession(event)` calls — it caches per request
@@ -35,6 +35,7 @@ Use this page when you want a quick inventory of what the module registers for y
 - `serverAuth(event?)`
 - `getRequestSession(event)`
 - `getUserSession(event)`
+- `refreshSessionCookieCache(event)`
 - `createSession(event, userId)`
 - `setSessionCookie(event, token)`
 - `requireUserSession(event, options?)`
@@ -58,6 +59,7 @@ export default defineEventHandler(async (event) => {
 
 Use `getRequestSession(event)` when multiple handlers or middleware in the same request need session data. The helper should be preferred over repeated `getUserSession(event)` calls in the same request chain.
 `getUserSession(event)` does not memoize by itself.
+Use `refreshSessionCookieCache(event)` after server-side code updates data returned by the Better Auth session. This refreshes the cached session cookie. It does not update the session or user record; perform that update first.
 
 Use `createSession(event, userId)` when a custom server handler finishes its own verification logic and needs a Better Auth session record without reaching into module internals.
 Use `setSessionCookie(event, token)` when a custom server handler completes its own verification step and needs to attach a Better Auth session cookie to the response.

--- a/docs/content/5.api/2.server-utils.md
+++ b/docs/content/5.api/2.server-utils.md
@@ -76,6 +76,25 @@ Use this helper when multiple handlers/middleware in the same request need sessi
 `getRequestSession` stays type-compatible in projects that use narrowed `h3` typings where `H3Event` does not explicitly declare `context`.
 ::
 
+## refreshSessionCookieCache
+
+Refreshes Better Auth's cached session cookie on the current response, then refreshes the request-cached session used by `getRequestSession(event)`.
+
+```ts [server/api/profile.patch.ts]
+export default defineEventHandler(async (event) => {
+  await updateCurrentUserProfile(event)
+  await refreshSessionCookieCache(event)
+
+  return { ok: true }
+})
+```
+
+Use this helper after server-side code changes data returned by `auth.api.getSession()` or `getRequestSession(event)`, such as user fields added through Better Auth's `custom-session` plugin.
+
+::note
+This refreshes the cached session cookie. It does not update the session or user record; perform that update first.
+::
+
 ## Session Enrichment with `custom-session`
 
 Use Better Auth's `custom-session` plugin when your app needs computed fields in the session payload returned by server helpers. Define the enrichment in `server/auth.config.ts`, and `getUserSession` or `getRequestSession` will return the enriched shape.

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -1,6 +1,6 @@
 import type { H3Event } from 'h3'
 import type { AppSession, AuthSession, RequireSessionOptions } from '#nuxt-better-auth'
-import { createError } from 'h3'
+import { createError, splitCookiesString } from 'h3'
 import { matchesUser } from '../../utils/match-user'
 import { serverAuth } from './auth'
 
@@ -46,6 +46,11 @@ interface RequestSessionContext {
   [requestSessionLoadKey]?: Promise<AppSession | null>
 }
 
+interface SessionWithHeaders {
+  headers: Headers
+  response: AppSession | null
+}
+
 const fallbackRequestSessionContext = new WeakMap<object, RequestSessionContext>()
 
 function getRequestSessionContext(event: H3Event): RequestSessionContext {
@@ -68,6 +73,15 @@ function getRequestHeaders(event: H3Event): Headers {
 function loadSession(event: H3Event): Promise<AppSession | null> {
   const auth = serverAuth(event)
   return auth.api.getSession({ headers: getRequestHeaders(event) }) as Promise<AppSession | null>
+}
+
+function loadFreshSession(event: H3Event): Promise<SessionWithHeaders> {
+  const auth = serverAuth(event)
+  return auth.api.getSession({
+    headers: getRequestHeaders(event),
+    query: { disableCookieCache: true },
+    returnHeaders: true,
+  }) as unknown as Promise<SessionWithHeaders>
 }
 
 function getServerAuthContext(event: H3Event): Promise<ServerAuthContextLike> {
@@ -191,6 +205,21 @@ function appendCookieHeader(event: H3Event, header: string): void {
   responseHeaders?.append('set-cookie', header)
 }
 
+function getSetCookieHeaders(headers: Headers): string[] {
+  const getSetCookie = (headers as Headers & { getSetCookie?: () => string[] }).getSetCookie
+  const cookies = getSetCookie?.call(headers)
+  if (cookies?.length)
+    return cookies.flatMap(cookie => splitCookiesString(cookie))
+
+  const header = headers.get('set-cookie')
+  return header ? splitCookiesString(header) : []
+}
+
+function appendSetCookieHeaders(event: H3Event, headers: Headers): void {
+  for (const header of getSetCookieHeaders(headers))
+    appendCookieHeader(event, header)
+}
+
 function parseRequestCookies(cookieHeader: string | null): Map<string, string> {
   const cookies = new Map<string, string>()
   if (!cookieHeader)
@@ -297,6 +326,29 @@ export async function getUserSession(event: H3Event): Promise<AppSession | null>
     return inFlight
 
   return loadSession(event)
+}
+
+export async function refreshSessionCookieCache(event: H3Event): Promise<AppSession | null> {
+  const context = getRequestSessionContext(event)
+  const inFlight = context[requestSessionLoadKey]
+  if (inFlight)
+    await inFlight.catch(() => undefined)
+
+  delete context.requestSession
+  const load = loadFreshSession(event).then(({ headers, response }) => {
+    appendSetCookieHeaders(event, headers)
+    context.requestSession = response
+    return response
+  })
+
+  context[requestSessionLoadKey] = load
+  try {
+    return await load
+  }
+  finally {
+    if (context[requestSessionLoadKey] === load)
+      delete context[requestSessionLoadKey]
+  }
 }
 
 export async function setSessionCookie(event: H3Event, token: string): Promise<void> {

--- a/test/get-request-session.test.ts
+++ b/test/get-request-session.test.ts
@@ -236,6 +236,52 @@ describe('getUserSession', () => {
   })
 })
 
+describe('refreshSessionCookieCache', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getSessionMock.mockReset()
+    createSessionMock.mockReset()
+  })
+
+  it('refreshes Better Auth cookie cache headers and request session memo', async () => {
+    const staleSession = {
+      user: { id: 'u1', name: 'Before' },
+      session: { id: 's1' },
+    }
+    const freshSession = {
+      user: { id: 'u1', name: 'After' },
+      session: { id: 's1' },
+    }
+    const sessionDataCookie = `${authContextMock.authCookies.sessionData.name}=fresh; Path=/; Expires=Wed, 21 Oct 2030 07:28:00 GMT; HttpOnly`
+    const sessionTokenCookie = `${authContextMock.authCookies.sessionToken.name}=token; Path=/; HttpOnly`
+    const headers = new Headers()
+    headers.set('set-cookie', `${sessionDataCookie}, ${sessionTokenCookie}`)
+
+    getSessionMock
+      .mockResolvedValueOnce(staleSession)
+      .mockResolvedValueOnce({ headers, response: freshSession })
+
+    const { getRequestSession, refreshSessionCookieCache } = await import('../src/runtime/server/utils/session')
+    const event = createEvent()
+
+    await expect(getRequestSession(event)).resolves.toEqual(staleSession)
+    await expect(refreshSessionCookieCache(event)).resolves.toEqual(freshSession)
+    await expect(getRequestSession(event)).resolves.toEqual(freshSession)
+
+    expect(getSessionMock).toHaveBeenCalledTimes(2)
+    expect(getSessionMock.mock.calls[1]?.[0]).toMatchObject({
+      query: { disableCookieCache: true },
+      returnHeaders: true,
+    })
+    expect(getSessionMock.mock.calls[1]?.[0].headers).toBe(event.headers)
+    expect(event.context.requestSession).toEqual(freshSession)
+    expect(event.node.res.getHeader('set-cookie')).toEqual([
+      sessionDataCookie,
+      sessionTokenCookie,
+    ])
+  })
+})
+
 describe('requireUserSession', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/test/require-user-session-typing.test.ts
+++ b/test/require-user-session-typing.test.ts
@@ -75,6 +75,7 @@ export type UserMatch<T> = { [K in keyof T]?: T[K] | T[K][] }
   }
 
   export function createError(input: { statusCode: number, statusMessage: string }): Error
+  export function splitCookiesString(header: string): string[]
 }
 `)
 
@@ -117,7 +118,7 @@ export async function check(event: H3Event) {
 }
 `)
 
-      const typecheck = spawnSync('pnpm', ['exec', 'tsc', '--noEmit', '--pretty', 'false', '-p', tsconfigPath], {
+      const typecheck = spawnSync('corepack', ['pnpm', 'exec', 'tsc', '--noEmit', '--pretty', 'false', '-p', tsconfigPath], {
         cwd: import.meta.dirname,
         encoding: 'utf8',
       })


### PR DESCRIPTION
Adds refreshSessionCookieCache(event) as an auto-imported server utility for refreshing Better Auth's cached session cookie after server-side code updates data returned by session helpers.\n\nThe helper asks Better Auth for a fresh session with cookie cache disabled, forwards returned Set-Cookie headers, and refreshes the per-request getRequestSession(event) memo. Docs now call out that the helper only refreshes the cached cookie; user code must update the session or user record first.