### PR TITLE
fix: serve docs clean urls on vercel

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,3 +1,5 @@
 {
-  "outputDirectory": ".output/public"
+  "outputDirectory": ".output/public",
+  "cleanUrls": true,
+  "trailingSlash": false
 }


### PR DESCRIPTION
Enables Vercel clean URL serving for the generated docs output and normalizes trailing slashes.

The docs build emits prerendered files like `getting-started.html`, but Vercel was only pointed at `.output/public`, so hard-refresh requests to `/getting-started` missed the static HTML file and returned Vercel 404 before Nuxt could hydrate. With `cleanUrls` enabled, nested docs URLs resolve to their generated HTML files on direct loads.

Closes #376