### PR TITLE
fix: allow runtime-only auth secrets

### DIFF
--- a/docs/content/3.guides/9.production-deployment.md
+++ b/docs/content/3.guides/9.production-deployment.md
@@ -7,7 +7,7 @@ Use this guide when your auth flow works locally and you are preparing to ship i
 
 ## Environment Variables
 
-Production requires these environment variables:
+Production requires these environment variables at runtime:
 
 ```ini [.env.production]
 # Required: 32+ character secret for session encryption
@@ -27,7 +27,7 @@ GOOGLE_CLIENT_SECRET="..."
 node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 ```
 
-The secret must be at least 32 characters. Shorter secrets will cause the module to throw an error.
+The secret must be at least 32 characters. Shorter secrets will cause auth initialization to throw an error at runtime.
 
 ## Security Checklist
 
@@ -81,6 +81,10 @@ export default defineEventHandler((event) => {
 
 For production, consider using Cloudflare rate limiting or a Redis-backed solution.
 
+### Separate Build and Runtime Environments
+
+Some platforms, including Cloudflare Workers Builds, expose build-time and runtime environment variables separately. `NUXT_BETTER_AUTH_SECRET` must be available to the deployed runtime, but it does not need to be present in the build container.
+
 ### Trusted Origins for Preview Environments
 
 If your workflow uses preview URLs (for example, `*.workers.dev`), include those origins in your Better Auth server config.
@@ -119,7 +123,11 @@ export default defineNuxtConfig({
 
 ### "NUXT_BETTER_AUTH_SECRET must be at least 32 characters"
 
-Your secret is too short. Generate a new one using the command above. `BETTER_AUTH_SECRET` is still accepted as a fallback, but `NUXT_BETTER_AUTH_SECRET` is the recommended variable.
+Your secret is too short. Generate a new one using the command above. This error is raised when auth initializes at runtime. `BETTER_AUTH_SECRET` is still accepted as a fallback, but `NUXT_BETTER_AUTH_SECRET` is the recommended variable.
+
+### "NUXT_BETTER_AUTH_SECRET is required in production"
+
+The deployed server runtime could not resolve an auth secret. Set `NUXT_BETTER_AUTH_SECRET` or `BETTER_AUTH_SECRET` in the runtime environment for your app.
 
 ### "siteUrl required in production"
 

--- a/src/module/runtime.ts
+++ b/src/module/runtime.ts
@@ -68,14 +68,6 @@ export function setupRuntimeConfig(input: SetupRuntimeConfigInput): { useHubKV: 
   const currentSecret = nuxt.options.runtimeConfig.betterAuthSecret as string | undefined
   nuxt.options.runtimeConfig.betterAuthSecret = currentSecret || process.env.NUXT_BETTER_AUTH_SECRET || process.env.BETTER_AUTH_SECRET || ''
 
-  const betterAuthSecret = nuxt.options.runtimeConfig.betterAuthSecret as string
-  if (!nuxt.options.dev && !nuxt.options._prepare && !betterAuthSecret) {
-    throw new Error('[nuxt-better-auth] NUXT_BETTER_AUTH_SECRET is required in production. Set NUXT_BETTER_AUTH_SECRET or BETTER_AUTH_SECRET environment variable.')
-  }
-  if (betterAuthSecret && betterAuthSecret.length < 32) {
-    throw new Error('[nuxt-better-auth] NUXT_BETTER_AUTH_SECRET must be at least 32 characters for security')
-  }
-
   nuxt.options.runtimeConfig.auth = defu(nuxt.options.runtimeConfig.auth as Record<string, unknown>, {
     hubSecondaryStorage: options.hubSecondaryStorage ?? false,
   }) as AuthPrivateRuntimeConfig

--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -275,6 +275,12 @@ function withDevTrustedOrigins(
 /** Returns Better Auth instance. Caches per resolved host (or single instance when siteUrl is explicit). */
 export function serverAuth(event?: H3Event): AuthInstance {
   const runtimeConfig = useRuntimeConfig()
+  const betterAuthSecret = runtimeConfig.betterAuthSecret || ''
+  if (!import.meta.dev && !betterAuthSecret)
+    throw new Error('[nuxt-better-auth] NUXT_BETTER_AUTH_SECRET is required in production. Set NUXT_BETTER_AUTH_SECRET or BETTER_AUTH_SECRET environment variable.')
+  if (betterAuthSecret && betterAuthSecret.length < 32)
+    throw new Error('[nuxt-better-auth] NUXT_BETTER_AUTH_SECRET must be at least 32 characters for security')
+
   const siteUrl = getBaseURL(event)
   const requestOrigin = resolveEventOrigin(event)
   const hasExplicitSiteUrl = runtimeConfig.public.siteUrl && typeof runtimeConfig.public.siteUrl === 'string'
@@ -310,7 +316,7 @@ export function serverAuth(event?: H3Event): AuthInstance {
     ...userConfig,
     ...(database ? { database } : {}),
     ...(hubSecondaryStorage === true ? { secondaryStorage: createSecondaryStorage() } : {}),
-    secret: runtimeConfig.betterAuthSecret,
+    secret: betterAuthSecret,
     baseURL: siteUrl,
     trustedOrigins,
   }

--- a/test/cases/runtime-only-secret-build/.nuxtrc
+++ b/test/cases/runtime-only-secret-build/.nuxtrc
@@ -1,0 +1,1 @@
+setups.@onmax/nuxt-better-auth="0.0.4"

--- a/test/cases/runtime-only-secret-build/app/app.vue
+++ b/test/cases/runtime-only-secret-build/app/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <main>Runtime-only auth secret build</main>
+</template>

--- a/test/cases/runtime-only-secret-build/app/auth.config.ts
+++ b/test/cases/runtime-only-secret-build/app/auth.config.ts
@@ -1,0 +1,3 @@
+import { defineClientAuth } from '../../../../src/runtime/config'
+
+export default defineClientAuth({})

--- a/test/cases/runtime-only-secret-build/nuxt.config.ts
+++ b/test/cases/runtime-only-secret-build/nuxt.config.ts
@@ -1,0 +1,18 @@
+export default defineNuxtConfig({
+  modules: [
+    '@nuxthub/core',
+    '../../../src/module',
+  ],
+
+  compatibilityDate: '2026-07-15',
+
+  nitro: {
+    preset: 'cloudflare_module',
+  },
+
+  runtimeConfig: {
+    public: {
+      siteUrl: 'https://runtime-secret.example.workers.dev',
+    },
+  },
+})

--- a/test/cases/runtime-only-secret-build/server/auth.config.ts
+++ b/test/cases/runtime-only-secret-build/server/auth.config.ts
@@ -1,0 +1,3 @@
+import { defineServerAuth } from '../../../../src/runtime/config'
+
+export default defineServerAuth({})

--- a/test/runtime-config.test.ts
+++ b/test/runtime-config.test.ts
@@ -135,7 +135,7 @@ describe('setupRuntimeConfig secret resolution', () => {
     expect((nuxt.options as any).runtimeConfig.betterAuthSecret).toBe('fallback-secret-for-testing-only-32chars')
   })
 
-  it('throws in production when no secret is configured', () => {
+  it('allows production builds without a configured secret', () => {
     const nuxt = createNuxtWithRuntimeConfig()
     nuxt.options.dev = false
     const consola = createConsolaMock()
@@ -147,7 +147,8 @@ describe('setupRuntimeConfig secret resolution', () => {
       databaseProvider: 'none',
       hasNuxtHub: false,
       consola,
-    })).toThrow('NUXT_BETTER_AUTH_SECRET is required in production')
+    })).not.toThrow()
+    expect((nuxt.options as any).runtimeConfig.betterAuthSecret).toBe('')
   })
 })
 

--- a/test/runtime-only-secret-build.test.ts
+++ b/test/runtime-only-secret-build.test.ts
@@ -1,0 +1,27 @@
+import { existsSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { join } from 'pathe'
+import { describe, expect, it } from 'vitest'
+
+const fixtureDir = fileURLToPath(new URL('./cases/runtime-only-secret-build', import.meta.url))
+
+describe('runtime-only auth secret', () => {
+  it('builds for Cloudflare without exposing the runtime secret to the build', () => {
+    const env = {
+      ...process.env,
+      CI: '1',
+    }
+    delete env.NUXT_BETTER_AUTH_SECRET
+    delete env.BETTER_AUTH_SECRET
+
+    const build = spawnSync('npx', ['nuxi', 'build'], {
+      cwd: fixtureDir,
+      env,
+      encoding: 'utf8',
+    })
+
+    expect(build.status, `nuxi build failed:\n${build.stdout}\n${build.stderr}`).toBe(0)
+    expect(existsSync(join(fixtureDir, '.output/server/wrangler.json'))).toBe(true)
+  }, 120_000)
+})

--- a/test/server-auth-database-cache.test.ts
+++ b/test/server-auth-database-cache.test.ts
@@ -41,7 +41,7 @@ function createEvent(): MockEvent {
   } as unknown as MockEvent
 }
 
-describe('serverAuth database cache behavior', () => {
+describe('serverAuth database cache and secret validation', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
@@ -51,7 +51,7 @@ describe('serverAuth database cache behavior', () => {
         siteUrl: 'https://example.com',
       },
       auth: {},
-      betterAuthSecret: 'test-secret',
+      betterAuthSecret: 'test-secret-for-testing-only-32chars',
     })
 
     createServerAuthMock.mockReturnValue({
@@ -62,6 +62,32 @@ describe('serverAuth database cache behavior', () => {
       options,
       marker: Symbol('auth-instance'),
     }))
+  })
+
+  it('rejects a missing runtime secret before creating auth', async () => {
+    useRuntimeConfigMock.mockReturnValue({
+      public: { siteUrl: 'https://example.com' },
+      auth: {},
+      betterAuthSecret: '',
+    })
+
+    const { serverAuth } = await import('../src/runtime/server/utils/auth')
+
+    expect(() => serverAuth()).toThrow('NUXT_BETTER_AUTH_SECRET is required in production')
+    expect(betterAuthMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a short runtime secret before creating auth', async () => {
+    useRuntimeConfigMock.mockReturnValue({
+      public: { siteUrl: 'https://example.com' },
+      auth: {},
+      betterAuthSecret: 'too-short',
+    })
+
+    const { serverAuth } = await import('../src/runtime/server/utils/auth')
+
+    expect(() => serverAuth()).toThrow('NUXT_BETTER_AUTH_SECRET must be at least 32 characters')
+    expect(betterAuthMock).not.toHaveBeenCalled()
   })
 
   it('reuses the same auth instance within a request when a database adapter is active', async () => {


### PR DESCRIPTION
## Summary

- allow production builds without exposing the auth secret to the build environment
- validate missing and short secrets when `serverAuth()` initializes at runtime
- add a Cloudflare Workers + NuxtHub regression fixture and update deployment guidance

## Root cause

#303 moved secret validation to runtime, but #305 accidentally restored the build-time guard while landing the unrelated NuxtHub prerender import fix. Platforms with separate build and runtime environments then failed before the deployed runtime could provide `NUXT_BETTER_AUTH_SECRET`.

Closes #302

## Testing

- `pnpm test` (53 files, 293 tests)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec nuxt-module-build build`
