### PR TITLE
fix(types): avoid global auth endpoint inference

### DIFF
--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -228,7 +228,7 @@ const { data: customerById } = await useLazyFetch('/api/auth/customer/123/state'
 customerById.value?.customerId.toUpperCase()
 ```
 
-Global `$fetch` keeps Nitro `InternalApi` response inference, but path autocomplete is best on `useFetch`/`useLazyFetch` and `useAuthRequestFetch`.
+Global `$fetch` is not augmented by this module; use `useAuthRequestFetch()` for typed auth endpoint payloads with request-scoped cookies.
 
 ```ts [pages/app.vue]
 const requestFetch = useAuthRequestFetch()

--- a/src/module/type-templates.ts
+++ b/src/module/type-templates.ts
@@ -320,7 +320,6 @@ declare module 'nitropack' {
   interface NitroRouteConfig {
     auth?: import('${runtimeTypesPath}').AuthMeta
   }
-  interface InternalApi extends _GeneratedAuthInternalApi {}
 }
 declare module 'nitropack/types' {
   interface NitroRouteRules {
@@ -329,7 +328,6 @@ declare module 'nitropack/types' {
   interface NitroRouteConfig {
     auth?: import('${runtimeTypesPath}').AuthMeta
   }
-  interface InternalApi extends _GeneratedAuthInternalApi {}
 }
 declare module 'nitro/types' {
   interface NitroRouteRules {
@@ -338,7 +336,6 @@ declare module 'nitro/types' {
   interface NitroRouteConfig {
     auth?: import('${runtimeTypesPath}').AuthMeta
   }
-  interface InternalApi extends _GeneratedAuthInternalApi {}
 }
 export {}
 `,

--- a/test/cases/nitro-endpoints-type-inference/typecheck-target.ts
+++ b/test/cases/nitro-endpoints-type-inference/typecheck-target.ts
@@ -1,38 +1,16 @@
 import type { Base$Fetch } from 'nitropack/types'
-import type { AuthApiEndpointPath, AuthApiEndpointResponse } from '#nuxt-better-auth'
+import type { AuthApiEndpointPath } from '#nuxt-better-auth'
 
 declare const requestFetch: Base$Fetch
 
 type CustomerStatePath = Extract<AuthApiEndpointPath, '/api/auth/customer/state'>
 const customerStatePath: CustomerStatePath = '/api/auth/customer/state'
 
-async function assertEndpointInference() {
+async function assertNoGlobalEndpointInference() {
   const customerState = await requestFetch('/api/auth/customer/state')
+  // @ts-expect-error use useAuthRequestFetch for typed auth endpoint payloads
   customerState.activeSubscriptions[0]?.toUpperCase()
-  customerState.hasBillingIssue.valueOf()
-  // @ts-expect-error no unknown key
-  void customerState.missingField
-
-  const customerViaHelper: AuthApiEndpointResponse<'/api/auth/customer/state'> = customerState
-  void customerViaHelper
-
-  const customerSessionGet = await requestFetch('/api/auth/customer/session')
-  const customerSessionPost = await requestFetch('/api/auth/customer/session', { method: 'POST' })
-  customerSessionGet.ok.valueOf()
-  customerSessionPost.ok.valueOf()
-
-  const session = await requestFetch('/api/auth/get-session')
-  if (session) {
-    void session.user.id
-    void session.session.expiresAt
-  }
-  // @ts-expect-error get-session can be null
-  const shouldFailNullability: { user: { id: string } } = session
-  void shouldFailNullability
-
-  const sessionViaHelper: AuthApiEndpointResponse<'/api/auth/get-session', 'get'> = session
-  void sessionViaHelper
 }
 
 void customerStatePath
-void assertEndpointInference
+void assertNoGlobalEndpointInference

--- a/test/infer-nitro-endpoints-types.test.ts
+++ b/test/infer-nitro-endpoints-types.test.ts
@@ -8,8 +8,8 @@ const env = {
   BETTER_AUTH_SECRET: 'test-secret-for-testing-only-32chars',
 }
 
-describe('typed nitro route inference #194', () => {
-  it('typechecks generated InternalApi endpoint inference for /api/auth routes', () => {
+describe('nitro route inference', () => {
+  it('does not augment global InternalApi with /api/auth routes', () => {
     const prepare = spawnSync('npx', ['nuxi', 'prepare'], {
       cwd: fixtureDir,
       env,


### PR DESCRIPTION
Removes the generated Better Auth endpoint map from Nitro's global `InternalApi` augmentation. Auth endpoint payload typing stays available through the scoped helpers (`useFetch`, `useLazyFetch`, `useAuthRequestFetch`, and `AuthApiEndpointResponse`) without changing every app-level `$fetch` inference path.

This avoids unrelated Nitro route inference collapsing in downstream apps while keeping the dedicated auth DX surface typed.