### PR TITLE
fix: register auth types across Nuxt projects

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -114,7 +114,6 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
       consola,
     })
 
-    nuxt.options.alias['#nuxt-better-auth'] = setup.aliases['#nuxt-better-auth']
     if (setup.aliases['#auth/server'])
       nuxt.options.alias['#auth/server'] = setup.aliases['#auth/server']
     nuxt.options.alias['#auth/client'] = setup.aliases['#auth/client']
@@ -188,12 +187,11 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
       )
     }
 
-    const authTypesTemplate = registerSharedTypeTemplates({
-      runtimeTypesAugmentPath: setup.aliases['#nuxt-better-auth'],
+    registerSharedTypeTemplates({
+      runtimeTypesAugmentPath: setup.sharedTypes.runtimeTypesAugmentPath,
       runtimeTypesPath: resolver.resolve('./runtime/types'),
       clientConfigPath: setup.sharedTypes.clientConfigPath,
     })
-    nuxt.options.alias['#nuxt-better-auth'] = authTypesTemplate.dst
 
     registerTemplateHmrHook(nuxt)
     registerServerRuntime({ clientOnly: setup.clientOnly, resolve: resolver.resolve })

--- a/src/module.ts
+++ b/src/module.ts
@@ -188,11 +188,12 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
       )
     }
 
