### PR TITLE
fix: bootstrap auth schema before config loading

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,11 +1,12 @@
 import type { Nuxt } from '@nuxt/schema'
+import type { DbDialect } from './module/hub'
 import type { BetterAuthModuleOptions } from './runtime/config'
 import type { BetterAuthDatabaseProviderSetupContext } from './types/hooks'
 import { existsSync, readFileSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { addTemplate, createResolver, defineNuxtModule } from '@nuxt/kit'
 import { consola as _consola } from 'consola'
-import { dirname, relative } from 'pathe'
+import { dirname, join, relative } from 'pathe'
 import { version } from '../package.json'
 import { resolveAuthConfigDescriptors } from './module/config-paths'
 import { registerAuthMiddlewareHook, registerDevtools, registerNuxtHubDatabaseExternalHook, registerPrepareTypesHook, registerRouteRulesMetaHook, registerServerRuntime, registerTemplateHmrHook } from './module/hooks'
@@ -83,6 +84,15 @@ export default defineClientAuth({})
   }
 }
 
+async function ensureSchemaBootstrap(schemaPath: string, dialect: DbDialect): Promise<void> {
+  const dialectSchemaPath = join(dirname(schemaPath), `schema.${dialect}.mjs`)
+  if (existsSync(schemaPath) && existsSync(dialectSchemaPath))
+    return
+
+  await mkdir(dirname(schemaPath), { recursive: true })
+  await writeFile(schemaPath, buildSchemaExportCode(false, dialect))
+}
+
 export type { BetterAuthModuleOptions } from './runtime/config'
 
 export default defineNuxtModule<BetterAuthModuleOptions>({
@@ -139,6 +149,9 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
         write: true,
       })
       nuxt.options.alias['#auth/schema'] = schemaTemplate.dst
+
+      if (setup.schemaGeneration)
+        await ensureSchemaBootstrap(schemaTemplate.dst, setup.database.buildContext?.hubDialect ?? 'sqlite')
     }
 
     if (setup.prepareTypes) {

--- a/test/auth-schema-export.test.ts
+++ b/test/auth-schema-export.test.ts
@@ -1,10 +1,23 @@
+import { spawnSync } from 'node:child_process'
+import { rmSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
+import { join } from 'pathe'
 import { $fetch, setup } from '@nuxt/test-utils/e2e'
 import { describe, expect, it } from 'vitest'
 
 describe('#auth/schema export', async () => {
+  const rootDir = fileURLToPath(new URL('./cases/auth-schema-export', import.meta.url))
+  rmSync(join(rootDir, '.nuxt'), { force: true, recursive: true })
+
+  const prepare = spawnSync('npx', ['nuxi', 'prepare'], {
+    cwd: rootDir,
+    encoding: 'utf8',
+  })
+  if (prepare.status !== 0)
+    throw new Error(`clean nuxi prepare failed:\n${prepare.stdout}\n${prepare.stderr}`)
+
   await setup({
-    rootDir: fileURLToPath(new URL('./cases/auth-schema-export', import.meta.url)),
+    rootDir,
   })
 
   it('exports stable auth tables with plural generation enabled', async () => {

--- a/test/cases/auth-schema-export/server/auth.config.ts
+++ b/test/cases/auth-schema-export/server/auth.config.ts
@@ -1,6 +1,16 @@
 import { defineServerAuth } from '../../../../src/runtime/config'
+import { posts } from './db/schema/posts'
 
 export default defineServerAuth(({ runtimeConfig }) => ({
   appName: runtimeConfig.public.app.routes.signUp,
   emailAndPassword: { enabled: true },
+  databaseHooks: {
+    user: {
+      create: {
+        async after() {
+          void posts
+        },
+      },
+    },
+  },
 }))

--- a/test/cases/auth-schema-export/server/db/schema/posts.ts
+++ b/test/cases/auth-schema-export/server/db/schema/posts.ts
@@ -1,0 +1,9 @@
+import { schema } from '#auth/schema'
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core'
+
+export const posts = sqliteTable('posts', {
+  id: text('id').primaryKey(),
+  authorId: text('author_id')
+    .notNull()
+    .references(() => schema.user.id),
+})


### PR DESCRIPTION
## Summary

- write an inert `#auth/schema` bootstrap before loading the server auth config on a clean Nuxt build
- leave Nuxt template generation responsible for replacing it with the final dialect schema
- cover an application table that lazily references `schema.user.id` during a clean `nuxi prepare`

Closes #384

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm prepack`
- `pnpm test` — 53 files, 294 tests
- applied the built change as a pnpm patch to `@onmax/nuxt-better-auth@0.0.6`; a clean install completed its `nuxt prepare` postinstall and generated the SQLite schema
