### PR TITLE
docs: sync public auth skill docs

### DIFF
--- a/docs/public/.well-known/skills/index.json
+++ b/docs/public/.well-known/skills/index.json
@@ -1,7 +1,7 @@
 {
   "skills": [{
     "name": "nuxt-better-auth",
-    "description": "Use when implementing auth in Nuxt apps with @onmax/nuxt-better-auth - provides useUserSession composable, server auth helpers, route protection, and Better Auth plugins integration.",
+    "description": "Use when implementing auth in Nuxt apps with @onmax/nuxt-better-auth - provides client composables, server helpers, route protection, session refresh helpers, and Better Auth plugin integration.",
     "files": [
       "SKILL.md",
       "references/client-auth.md",

--- a/docs/public/.well-known/skills/nuxt-better-auth/SKILL.md
+++ b/docs/public/.well-known/skills/nuxt-better-auth/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nuxt-better-auth
-description: Use when implementing auth in Nuxt apps with @onmax/nuxt-better-auth - provides useUserSession composable, server auth helpers, route protection, and Better Auth plugins integration.
+description: Use when implementing auth in Nuxt apps with @onmax/nuxt-better-auth - provides client composables, server helpers, route protection, session refresh helpers, and Better Auth plugin integration.
 license: MIT
 ---
 
@@ -13,9 +13,10 @@ Authentication module for Nuxt 4+ built on [Better Auth](https://www.better-auth
 ## When to Use
 
 - Installing/configuring `@onmax/nuxt-better-auth`
-- Implementing sign-in, sign-up, or sign-out flows
+- Implementing sign-in, sign-up, sign-out, or custom auth flows
 - Protecting routes (client and server)
 - Accessing user session in API routes
+- Refreshing session state after custom auth endpoints or server-side session changes
 - Integrating Better Auth plugins (admin, passkey, 2FA)
 - Setting up database with NuxtHub
 - Using clientOnly mode for external auth backends
@@ -25,8 +26,8 @@ Authentication module for Nuxt 4+ built on [Better Auth](https://www.better-auth
 | File                                                                 | Topics                                                                 |
 | -------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | **[references/installation.md](references/installation.md)**         | install flow, env vars, config files                                   |
-| **[references/client-auth.md](references/client-auth.md)**           | `useUserSession`, client methods, redirects, loading states            |
-| **[references/server-auth.md](references/server-auth.md)**           | `serverAuth`, `getUserSession`, `getRequestSession`, `requireUserSession` |
+| **[references/client-auth.md](references/client-auth.md)**           | `useUserSession`, client methods, redirects, loading states, custom actions |
+| **[references/server-auth.md](references/server-auth.md)**           | `serverAuth`, session helpers, `refreshSessionCookieCache`, API enforcement |
 | **[references/route-protection.md](references/route-protection.md)** | route rules, page meta, API protection                                 |
 | **[references/plugins.md](references/plugins.md)**                   | plugin pairing between server and client                               |
 | **[references/database.md](references/database.md)**                 | NuxtHub schema generation, secondary storage                           |
@@ -50,8 +51,10 @@ Do not load every reference file by default. Pick the smallest file that matches
 
 | Concept                | Description                                                     |
 | ---------------------- | --------------------------------------------------------------- |
-| `useUserSession()`     | Client composable - user, session, loggedIn, signIn/Out methods |
+| `useUserSession()`     | Client composable - user, session, loggedIn, refresh, sign-out |
+| `runWithSessionRefresh()` | Refresh local session after custom auth endpoints |
 | `requireUserSession()` | Server helper - throws 401/403 if not authenticated             |
+| `refreshSessionCookieCache()` | Refresh Better Auth's cached session cookie after server updates |
 | `auth` route mode      | `'user'`, `'guest'`, `{ user: {...} }`, or `false`              |
 | `serverAuth()`         | Get Better Auth instance in server routes                       |
 
@@ -64,8 +67,19 @@ await signIn.email({ email, password }, { onSuccess: () => navigateTo('/') })
 ```
 
 ```ts
+// Client: custom auth endpoint
+await runWithSessionRefresh(() => $fetch('/api/custom-login', { method: 'POST', body }))
+```
+
+```ts
 // Server: requireUserSession()
 const { user } = await requireUserSession(event, { user: { role: 'admin' } })
+```
+
+```ts
+// Server: after updating fields returned by session helpers
+await updateCurrentUser(event)
+await refreshSessionCookieCache(event)
 ```
 
 ```ts
@@ -76,6 +90,8 @@ routeRules: {
   '/app/**': { auth: 'user' }
 }
 ```
+
+Broad rules such as `'/**': { auth: 'user' }` skip framework/module internals like `/_nuxt/**`, `/_ipx/**`, `/api/auth/**`, `/api/_better-auth/**`, and `/api/_nuxt_icon/**`.
 
 ## Resources
 

--- a/docs/public/.well-known/skills/nuxt-better-auth/references/client-auth.md
+++ b/docs/public/.well-known/skills/nuxt-better-auth/references/client-auth.md
@@ -1,95 +1,84 @@
 # Client-side authentication
 
-## Primary entry point
+## Primary entry points
 
 ```ts
-const {
-  user,
-  session,
-  loggedIn,
-  ready,
-  client,
-  signIn,
-  signUp,
-  signOut,
-  fetchSession,
-  updateUser,
-} = useUserSession()
+const { user, session, loggedIn, ready, fetchSession, signOut, updateUser } = useUserSession()
+const client = useAuthClient()
 ```
 
-## What to rely on
+`useUserSession()` is the store-safe session API. It returns auth state plus session lifecycle actions. It does not expose raw Better Auth client namespaces.
 
-- `ready` means the initial auth state has resolved.
-- `client` is browser-only and `null` during SSR.
-- `signIn` and `signUp` proxy Better Auth client methods.
-- `signOut` clears local state after the server sign-out flow completes.
+Use `useAuthClient()` when you need direct Better Auth client/plugin methods. It returns the client in the browser and `null` during SSR.
 
-## Common patterns
+## Sign-in and sign-up forms
 
-### Email sign-in
+Use action composables for form flows that need loading, error, and success state.
 
 ```ts
-await signIn.email(
-  { email: 'user@example.com', password: 'password123' },
-  { onSuccess: () => navigateTo('/dashboard') },
+const signInEmail = useSignIn('email')
+
+await signInEmail.execute({
+  email: 'user@example.com',
+  password: 'password123',
+})
+```
+
+```ts
+const signUpEmail = useSignUp('email')
+await signUpEmail.execute({ email, password, name })
+```
+
+If no `onSuccess` callback is passed, sign-in and sign-up can redirect to a safe local `?redirect=...` target or the configured authenticated redirect.
+
+## Plugin client actions
+
+Use `useAuthClientAction()` for Better Auth client/plugin methods that should expose action state.
+
+```ts
+const openPortal = useAuthClientAction(client => client.customer.portal)
+await openPortal.execute()
+```
+
+## Custom auth endpoints
+
+Use `runWithSessionRefresh()` around custom endpoints that create or change the current session.
+
+```ts
+await runWithSessionRefresh(() =>
+  $fetch('/api/custom-login', {
+    method: 'POST',
+    body: { email, password },
+  }),
 )
 ```
 
-### Social sign-in
+The helper awaits your request, then refreshes local session state unless the result is a Better Auth action error result.
 
-```ts
-await signIn.social({ provider: 'github' })
-```
-
-### Loading state
-
-```vue
-<template>
-  <div v-if="!ready">Loading...</div>
-  <div v-else-if="loggedIn">Welcome, {{ user?.name }}</div>
-  <div v-else>Please log in</div>
-</template>
-```
-
-### Force refresh
+## Force refresh
 
 ```ts
 await fetchSession({ force: true })
 ```
 
+Use `force: true` when the server-side session payload changed and Better Auth's cookie cache should be bypassed for this fetch.
+
 ## Redirect rule
 
 If you read `route.query.redirect`, validate it before navigating. Only allow local paths.
-await client.revokeSession({ sessionId: 'xxx' })
 
-// Revoke all sessions except current
-await client.revokeOtherSessions()
+## BetterAuthState
 
-// Revoke all sessions (logs out everywhere)
-await client.revokeSessions()
-```
-
-These methods require the user to be authenticated.
-
-## BetterAuthState Component
-
-Renders once session hydration completes (`ready === true`), with loading placeholder support.
+`<BetterAuthState>` renders once session hydration completes (`ready === true`) and supports a loading placeholder.
 
 ```vue
 <BetterAuthState>
-  <template #default="{ loggedIn, user, session, signOut }">
+  <template #default="{ loggedIn, user, signOut }">
     <p v-if="loggedIn">Hi {{ user?.name }}</p>
     <button v-else @click="navigateTo('/login')">Sign in</button>
   </template>
   <template #placeholder>
-    <p>Loading…</p>
+    <p>Loading...</p>
   </template>
 </BetterAuthState>
 ```
-
-**Slots:**
-
-- `default` - Renders when `ready === true`, provides `{ loggedIn, user, session, signOut }`
-- `placeholder` - Renders while session hydrates
-
-Useful in clientOnly mode or for graceful SSR loading states.

--- a/docs/public/.well-known/skills/nuxt-better-auth/references/installation.md
+++ b/docs/public/.well-known/skills/nuxt-better-auth/references/installation.md
@@ -12,7 +12,7 @@ Required files:
 - `app/auth.config.ts` or the equivalent file inside your `srcDir`
 - `.env` with `NUXT_BETTER_AUTH_SECRET`
 
-## Required environment variables
+## Environment variables
 
 ```ini
 NUXT_BETTER_AUTH_SECRET=replace-with-a-random-32-character-secret
@@ -60,26 +60,34 @@ export default defineClientAuth({})
 - Do not set `baseURL` manually in full mode. The module resolves it.
 - Use `auth.clientOnly = true` only when Better Auth runs on an external backend.
 - For database-backed auth with the shortest setup, prefer NuxtHub.
+
+## NuxtHub setup
+
+```ts
+export default defineNuxtConfig({
   modules: ['@nuxthub/core', '@onmax/nuxt-better-auth'],
-  hub: { database: true },
+  hub: {
+    db: 'sqlite',
+    kv: true,
+  },
   auth: {
-    hubSecondaryStorage: true  // Enable KV for session caching
-  }
+    hubSecondaryStorage: true,
+  },
 })
 ```
 
 See [references/database.md](database.md) for schema setup.
 
-## Client-Only Mode
+## Client-only mode
 
-For external auth backends (microservices, separate servers):
+For external auth backends:
 
 ```ts
-// nuxt.config.ts
 export default defineNuxtConfig({
+  modules: ['@onmax/nuxt-better-auth'],
   auth: {
-    clientOnly: true,  // No local auth server
-  }
+    clientOnly: true,
+  },
 })
 ```
 

--- a/docs/public/.well-known/skills/nuxt-better-auth/references/plugins.md
+++ b/docs/public/.well-known/skills/nuxt-better-auth/references/plugins.md
@@ -11,6 +11,7 @@ If a Better Auth plugin has a client companion, register both:
 
 ```ts
 import { admin, twoFactor } from 'better-auth/plugins'
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
 
 export default defineServerAuth({
   plugins: [admin(), twoFactor()],
@@ -19,6 +20,7 @@ export default defineServerAuth({
 
 ```ts
 import { adminClient, twoFactorClient } from 'better-auth/client/plugins'
+import { defineClientAuth } from '@onmax/nuxt-better-auth/config'
 
 export default defineClientAuth({
   plugins: [adminClient(), twoFactorClient()],
@@ -34,25 +36,22 @@ export default defineClientAuth({
 | `passkey()` | `passkeyClient()` |
 | `multiSession()` | `multiSessionClient()` |
 
-## Why it matters
-
 Without the matching client plugin, client-side methods and inferred types for that feature are incomplete.
 
-// Client
-import { multiSessionClient } from 'better-auth/client/plugins'
-plugins: [multiSessionClient()]
-```
+## Calling plugin client methods
 
-Usage:
+Use `useAuthClientAction()` when plugin methods should expose loading/error/success state.
 
 ```ts
-// List all sessions
-const sessions = await client.multiSession.listDeviceSessions()
-
-// Revoke specific session
-await client.multiSession.revokeSession({ sessionId: 'xxx' })
+const revokeSession = useAuthClientAction(client => client.multiSession.revokeSession)
+await revokeSession.execute({ sessionId })
 ```
 
-## Plugin Type Inference
+Use `useAuthClient()` for direct calls when action state is not needed.
 
-Types from plugins are automatically inferred. See [references/types.md](types.md) for type augmentation.
+```ts
+const client = useAuthClient()
+await client?.multiSession.listDeviceSessions()
+```
+
+Types from plugins are inferred automatically. See [references/types.md](types.md) for type augmentation.

--- a/docs/public/.well-known/skills/nuxt-better-auth/references/route-protection.md
+++ b/docs/public/.well-known/skills/nuxt-better-auth/references/route-protection.md
@@ -6,10 +6,7 @@
 2. `definePageMeta({ auth })` for page-level overrides
 3. `requireUserSession(event)` for server-side enforcement
 
-## Recommended split
-
-- use route rules and page meta for navigation UX
-- use `requireUserSession(event)` for protected API routes and mutations
+Use route rules and page meta for navigation UX. Use `requireUserSession(event)` for protected API routes and mutations.
 
 ## Common route rules
 
@@ -23,6 +20,8 @@ export default defineNuxtConfig({
 })
 ```
 
+The same auth keys work under `nitro.routeRules`. If both `routeRules` and `nitro.routeRules` are set, the module reads `nitro.routeRules`.
+
 ## Matching
 
 - `'user'`: authenticated users only
@@ -30,3 +29,34 @@ export default defineNuxtConfig({
 - `{ user: { ... } }`: user must match fields
 - arrays inside a field mean OR matching
 - multiple fields mean AND matching
+- `false`: disable auth for that route/page
+
+## Broad rules and internals
+
+Broad rules such as `'/**': { auth: 'user' }` intentionally skip framework and module internals that must stay reachable:
+
+- `/_nuxt/**`
+- `/_ipx/**`
+- `/__nuxt_devtools__/**`
+- `/__better-auth-devtools`
+- `/api/auth/**`
+- `/api/_better-auth/**`
+- `/api/_nuxt_icon/**`
+
+The same broad rules still apply to app-owned pages and app-owned `/api/**` handlers.
+
+## Page meta
+
+```vue
+<script setup lang="ts">
+definePageMeta({
+  auth: {
+    only: 'user',
+    redirectTo: '/login',
+    user: { role: ['admin', 'owner'] },
+  },
+})
+</script>
+```
+
+Page meta overrides global route rules for that page.

--- a/docs/public/.well-known/skills/nuxt-better-auth/references/server-auth.md
+++ b/docs/public/.well-known/skills/nuxt-better-auth/references/server-auth.md
@@ -2,14 +2,15 @@
 
 ## Helpers
 
+These helpers are auto-imported inside `server/` in full mode:
+
 - `serverAuth(event?)`
 - `getUserSession(event)`
 - `getRequestSession(event)`
+- `refreshSessionCookieCache(event)`
 - `requireUserSession(event, options?)`
 - `createSession(event, userId)`
 - `setSessionCookie(event, token)`
-
-All of them are auto-imported inside `server/`.
 
 ## Which helper to use
 
@@ -18,11 +19,12 @@ All of them are auto-imported inside `server/`.
 | Access raw Better Auth APIs | `serverAuth(event)` |
 | Read session if it exists | `getUserSession(event)` |
 | Reuse the same session lookup in one request | `getRequestSession(event)` |
+| Refresh Better Auth's cached session cookie after server-side updates | `refreshSessionCookieCache(event)` |
 | Enforce auth | `requireUserSession(event, options?)` |
-| Create session in a custom flow | `createSession(event, userId)` |
-| Attach session cookie manually | `setSessionCookie(event, token)` |
+| Create a session in a custom flow | `createSession(event, userId)` |
+| Attach a session token cookie manually | `setSessionCookie(event, token)` |
 
-## Common pattern
+## Common API protection
 
 ```ts
 export default defineEventHandler(async (event) => {
@@ -34,24 +36,47 @@ export default defineEventHandler(async (event) => {
 })
 ```
 
+`requireUserSession(event)` throws `401` when unauthenticated and `403` when the user match or custom rule fails.
+
+## Refresh cached session data
+
+Use `refreshSessionCookieCache(event)` after server-side code updates data returned by `auth.api.getSession()`, `getUserSession(event)`, or `getRequestSession(event)`.
+
+```ts
+export default defineEventHandler(async (event) => {
+  await updateCurrentUserProfile(event)
+  await refreshSessionCookieCache(event)
+
+  return { ok: true }
+})
+```
+
+The helper refreshes the cached session cookie and the request-scoped `getRequestSession(event)` memo. It does not update the user or session record; do that first.
+
 ## Matching rules
 
 - scalar value: exact match
 - array value: OR match
 - multiple fields: AND match
-- `rule`: custom callback for logic that field matching cannot express
-  })
-  return getPremiumContent()
-})
+- `rule`: custom callback for logic field matching cannot express
 
-// Owner-only resource
-export default defineEventHandler(async (event) => {
-  const id = getRouterParam(event, 'id')
-  const { user } = await requireUserSession(event)
-  const resource = await getResource(id)
-  if (resource.ownerId !== user.id) {
-    throw createError({ statusCode: 403 })
-  }
-  return resource
+```ts
+await requireUserSession(event, {
+  user: { role: ['admin', 'owner'] },
+  rule: ({ user }) => user.verified === true,
 })
 ```
+
+## Custom server auth flow
+
+```ts
+export default defineEventHandler(async (event) => {
+  const userId = await verifyCustomLogin(event)
+  const session = await createSession(event, userId)
+  await setSessionCookie(event, session.token)
+
+  return { ok: true }
+})
+```
+
+`setSessionCookie(event, token)` sets the Better Auth session token cookie only. It does not recreate every Better Auth sign-in side effect.

--- a/docs/public/.well-known/skills/nuxt-better-auth/references/types.md
+++ b/docs/public/.well-known/skills/nuxt-better-auth/references/types.md
@@ -15,11 +15,11 @@ import type {
 
 ## Key guarantees
 
-- `AuthUser` and `AuthSession` are inferred from your Better Auth config
-- plugin fields flow into `useUserSession()`, `requireUserSession()`, and auth route matching
-- `AuthSocialProviderId` is inferred from configured social providers
+- `AuthUser` and `AuthSession` are inferred from your Better Auth config.
+- plugin fields flow into `useUserSession()`, `getUserSession()`, `getRequestSession()`, `requireUserSession()`, and auth route matching.
+- `AuthSocialProviderId` is inferred from configured social providers.
 
-## When to augment manually
+## Manual augmentation
 
 Only add manual module augmentation if inference is not enough or you need to declare project-specific fields in advance.
 
@@ -32,27 +32,13 @@ declare module '#nuxt-better-auth' {
   }
 }
 ```
-    }
-  }
-})
-```
 
-Types automatically include these fields:
+## Type-safe user matching
 
 ```ts
-// AuthUser now includes:
-interface AuthUser {
-  // ... base fields
-  plan: string
-  credits: number
-}
-```
-
-## Type-Safe User Matching
-
-```ts
-// Fully typed
 await requireUserSession(event, {
-  user: { role: 'admin' }  // TypeScript knows valid fields
+  user: { role: 'admin' },
 })
 ```
+
+The same user matcher shape works in route rules and page meta.


### PR DESCRIPTION
Updates the published .well-known skill docs after the recent auth DX merges.\n\n- Adds the new custom action/session refresh helpers to the skill guidance\n- Documents broad route-rule internal skips\n- Replaces stale malformed reference sections with current concise examples\n\nValidation: `fnm exec --using 24 corepack pnpm build:docs`