### PR TITLE
fix: register site URL for runtime overrides

### DIFF
--- a/src/module/runtime.ts
+++ b/src/module/runtime.ts
@@ -37,8 +37,7 @@ export function setupRuntimeConfig(input: SetupRuntimeConfigInput): { useHubKV: 
 
   nuxt.options.runtimeConfig.public = nuxt.options.runtimeConfig.public || {}
   const configuredSiteUrl = nuxt.options.runtimeConfig.public.siteUrl as string | undefined
-  if (!configuredSiteUrl && process.env.NUXT_PUBLIC_SITE_URL)
-    nuxt.options.runtimeConfig.public.siteUrl = process.env.NUXT_PUBLIC_SITE_URL
+  nuxt.options.runtimeConfig.public.siteUrl = configuredSiteUrl || process.env.NUXT_PUBLIC_SITE_URL || ''
 
   nuxt.options.runtimeConfig.public.auth = defu(nuxt.options.runtimeConfig.public.auth as Record<string, unknown>, {
     redirects: {

--- a/src/runtime/app/composables/useAuthClient.ts
+++ b/src/runtime/app/composables/useAuthClient.ts
@@ -34,7 +34,8 @@ export function useRawAuthClient(): AppAuthClient | null {
 
   const runtimeConfig = useRuntimeConfig()
   const requestURL = useRequestURL()
-  const siteUrl = typeof runtimeConfig.public.siteUrl === 'string' ? runtimeConfig.public.siteUrl : requestURL.origin
+  const configuredSiteUrl = runtimeConfig.public.siteUrl
+  const siteUrl = typeof configuredSiteUrl === 'string' && configuredSiteUrl ? configuredSiteUrl : requestURL.origin
   return getClient(siteUrl)
 }
 

--- a/test/runtime-config.test.ts
+++ b/test/runtime-config.test.ts
@@ -29,6 +29,23 @@ afterEach(() => {
 })
 
 describe('setupRuntimeConfig siteUrl hydration', () => {
+  it('declares public.siteUrl when no value is configured', () => {
+    delete process.env.NUXT_PUBLIC_SITE_URL
+    const nuxt = createNuxtWithRuntimeConfig()
+    const consola = createConsolaMock()
+
+    setupRuntimeConfig({
+      nuxt,
+      options: {},
+      clientOnly: true,
+      databaseProvider: 'none',
+      hasNuxtHub: false,
+      consola,
+    })
+
+    expect(nuxt.options.runtimeConfig.public.siteUrl).toBe('')
+  })
+
   it('hydrates public.siteUrl from NUXT_PUBLIC_SITE_URL when missing', () => {
     process.env.NUXT_PUBLIC_SITE_URL = 'http://localhost:3000'
     const nuxt = createNuxtWithRuntimeConfig()

--- a/test/use-auth-client.test.ts
+++ b/test/use-auth-client.test.ts
@@ -59,4 +59,14 @@ describe('useAuthClient', () => {
     expect(isReactive(client!.signIn.email)).toBe(false)
     await expect(client!.signIn.email({ email: 'user@example.com', password: 'password' })).resolves.toEqual({ ok: true })
   })
+
+  it('falls back to the request origin when runtime siteUrl is empty', async () => {
+    setRuntimeFlags({ client: true, server: false })
+    runtimeConfig.public.siteUrl = ''
+
+    const useAuthClient = await loadUseAuthClient()
+    useAuthClient()
+
+    expect(createAppAuthClient).toHaveBeenLastCalledWith(requestURL.origin)
+  })
 })


### PR DESCRIPTION
## Summary

- always register `runtimeConfig.public.siteUrl` so Nuxt can apply `NUXT_PUBLIC_SITE_URL` after the app is built
- preserve explicit config and build-time environment precedence
- cover the unset build-time case with a focused regression test

## Why

Nuxt runtime environment variables only override keys present in the built runtime config. A generic image built without `NUXT_PUBLIC_SITE_URL` currently omits `public.siteUrl`, so supplying the variable when the server starts has no effect and eventless `serverAuth()` can fail to resolve its base URL.

Registering an empty default keeps the key in the build while retaining the existing precedence rules. This change is intentionally independent from #87 and does not include Nitro 3 compatibility work.

## Testing

- `pnpm exec vitest run test/runtime-config.test.ts test/server-auth-base-url-cache.test.ts` (16 tests)
- `pnpm typecheck`
- `pnpm lint`
- built the `base-url-inference` fixture with `NUXT_PUBLIC_SITE_URL` unset, then started the built Node server with `NUXT_PUBLIC_SITE_URL=https://runtime.example.test`; eventless `serverAuth()` resolved `baseURL` to `https://runtime.example.test`