-    registerSharedTypeTemplates({
+    const authTypesTemplate = registerSharedTypeTemplates({
       runtimeTypesAugmentPath: setup.aliases['#nuxt-better-auth'],
       runtimeTypesPath: resolver.resolve('./runtime/types'),
       clientConfigPath: setup.sharedTypes.clientConfigPath,
     })
+    nuxt.options.alias['#nuxt-better-auth'] = authTypesTemplate.dst
 
     registerTemplateHmrHook(nuxt)
     registerServerRuntime({ clientOnly: setup.clientOnly, resolve: resolver.resolve })

--- a/src/module/hooks.ts
+++ b/src/module/hooks.ts
@@ -83,7 +83,6 @@ export function registerPrepareTypesHook(input: RegisterPrepareTypesHookInput): 
       '#auth/schema': nuxt.options.alias['#auth/schema'],
       '#auth/secondary-storage': nuxt.options.alias['#auth/secondary-storage'],
       '#auth/route-rules': nuxt.options.alias['#auth/route-rules'],
-      '#nuxt-better-auth': nuxt.options.alias['#nuxt-better-auth'],
     } as const
 
     for (const [key, value] of Object.entries(exactNodeAliases)) {

--- a/src/module/setup.ts
+++ b/src/module/setup.ts
@@ -22,7 +22,6 @@ export interface ResolvedAuthModuleSetup {
     client: AuthConfigDescriptor
   }
   aliases: {
-    '#nuxt-better-auth': string
     '#auth/server'?: string
     '#auth/client': string
   }
@@ -50,6 +49,7 @@ export interface ResolvedAuthModuleSetup {
     hasHubDb: boolean
   }
   sharedTypes: {
+    runtimeTypesAugmentPath: string
     clientConfigPath: string
   }
   schemaGeneration?: {
@@ -136,12 +136,10 @@ export async function resolveAuthModuleSetup(
   assertConfigPresence(configs, clientOnly)
 
   const aliases: ResolvedAuthModuleSetup['aliases'] = {
-    '#nuxt-better-auth': runtimeTypesAugmentPath,
     '#auth/server': clientOnly ? undefined : configs.server.path,
     '#auth/client': configs.client.path,
   }
 
-  nuxt.options.alias['#nuxt-better-auth'] = aliases['#nuxt-better-auth']
   if (aliases['#auth/server'])
     nuxt.options.alias['#auth/server'] = aliases['#auth/server']
   nuxt.options.alias['#auth/client'] = aliases['#auth/client']
@@ -225,6 +223,7 @@ export async function resolveAuthModuleSetup(
           hasHubDb,
         },
     sharedTypes: {
+      runtimeTypesAugmentPath,
       clientConfigPath: configs.client.path,
     },
     schemaGeneration: hasHubDb

--- a/src/module/type-templates.ts
+++ b/src/module/type-templates.ts
@@ -348,8 +348,8 @@ interface RegisterSharedTypeTemplatesInput {
   clientConfigPath: string
 }
 
-export function registerSharedTypeTemplates(input: RegisterSharedTypeTemplatesInput): void {
-  addTypeTemplate({
+export function registerSharedTypeTemplates(input: RegisterSharedTypeTemplatesInput) {
+  const authTypesTemplate = addTypeTemplate({
     filename: 'types/nuxt-better-auth.d.ts',
     getContents: () => `
 import type { AppSession } from '${input.runtimeTypesAugmentPath}'
@@ -372,4 +372,6 @@ declare module '#nuxt-better-auth' {
 }
 `,
   })
+
+  return authTypesTemplate
 }

--- a/src/module/type-templates.ts
+++ b/src/module/type-templates.ts
@@ -143,7 +143,7 @@ declare module '#nuxt-better-auth' {
   }, serverConfigTypeTemplateOptions)
 
   addTypeTemplate({
-    filename: 'types/nuxt-better-auth-nitro.d.ts',
+    filename: 'types/nuxt-better-auth-endpoints.d.ts',
     getContents: () => `
 import type createServerAuth from '${serverConfigPath}'
 import type { BetterAuthOptions } from 'better-auth'
@@ -312,7 +312,13 @@ declare module 'nuxt/app' {
   >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: Omit<import('nuxt/dist/app/composables/fetch').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>, 'lazy'>): import('nuxt/dist/app/composables/asyncData').AsyncData<import('nuxt/dist/app/composables/asyncData').PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
   export function useLazyFetch(request: string | import('vue').Ref<string> | (() => string), opts?: any): any
 }
+export {}
+`,
+  }, serverConfigTypeTemplateOptions)
 
+  addTypeTemplate({
+    filename: 'types/nuxt-better-auth-nitro.d.ts',
+    getContents: () => `
 declare module 'nitropack' {
   interface NitroRouteRules {
     auth?: import('${runtimeTypesPath}').AuthMeta
@@ -349,19 +355,81 @@ interface RegisterSharedTypeTemplatesInput {
 }
 
 export function registerSharedTypeTemplates(input: RegisterSharedTypeTemplatesInput) {
-  const authTypesTemplate = addTypeTemplate({
+  addTypeTemplate({
     filename: 'types/nuxt-better-auth.d.ts',
     getContents: () => `
-import type { AppSession } from '${input.runtimeTypesAugmentPath}'
-export * from '${input.runtimeTypesAugmentPath}'
-export type { AuthMeta, AuthMode, AuthRouteRules, AuthSocialProviderId, Auth, InferUser, InferSession } from '${input.runtimeTypesPath}'
-declare module 'h3' {
-  interface H3EventContext {
-    requestSession?: AppSession | null
+declare module '#nuxt-better-auth' {
+  import type { ComputedRef, Ref } from 'vue'
+
+  export interface AuthUser {
+    id: string
+    createdAt: Date
+    updatedAt: Date
+    email: string
+    emailVerified: boolean
+    name: string
+    image?: string | null
   }
+
+  export interface AuthSession {
+    id: string
+    createdAt: Date
+    updatedAt: Date
+    userId: string
+    expiresAt: Date
+    token: string
+    ipAddress?: string | null
+    userAgent?: string | null
+  }
+
+  export interface ServerAuthContext {
+    runtimeConfig: Record<string, unknown>
+    db: unknown
+    requestOrigin?: string
+  }
+
+  export interface AuthSocialProviderRegistry {}
+  export type AuthSocialProviderId = AuthSocialProviderRegistry extends { ids: infer T } ? Extract<T, string> : never
+
+  export interface UserSessionComposable {
+    user: Ref<AuthUser | null>
+    session: Ref<AuthSession | null>
+    loggedIn: ComputedRef<boolean>
+    ready: ComputedRef<boolean>
+    fetchSession: (options?: { headers?: HeadersInit, force?: boolean }) => Promise<void>
+    waitForSession: () => Promise<void>
+    signOut: (options?: { onSuccess?: () => void | Promise<void> }) => Promise<void>
+    updateUser: (updates: Partial<AuthUser>) => Promise<void>
+  }
+
+  export type UserMatch<T> = { [K in keyof T]?: T[K] | T[K][] }
+
+  export interface AppSession {
+    user: AuthUser
+    session: AuthSession
+  }
+
+  export interface RequireSessionOptions {
+    user?: UserMatch<AuthUser>
+    rule?: (ctx: { user: AuthUser, session: AuthSession }) => boolean | Promise<boolean>
+  }
+
+  export type { AuthMeta, AuthMode, AuthRouteRules, Auth, InferUser, InferSession } from '${input.runtimeTypesPath}'
 }
 `,
-  })
+  }, { nuxt: true, nitro: true, node: true, shared: true })
+
+  addTypeTemplate({
+    filename: 'types/nuxt-better-auth-h3.d.ts',
+    getContents: () => `
+declare module 'h3' {
+  interface H3EventContext {
+    requestSession?: import('${input.runtimeTypesAugmentPath}').AppSession | null
+  }
+}
+export {}
+`,
+  }, { nuxt: true, nitro: true, node: true, shared: true })
 
   addTypeTemplate({
     filename: 'types/nuxt-better-auth-client.d.ts',
@@ -372,6 +440,4 @@ declare module '#nuxt-better-auth' {
 }
 `,
   })
-
-  return authTypesTemplate
 }

--- a/test/cases/composables-subpath-import/tsconfig.type-check.json
+++ b/test/cases/composables-subpath-import/tsconfig.type-check.json
@@ -4,10 +4,11 @@
     "noEmit": true
   },
   "include": [
+    "./.nuxt/types/nuxt-better-auth.d.ts",
     "./.nuxt/types/nuxt-better-auth-client.d.ts",
     "./.nuxt/types/nuxt-better-auth-infer.d.ts",
     "./.nuxt/types/nuxt-better-auth-social-providers.d.ts",
-    "./.nuxt/types/nuxt-better-auth-nitro.d.ts",
+    "./.nuxt/types/nuxt-better-auth-endpoints.d.ts",
     "./typecheck-target.ts"
   ]
 }

--- a/test/cases/nitro-endpoints-type-inference/tsconfig.type-check.json
+++ b/test/cases/nitro-endpoints-type-inference/tsconfig.type-check.json
@@ -9,8 +9,7 @@
     "moduleResolution": "bundler",
     "paths": {
       "#auth/client": ["../_base-module/app/auth.config"],
-      "#auth/server": ["./server/auth.config"],
-      "#nuxt-better-auth": ["../../../src/runtime/types/augment"]
+      "#auth/server": ["./server/auth.config"]
     },
     "types": [],
     "strict": true,
@@ -18,7 +17,9 @@
     "skipLibCheck": true
   },
   "files": [
+    "./.nuxt/types/nuxt-better-auth.d.ts",
     "./.nuxt/types/nuxt-better-auth-infer.d.ts",
+    "./.nuxt/types/nuxt-better-auth-endpoints.d.ts",
     "./.nuxt/types/nuxt-better-auth-nitro.d.ts",
     "./typecheck-target.ts"
   ]

--- a/test/cases/plugins-type-inference-layer/app/app.vue
+++ b/test/cases/plugins-type-inference-layer/app/app.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import type { AuthUser } from '#nuxt-better-auth'
+
+declare const user: AuthUser
+
+const role: string | null | undefined = user.role
+const banned: boolean | null | undefined = user.banned
+
+void role
+void banned
+</script>
+
+<template>
+  <div>layered admin types</div>
+</template>

--- a/test/cases/plugins-type-inference-layer/nuxt.config.ts
+++ b/test/cases/plugins-type-inference-layer/nuxt.config.ts
@@ -1,0 +1,3 @@
+export default defineNuxtConfig({
+  extends: ['../plugins-type-inference'],
+})

--- a/test/cases/plugins-type-inference-layer/shared/auth-types.ts
+++ b/test/cases/plugins-type-inference-layer/shared/auth-types.ts
@@ -1,0 +1,15 @@
+import type { AuthUser } from '#nuxt-better-auth'
+
+export function assertLayeredAdminTypes(user: AuthUser) {
+  const role: string | null | undefined = user.role
+  const banned: boolean | null | undefined = user.banned
+  const banReason: string | null | undefined = user.banReason
+  const banExpires: Date | null | undefined = user.banExpires
+
+  return {
+    banned,
+    banExpires,
+    banReason,
+    role,
+  }
+}

--- a/test/cases/plugins-type-inference/server/auth.config.ts
+++ b/test/cases/plugins-type-inference/server/auth.config.ts
@@ -1,41 +1,9 @@
-import { username } from 'better-auth/plugins'
+import { admin, username } from 'better-auth/plugins'
 import { defineServerAuth } from '../../../../src/runtime/config'
-
-function customAdminLikePlugin() {
-  return {
-    id: 'custom-admin-like',
-    $ERROR_CODES: {
-      BROKEN: {
-        code: 'BROKEN',
-        message: 'Broken',
-      },
-    },
-    schema: {
-      session: {
-        fields: {
-          workspaceId: {
-            type: 'string',
-            required: false,
-            input: false,
-          },
-        },
-      },
-      user: {
-        fields: {
-          role: {
-            type: 'string',
-            required: false,
-            input: false,
-          },
-        },
-      },
-    },
-  } as const
-}
 
 export default defineServerAuth(() => ({
   emailAndPassword: { enabled: true },
-  plugins: [customAdminLikePlugin(), username()] as const,
+  plugins: [admin(), username()] as const,
   socialProviders: {
     github: {
       clientId: 'test-client-id',

--- a/test/cases/plugins-type-inference/shared/auth-types.ts
+++ b/test/cases/plugins-type-inference/shared/auth-types.ts
@@ -3,14 +3,19 @@ import type { AuthSocialProviderId } from '../../../../src/runtime/types'
 
 export function assertSharedAuthTypes(user: AuthUser, session: AuthSession) {
   const role: string | null | undefined = user.role
+  const banned: boolean | null | undefined = user.banned
+  const banReason: string | null | undefined = user.banReason
+  const banExpires: Date | null | undefined = user.banExpires
   const internalCode: string | null | undefined = user.internalCode
-  const workspaceId: string | null | undefined = session.workspaceId
   const provider: AuthSocialProviderId = 'github'
 
   return {
+    banned,
+    banExpires,
+    banReason,
     internalCode,
     provider,
     role,
-    workspaceId,
+    session,
   }
 }

--- a/test/cases/plugins-type-inference/tsconfig.type-check.json
+++ b/test/cases/plugins-type-inference/tsconfig.type-check.json
@@ -9,8 +9,7 @@
     "moduleResolution": "bundler",
     "paths": {
       "#auth/client": ["./app/auth.config"],
-      "#auth/server": ["./server/auth.config"],
-      "#nuxt-better-auth": ["../../../src/runtime/types/augment"]
+      "#auth/server": ["./server/auth.config"]
     },
     "types": [],
     "strict": true,
@@ -19,8 +18,11 @@
   },
   "files": [
     "./virtual-modules.d.ts",
+    "./.nuxt/types/nuxt-better-auth.d.ts",
+    "./.nuxt/types/nuxt-better-auth-h3.d.ts",
     "./.nuxt/types/nuxt-better-auth-infer.d.ts",
     "./.nuxt/types/nuxt-better-auth-social-providers.d.ts",
+    "./.nuxt/types/nuxt-better-auth-endpoints.d.ts",
     "./.nuxt/types/nuxt-better-auth-nitro.d.ts",
     "./typecheck-target.ts"
   ]

--- a/test/cases/plugins-type-inference/typecheck-target.ts
+++ b/test/cases/plugins-type-inference/typecheck-target.ts
@@ -18,6 +18,9 @@ const user: AuthUser = {
   emailVerified: false,
   name: 'n',
   role: 'admin',
+  banned: false,
+  banReason: null,
+  banExpires: null,
   internalCode: 'x',
   foo: 'bar',
 }
@@ -29,7 +32,6 @@ const session: AuthSession = {
   userId: '1',
   expiresAt: new Date(),
   token: 'token',
-  workspaceId: 'workspace-1',
 }
 
 const provider: AuthSocialProviderId = 'github'

--- a/test/cases/signin-provider-alias-type-inference/tsconfig.type-check.json
+++ b/test/cases/signin-provider-alias-type-inference/tsconfig.type-check.json
@@ -7,11 +7,6 @@
     ],
     "module": "preserve",
     "moduleResolution": "bundler",
-    "paths": {
-      "#nuxt-better-auth": [
-        "./.nuxt/types/nuxt-better-auth.d.ts"
-      ]
-    },
     "types": [],
     "strict": true,
     "noEmit": true,

--- a/test/cases/use-fetch-endpoints-type-inference/tsconfig.type-check.json
+++ b/test/cases/use-fetch-endpoints-type-inference/tsconfig.type-check.json
@@ -10,7 +10,6 @@
     "paths": {
       "#auth/client": ["../_base-module/app/auth.config"],
       "#auth/server": ["./server/auth.config"],
-      "#nuxt-better-auth": ["../../../src/runtime/types/augment"],
       "#imports": ["./imports-shim"]
     },
     "types": [],
@@ -20,8 +19,9 @@
   },
   "files": [
     "./imports-shim.d.ts",
+    "./.nuxt/types/nuxt-better-auth.d.ts",
     "./.nuxt/types/nuxt-better-auth-infer.d.ts",
-    "./.nuxt/types/nuxt-better-auth-nitro.d.ts",
+    "./.nuxt/types/nuxt-better-auth-endpoints.d.ts",
     "./typecheck-target.ts"
   ]
 }

--- a/test/infer-plugins-types.test.ts
+++ b/test/infer-plugins-types.test.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
@@ -16,6 +17,11 @@ describe('type inference regressions #107 and #192', () => {
       encoding: 'utf8',
     })
     expect(prepare.status, `nuxi prepare failed:\n${prepare.stdout}\n${prepare.stderr}`).toBe(0)
+
+    const serverTsconfig = JSON.parse(readFileSync(`${fixtureDir}/.nuxt/tsconfig.server.json`, 'utf8'))
+    expect(serverTsconfig.compilerOptions.paths['#nuxt-better-auth']).toEqual([
+      './types/nuxt-better-auth.d',
+    ])
 
     const typecheck = spawnSync('npx', ['vue-tsc', '--noEmit', '--pretty', 'false', '-p', 'tsconfig.type-check.json'], {
       cwd: fixtureDir,

--- a/test/infer-plugins-types.test.ts
+++ b/test/infer-plugins-types.test.ts
@@ -1,15 +1,15 @@
 import { spawnSync } from 'node:child_process'
-import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
 const fixtureDir = fileURLToPath(new URL('./cases/plugins-type-inference', import.meta.url))
+const layerFixtureDir = fileURLToPath(new URL('./cases/plugins-type-inference-layer', import.meta.url))
 const env = {
   ...process.env,
   BETTER_AUTH_SECRET: 'test-secret-for-testing-only-32chars',
 }
 
-describe('type inference regressions #107 and #192', () => {
+describe('type inference regressions #107, #192, and #382', () => {
   it('typechecks plugin/additional fields and serverAuth plugin API inference', () => {
     const prepare = spawnSync('npx', ['nuxi', 'prepare'], {
       cwd: fixtureDir,
@@ -17,11 +17,6 @@ describe('type inference regressions #107 and #192', () => {
       encoding: 'utf8',
     })
     expect(prepare.status, `nuxi prepare failed:\n${prepare.stdout}\n${prepare.stderr}`).toBe(0)
-
-    const serverTsconfig = JSON.parse(readFileSync(`${fixtureDir}/.nuxt/tsconfig.server.json`, 'utf8'))
-    expect(serverTsconfig.compilerOptions.paths['#nuxt-better-auth']).toEqual([
-      './types/nuxt-better-auth.d',
-    ])
 
     const typecheck = spawnSync('npx', ['vue-tsc', '--noEmit', '--pretty', 'false', '-p', 'tsconfig.type-check.json'], {
       cwd: fixtureDir,
@@ -43,5 +38,23 @@ describe('type inference regressions #107 and #192', () => {
       encoding: 'utf8',
     })
     expect(sharedTypecheck.status, `shared vue-tsc failed:\n${sharedTypecheck.stdout}\n${sharedTypecheck.stderr}`).toBe(0)
+  }, 60_000)
+
+  it('keeps admin plugin fields in app and shared projects when auth config comes from a layer', () => {
+    const prepare = spawnSync('npx', ['nuxi', 'prepare'], {
+      cwd: layerFixtureDir,
+      env,
+      encoding: 'utf8',
+    })
+    expect(prepare.status, `layer nuxi prepare failed:\n${prepare.stdout}\n${prepare.stderr}`).toBe(0)
+
+    for (const project of ['app', 'shared']) {
+      const typecheck = spawnSync('npx', ['vue-tsc', '--noEmit', '--pretty', 'false', '-p', `.nuxt/tsconfig.${project}.json`], {
+        cwd: layerFixtureDir,
+        env,
+        encoding: 'utf8',
+      })
+      expect(typecheck.status, `${project} vue-tsc failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)
+    }
   }, 60_000)
 })

--- a/test/module-setup.test.ts
+++ b/test/module-setup.test.ts
@@ -129,7 +129,6 @@ describe('resolveAuthModuleSetup', () => {
           aliasesDuringProviderSelection = {
             server: nuxt.options.alias['#auth/server'],
             client: nuxt.options.alias['#auth/client'],
-            augment: nuxt.options.alias['#nuxt-better-auth'],
           }
           return true
         },
@@ -149,7 +148,6 @@ describe('resolveAuthModuleSetup', () => {
     expect(aliasesDuringProviderSelection).toEqual({
       server: setup.configs.server.path,
       client: setup.configs.client.path,
-      augment: '/virtual/runtime-types/augment',
     })
   })
 


### PR DESCRIPTION
## Summary

- define `#nuxt-better-auth` as an ambient generated module registered in Nuxt app, Nitro, node, and shared type contexts
- split endpoint inference from Nitro route-rule augmentation so each project references only compatible declarations
- cover the real Better Auth `admin()` plugin through an inherited Nuxt layer while retaining endpoint, provider, and public composables coverage

## Why

Nuxt modules register generated declarations through `addTypeTemplate` project references. Using a `.d.ts` path alias made the generated file responsible for replacing the package type surface and broke public composable exports. An ambient generated module keeps the mergeable interfaces inside the consuming project without adding a runtime or TypeScript alias.

Closes #382.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — 53 files and 294 tests passed
- patched `@onmax/nuxt-better-auth@0.0.5` with `pnpm patch` in `~/repros/nuxt-better-auth-382`; the layered `admin()` reproduction passes `pnpm typecheck`
