### PR TITLE
fix: skip session sync for generic OAuth sign-in

### DIFF
--- a/docs/content/3.guides/2.oauth-providers.md
+++ b/docs/content/3.guides/2.oauth-providers.md
@@ -64,7 +64,7 @@ const signInSocial = useSignIn('social')
 ```
 
 ::tip
-For OAuth flows (`useSignIn('social')`), Better Auth handles the browser redirect to the provider.
+For OAuth flows (`useSignIn('social')` and generic OAuth via `useSignIn('oauth2')`), Better Auth handles the browser redirect to the provider.
 No manual `fetchSession`/`waitForSession` step is needed before that redirect.
 `callbackURL` is optional. When your app configures `auth.redirects.authenticated` (or has a safe `?redirect=` query), the module can use that as the fallback callback URL.
 ::
@@ -90,3 +90,16 @@ Better Auth supports 20+ providers (Apple, Discord, Facebook, etc). The pattern 
 4. Call `useSignIn('social').execute({ provider: 'providerId' })`
 
 :read-more{to="https://www.better-auth.com/docs/authentication/other-social-providers" title="Full provider list"}
+
+## Generic OAuth
+
+Providers that are not in Better Auth's built-in `socialProviders` list (for example Seznam, Instagram, or Auth0) use the [`genericOAuth`](https://www.better-auth.com/docs/plugins/generic-oauth) plugin plus `genericOAuthClient`.
+
+That flow is `signIn.oauth2` (`POST /sign-in/oauth2`), not `signIn.social`:
+
+```ts
+const signInOAuth2 = useSignIn('oauth2')
+await signInOAuth2.execute({ providerId: 'seznam', callbackURL: '/app' })
+```
+
+Redirect session-sync is skipped the same way as `useSignIn('social')`: the first request only returns `{ url, redirect: true }`, and the session is created after the provider callback. Pass `disableRedirect: true` when you handle the redirect yourself (popup or manual navigation); that path still syncs the session.

--- a/docs/content/3.guides/2.oauth-providers.md
+++ b/docs/content/3.guides/2.oauth-providers.md
@@ -64,7 +64,7 @@ const signInSocial = useSignIn('social')
 ```
 
 ::tip
-For OAuth flows (`useSignIn('social')` and generic OAuth via `useSignIn('oauth2')`), Better Auth handles the browser redirect to the provider.
+For redirect OAuth methods exposed by your Better Auth client, including `useSignIn('social')` and `useSignIn('oauth2')`, Better Auth handles the browser redirect to the provider.
 No manual `fetchSession`/`waitForSession` step is needed before that redirect.
 `callbackURL` is optional. When your app configures `auth.redirects.authenticated` (or has a safe `?redirect=` query), the module can use that as the fallback callback URL.
 ::
@@ -93,9 +93,7 @@ Better Auth supports 20+ providers (Apple, Discord, Facebook, etc). The pattern 
 
 ## Generic OAuth
 
-Providers that are not in Better Auth's built-in `socialProviders` list (for example Seznam, Instagram, or Auth0) use the [`genericOAuth`](https://www.better-auth.com/docs/plugins/generic-oauth) plugin plus `genericOAuthClient`.
-
-That flow is `signIn.oauth2` (`POST /sign-in/oauth2`), not `signIn.social`:
+When your configured Better Auth client exposes the [`genericOAuth`](https://www.better-auth.com/docs/plugins/generic-oauth) flow through `signIn.oauth2`, use the matching keyed composable:
 
 ```ts
 const signInOAuth2 = useSignIn('oauth2')

--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -295,13 +295,16 @@ export function useAuthActionNamespaces() {
         const method = targetRecord[prop]
         if (typeof method !== 'function')
           return method
-        const shouldSkipSessionSync = prop === 'social'
+        const isRedirectOAuthSignIn = prop === 'social' || prop === 'oauth2'
+        const shouldSkipSessionSync = isRedirectOAuthSignIn
           ? (data: unknown) => {
-              const socialData = isRecord(data) ? data : undefined
-              return socialData?.disableRedirect !== true
+              const oauthData = isRecord(data) ? data : undefined
+              return oauthData?.disableRedirect !== true
             }
           : undefined
-        const transformData = prop === 'social' ? (data: unknown) => withFallbackSocialCallbackURL(data, requestURL) : undefined
+        const transformData = isRedirectOAuthSignIn
+          ? (data: unknown) => withFallbackSocialCallbackURL(data, requestURL)
+          : undefined
         return wrapAuthMethod(
           (...args: unknown[]) => (targetRecord[prop] as (...a: unknown[]) => Promise<unknown>)(...args),
           wrapDeps,

--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -296,19 +296,15 @@ export function useAuthActionNamespaces() {
         if (typeof method !== 'function')
           return method
         const isRedirectOAuthSignIn = prop === 'social' || prop === 'oauth2'
-        const shouldSkipSessionSync = isRedirectOAuthSignIn
-          ? (data: unknown) => {
-              const oauthData = isRecord(data) ? data : undefined
-              return oauthData?.disableRedirect !== true
-            }
-          : undefined
-        const transformData = isRedirectOAuthSignIn
-          ? (data: unknown) => withFallbackSocialCallbackURL(data, requestURL)
-          : undefined
         return wrapAuthMethod(
           (...args: unknown[]) => (targetRecord[prop] as (...a: unknown[]) => Promise<unknown>)(...args),
           wrapDeps,
-          { shouldSkipSessionSync, transformData },
+          isRedirectOAuthSignIn
+            ? {
+                shouldSkipSessionSync: (data: unknown) => !isRecord(data) || data.disableRedirect !== true,
+                transformData: (data: unknown) => withFallbackSocialCallbackURL(data, requestURL),
+              }
+            : {},
         )
       })
     : _signInServerOnly as SignIn

--- a/test/use-signin.test.ts
+++ b/test/use-signin.test.ts
@@ -207,20 +207,6 @@ describe('useSignIn', () => {
     expect(signInSocial.status.value).toBe('success')
   })
 
-  it('supports keyed generic OAuth sign-in handle', async () => {
-    sessionMock = {
-      signIn: {
-        oauth2: vi.fn(async () => ({ ok: true })),
-      },
-    }
-
-    const useSignIn = await loadUseSignIn()
-    const signInOAuth2 = useSignIn('oauth2' as any)
-
-    await signInOAuth2.execute({ providerId: 'seznam', callbackURL: '/app' } as any)
-    expect(signInOAuth2.status.value).toBe('success')
-  })
-
   it('keeps pending for redirect responses until fallback timeout', async () => {
     vi.useFakeTimers()
     sessionMock = {
@@ -240,28 +226,6 @@ describe('useSignIn', () => {
 
     vi.advanceTimersByTime(10_000)
     expect(signInSocial.status.value).toBe('success')
-    vi.useRealTimers()
-  })
-
-  it('keeps pending for generic OAuth redirect responses until fallback timeout', async () => {
-    vi.useFakeTimers()
-    sessionMock = {
-      signIn: {
-        oauth2: vi.fn(async () => ({
-          url: 'https://login.szn.cz/oauth/authorize',
-          redirect: true,
-        })),
-      },
-    }
-
-    const useSignIn = await loadUseSignIn()
-    const signInOAuth2 = useSignIn('oauth2' as any)
-
-    await signInOAuth2.execute({ providerId: 'seznam' } as any)
-    expect(signInOAuth2.status.value).toBe('pending')
-
-    vi.advanceTimersByTime(10_000)
-    expect(signInOAuth2.status.value).toBe('success')
     vi.useRealTimers()
   })
 
@@ -287,31 +251,6 @@ describe('useSignIn', () => {
 
     vi.advanceTimersByTime(10_000)
     expect(signInSocial.status.value).toBe('success')
-    vi.useRealTimers()
-  })
-
-  it('keeps pending for nested generic OAuth redirect responses until fallback timeout', async () => {
-    vi.useFakeTimers()
-    sessionMock = {
-      signIn: {
-        oauth2: vi.fn(async () => ({
-          data: {
-            url: 'https://login.szn.cz/oauth/authorize',
-            redirect: true,
-          },
-          error: null,
-        })),
-      },
-    }
-
-    const useSignIn = await loadUseSignIn()
-    const signInOAuth2 = useSignIn('oauth2' as any)
-
-    await signInOAuth2.execute({ providerId: 'seznam' } as any)
-    expect(signInOAuth2.status.value).toBe('pending')
-
-    vi.advanceTimersByTime(10_000)
-    expect(signInOAuth2.status.value).toBe('success')
     vi.useRealTimers()
   })
 

--- a/test/use-signin.test.ts
+++ b/test/use-signin.test.ts
@@ -207,6 +207,20 @@ describe('useSignIn', () => {
     expect(signInSocial.status.value).toBe('success')
   })
 
+  it('supports keyed generic OAuth sign-in handle', async () => {
+    sessionMock = {
+      signIn: {
+        oauth2: vi.fn(async () => ({ ok: true })),
+      },
+    }
+
+    const useSignIn = await loadUseSignIn()
+    const signInOAuth2 = useSignIn('oauth2' as any)
+
+    await signInOAuth2.execute({ providerId: 'seznam', callbackURL: '/app' } as any)
+    expect(signInOAuth2.status.value).toBe('success')
+  })
+
   it('keeps pending for redirect responses until fallback timeout', async () => {
     vi.useFakeTimers()
     sessionMock = {
@@ -226,6 +240,28 @@ describe('useSignIn', () => {
 
     vi.advanceTimersByTime(10_000)
     expect(signInSocial.status.value).toBe('success')
+    vi.useRealTimers()
+  })
+
+  it('keeps pending for generic OAuth redirect responses until fallback timeout', async () => {
+    vi.useFakeTimers()
+    sessionMock = {
+      signIn: {
+        oauth2: vi.fn(async () => ({
+          url: 'https://login.szn.cz/oauth/authorize',
+          redirect: true,
+        })),
+      },
+    }
+
+    const useSignIn = await loadUseSignIn()
+    const signInOAuth2 = useSignIn('oauth2' as any)
+
+    await signInOAuth2.execute({ providerId: 'seznam' } as any)
+    expect(signInOAuth2.status.value).toBe('pending')
+
+    vi.advanceTimersByTime(10_000)
+    expect(signInOAuth2.status.value).toBe('success')
     vi.useRealTimers()
   })
 
@@ -251,6 +287,31 @@ describe('useSignIn', () => {
 
     vi.advanceTimersByTime(10_000)
     expect(signInSocial.status.value).toBe('success')
+    vi.useRealTimers()
+  })
+
+  it('keeps pending for nested generic OAuth redirect responses until fallback timeout', async () => {
+    vi.useFakeTimers()
+    sessionMock = {
+      signIn: {
+        oauth2: vi.fn(async () => ({
+          data: {
+            url: 'https://login.szn.cz/oauth/authorize',
+            redirect: true,
+          },
+          error: null,
+        })),
+      },
+    }
+
+    const useSignIn = await loadUseSignIn()
+    const signInOAuth2 = useSignIn('oauth2' as any)
+
+    await signInOAuth2.execute({ providerId: 'seznam' } as any)
+    expect(signInOAuth2.status.value).toBe('pending')
+
+    vi.advanceTimersByTime(10_000)
+    expect(signInOAuth2.status.value).toBe('success')
     vi.useRealTimers()
   })
 

--- a/test/use-user-session.test.ts
+++ b/test/use-user-session.test.ts
@@ -625,16 +625,28 @@ describe('useUserSession hydration bootstrap', () => {
     expect(navigateTo).not.toHaveBeenCalled()
   })
 
-  it('signIn.social injects callbackURL from auth.redirects.authenticated when missing', async () => {
+  it.each([
+    { method: 'social', data: { provider: 'github' }, providerURL: 'https://github.com/login/oauth/authorize' },
+    { method: 'oauth2', data: { providerId: 'seznam' }, providerURL: 'https://login.szn.cz/oauth/authorize' },
+  ])('signIn.$method injects callbackURL and skips session sync', async ({ method, data, providerURL }) => {
     runtimeConfig.public.auth.redirects = { authenticated: '/app' }
-    mockClient.signIn.social.mockResolvedValueOnce({ url: 'https://github.com/login/oauth/authorize', redirect: true })
+    mockClient.getSession.mockResolvedValueOnce({
+      data: {
+        session: { id: 'session-1', ipAddress: '127.0.0.1' },
+        user: { id: 'user-1', email: 'user@example.com' },
+      },
+    })
+    mockClient.signIn[method].mockImplementationOnce(async (_data, opts) => {
+      await opts?.onSuccess?.('ctx')
+      return { url: providerURL, redirect: true }
+    })
 
     const { useAuthActionNamespaces } = await loadAuthComposables()
     const auth = useAuthActionNamespaces()
 
-    await auth.signIn.social({ provider: 'github' } as never)
+    await (auth.signIn as unknown as Record<string, (...args: unknown[]) => Promise<unknown>>)[method](data)
 
-    expect(mockClient.signIn.social).toHaveBeenCalledWith({ provider: 'github', callbackURL: '/app' }, undefined)
+    expect(mockClient.signIn[method]).toHaveBeenCalledWith({ ...data, callbackURL: '/app' }, undefined)
     expect(mockClient.getSession).not.toHaveBeenCalled()
     expect(navigateTo).not.toHaveBeenCalled()
   })
@@ -693,7 +705,10 @@ describe('useUserSession hydration bootstrap', () => {
     expect(mockClient.getSession).not.toHaveBeenCalled()
   })
 
-  it('signIn.social with disableRedirect wraps explicit onSuccess with session sync', async () => {
+  it.each([
+    { method: 'social', data: { provider: 'github', disableRedirect: true } },
+    { method: 'oauth2', data: { providerId: 'seznam', disableRedirect: true } },
+  ])('signIn.$method with disableRedirect syncs session before onSuccess', async ({ method, data }) => {
     let sessionAuth!: ReturnType<Awaited<ReturnType<typeof loadUseUserSession>>>
     let sessionAtCallback: unknown
     const onSuccess = vi.fn(() => {
@@ -705,7 +720,7 @@ describe('useUserSession hydration bootstrap', () => {
         user: { id: 'user-1', email: 'user@example.com' },
       },
     })
-    mockClient.signIn.social.mockImplementation(async (_data, opts) => {
+    mockClient.signIn[method].mockImplementation(async (_data, opts) => {
       await opts?.onSuccess?.('ctx')
     })
 
@@ -713,7 +728,7 @@ describe('useUserSession hydration bootstrap', () => {
     sessionAuth = useUserSession()
     const auth = useAuthActionNamespaces()
 
-    await auth.signIn.social({ provider: 'github', disableRedirect: true } as never, { onSuccess } as never)
+    await (auth.signIn as unknown as Record<string, (...args: unknown[]) => Promise<unknown>>)[method](data, { onSuccess })
 
     expect(onSuccess).toHaveBeenCalledOnce()
     expect(sessionAtCallback).toEqual({ id: 'session-1', ipAddress: '127.0.0.1' })
@@ -738,135 +753,6 @@ describe('useUserSession hydration bootstrap', () => {
 
     expect(mockClient.getSession).toHaveBeenCalledOnce()
     expect(navigateTo).toHaveBeenCalledWith('/app')
-  })
-
-  it('signIn.oauth2 injects callbackURL from auth.redirects.authenticated when missing', async () => {
-    runtimeConfig.public.auth.redirects = { authenticated: '/app' }
-    mockClient.signIn.oauth2.mockResolvedValueOnce({ url: 'https://login.szn.cz/oauth/authorize', redirect: true })
-
-    const { useAuthActionNamespaces } = await loadAuthComposables()
-    const auth = useAuthActionNamespaces()
-
-    await auth.signIn.oauth2({ providerId: 'seznam' } as never)
-
-    expect(mockClient.signIn.oauth2).toHaveBeenCalledWith({ providerId: 'seznam', callbackURL: '/app' }, undefined)
-    expect(mockClient.getSession).not.toHaveBeenCalled()
-    expect(navigateTo).not.toHaveBeenCalled()
-  })
-
-  it('signIn.oauth2 injects callbackURL from safe redirect query first', async () => {
-    runtimeConfig.public.auth.redirects = { authenticated: '/app' }
-    requestURL.searchParams = new URLSearchParams({ redirect: '/app/billing' })
-    mockClient.signIn.oauth2.mockResolvedValueOnce({ url: 'https://login.szn.cz/oauth/authorize', redirect: true })
-
-    const { useAuthActionNamespaces } = await loadAuthComposables()
-    const auth = useAuthActionNamespaces()
-
-    await auth.signIn.oauth2({ providerId: 'seznam' } as never)
-
-    expect(mockClient.signIn.oauth2).toHaveBeenCalledWith({ providerId: 'seznam', callbackURL: '/app/billing' }, undefined)
-  })
-
-  it('signIn.oauth2 does not override explicit callbackURL', async () => {
-    runtimeConfig.public.auth.redirects = { authenticated: '/app' }
-    requestURL.searchParams = new URLSearchParams({ redirect: '/app/billing' })
-    mockClient.signIn.oauth2.mockResolvedValueOnce({ url: 'https://login.szn.cz/oauth/authorize', redirect: true })
-
-    const { useAuthActionNamespaces } = await loadAuthComposables()
-    const auth = useAuthActionNamespaces()
-
-    await auth.signIn.oauth2({ providerId: 'seznam', callbackURL: '/custom' } as never)
-
-    expect(mockClient.signIn.oauth2).toHaveBeenCalledWith({ providerId: 'seznam', callbackURL: '/custom' }, undefined)
-  })
-
-  it('signIn.oauth2 preserves explicit onSuccess without wrapping session sync', async () => {
-    const onSuccess = vi.fn()
-    mockClient.signIn.oauth2.mockImplementation(async (_data, opts) => {
-      await opts?.onSuccess?.('ctx')
-    })
-
-    const { useAuthActionNamespaces } = await loadAuthComposables()
-    const auth = useAuthActionNamespaces()
-
-    await auth.signIn.oauth2({ providerId: 'seznam' } as never, { onSuccess } as never)
-
-    expect(onSuccess).toHaveBeenCalledOnce()
-    expect(mockClient.getSession).not.toHaveBeenCalled()
-  })
-
-  it('signIn.oauth2 with disableRedirect wraps explicit onSuccess with session sync', async () => {
-    let sessionAuth!: ReturnType<Awaited<ReturnType<typeof loadUseUserSession>>>
-    let sessionAtCallback: unknown
-    const onSuccess = vi.fn(() => {
-      sessionAtCallback = sessionAuth.session.value
-    })
-    mockClient.getSession.mockResolvedValueOnce({
-      data: {
-        session: { id: 'session-1', ipAddress: '127.0.0.1' },
-        user: { id: 'user-1', email: 'user@example.com' },
-      },
-    })
-    mockClient.signIn.oauth2.mockImplementation(async (_data, opts) => {
-      await opts?.onSuccess?.('ctx')
-    })
-
-    const { useAuthActionNamespaces, useUserSession } = await loadAuthComposables()
-    sessionAuth = useUserSession()
-    const auth = useAuthActionNamespaces()
-
-    await auth.signIn.oauth2({ providerId: 'seznam', disableRedirect: true } as never, { onSuccess } as never)
-
-    expect(onSuccess).toHaveBeenCalledOnce()
-    expect(sessionAtCallback).toEqual({ id: 'session-1', ipAddress: '127.0.0.1' })
-  })
-
-  it('signIn.oauth2 with disableRedirect uses fallback redirect when callback is missing', async () => {
-    runtimeConfig.public.auth.redirects = { authenticated: '/app' }
-    mockClient.getSession.mockResolvedValueOnce({
-      data: {
-        session: { id: 'session-1', ipAddress: '127.0.0.1' },
-        user: { id: 'user-1', email: 'user@example.com' },
-      },
-    })
-    mockClient.signIn.oauth2.mockImplementation(async (_data, opts) => {
-      await opts?.onSuccess?.('ctx')
-    })
-
-    const { useAuthActionNamespaces } = await loadAuthComposables()
-    const auth = useAuthActionNamespaces()
-
-    await auth.signIn.oauth2({ providerId: 'seznam', disableRedirect: true } as never)
-
-    expect(mockClient.getSession).toHaveBeenCalledOnce()
-    expect(navigateTo).toHaveBeenCalledWith('/app')
-  })
-
-  it('signIn.email still syncs session after a successful call', async () => {
-    let sessionAuth!: ReturnType<Awaited<ReturnType<typeof loadUseUserSession>>>
-    let sessionAtCallback: unknown
-    const onSuccess = vi.fn(() => {
-      sessionAtCallback = sessionAuth.session.value
-    })
-    mockClient.getSession.mockResolvedValueOnce({
-      data: {
-        session: { id: 'session-1', ipAddress: '127.0.0.1' },
-        user: { id: 'user-1', email: 'user@example.com' },
-      },
-    })
-    mockClient.signIn.email.mockImplementation(async (_data, opts) => {
-      await opts?.onSuccess?.('ctx')
-    })
-
-    const { useAuthActionNamespaces, useUserSession } = await loadAuthComposables()
-    sessionAuth = useUserSession()
-    const auth = useAuthActionNamespaces()
-
-    await auth.signIn.email({ email: 'user@example.com', password: 'password' }, { onSuccess } as never)
-
-    expect(onSuccess).toHaveBeenCalledOnce()
-    expect(mockClient.getSession).toHaveBeenCalledOnce()
-    expect(sessionAtCallback).toEqual({ id: 'session-1', ipAddress: '127.0.0.1' })
   })
 
   it('signUp does not auto-navigate to authenticated redirect when session is unresolved', async () => {

--- a/test/use-user-session.test.ts
+++ b/test/use-user-session.test.ts
@@ -644,7 +644,12 @@ describe('useUserSession hydration bootstrap', () => {
     const { useAuthActionNamespaces } = await loadAuthComposables()
     const auth = useAuthActionNamespaces()
 
-    await (auth.signIn as unknown as Record<string, (...args: unknown[]) => Promise<unknown>>)[method](data)
+    if (method === 'social') {
+      await auth.signIn.social(data)
+    }
+    else {
+      await auth.signIn.oauth2(data)
+    }
 
     expect(mockClient.signIn[method]).toHaveBeenCalledWith({ ...data, callbackURL: '/app' }, undefined)
     expect(mockClient.getSession).not.toHaveBeenCalled()
@@ -728,7 +733,12 @@ describe('useUserSession hydration bootstrap', () => {
     sessionAuth = useUserSession()
     const auth = useAuthActionNamespaces()
 
-    await (auth.signIn as unknown as Record<string, (...args: unknown[]) => Promise<unknown>>)[method](data, { onSuccess })
+    if (method === 'social') {
+      await auth.signIn.social(data, { onSuccess })
+    }
+    else {
+      await auth.signIn.oauth2(data, { onSuccess })
+    }
 
     expect(onSuccess).toHaveBeenCalledOnce()
     expect(sessionAtCallback).toEqual({ id: 'session-1', ipAddress: '127.0.0.1' })

--- a/test/use-user-session.test.ts
+++ b/test/use-user-session.test.ts
@@ -60,7 +60,7 @@ const mockClient: Record<string, any> = {
     listen: vi.fn(),
   },
   signOut: vi.fn(async () => {}),
-  signIn: { social: vi.fn(async () => ({})), email: vi.fn(async () => ({})) },
+  signIn: { social: vi.fn(async () => ({})), oauth2: vi.fn(async () => ({})), email: vi.fn(async () => ({})) },
   signUp: { email: vi.fn(async () => ({})) },
 }
 let activeClient: Record<string, any> = mockClient
@@ -175,6 +175,8 @@ describe('useUserSession hydration bootstrap', () => {
     mockClient.updateUser = undefined
     mockClient.signIn.social.mockReset()
     mockClient.signIn.social.mockResolvedValue({})
+    mockClient.signIn.oauth2.mockReset()
+    mockClient.signIn.oauth2.mockResolvedValue({})
     mockClient.signIn.email.mockReset()
     mockClient.signIn.email.mockResolvedValue({})
     mockClient.signUp.email.mockReset()
@@ -736,6 +738,135 @@ describe('useUserSession hydration bootstrap', () => {
 
     expect(mockClient.getSession).toHaveBeenCalledOnce()
     expect(navigateTo).toHaveBeenCalledWith('/app')
+  })
+
+  it('signIn.oauth2 injects callbackURL from auth.redirects.authenticated when missing', async () => {
+    runtimeConfig.public.auth.redirects = { authenticated: '/app' }
+    mockClient.signIn.oauth2.mockResolvedValueOnce({ url: 'https://login.szn.cz/oauth/authorize', redirect: true })
+
+    const { useAuthActionNamespaces } = await loadAuthComposables()
+    const auth = useAuthActionNamespaces()
+
+    await auth.signIn.oauth2({ providerId: 'seznam' } as never)
+
+    expect(mockClient.signIn.oauth2).toHaveBeenCalledWith({ providerId: 'seznam', callbackURL: '/app' }, undefined)
+    expect(mockClient.getSession).not.toHaveBeenCalled()
+    expect(navigateTo).not.toHaveBeenCalled()
+  })
+
+  it('signIn.oauth2 injects callbackURL from safe redirect query first', async () => {
+    runtimeConfig.public.auth.redirects = { authenticated: '/app' }
+    requestURL.searchParams = new URLSearchParams({ redirect: '/app/billing' })
+    mockClient.signIn.oauth2.mockResolvedValueOnce({ url: 'https://login.szn.cz/oauth/authorize', redirect: true })
+
+    const { useAuthActionNamespaces } = await loadAuthComposables()
+    const auth = useAuthActionNamespaces()
+
+    await auth.signIn.oauth2({ providerId: 'seznam' } as never)
+
+    expect(mockClient.signIn.oauth2).toHaveBeenCalledWith({ providerId: 'seznam', callbackURL: '/app/billing' }, undefined)
+  })
+
+  it('signIn.oauth2 does not override explicit callbackURL', async () => {
+    runtimeConfig.public.auth.redirects = { authenticated: '/app' }
+    requestURL.searchParams = new URLSearchParams({ redirect: '/app/billing' })
+    mockClient.signIn.oauth2.mockResolvedValueOnce({ url: 'https://login.szn.cz/oauth/authorize', redirect: true })
+
+    const { useAuthActionNamespaces } = await loadAuthComposables()
+    const auth = useAuthActionNamespaces()
+
+    await auth.signIn.oauth2({ providerId: 'seznam', callbackURL: '/custom' } as never)
+
+    expect(mockClient.signIn.oauth2).toHaveBeenCalledWith({ providerId: 'seznam', callbackURL: '/custom' }, undefined)
+  })
+
+  it('signIn.oauth2 preserves explicit onSuccess without wrapping session sync', async () => {
+    const onSuccess = vi.fn()
+    mockClient.signIn.oauth2.mockImplementation(async (_data, opts) => {
+      await opts?.onSuccess?.('ctx')
+    })
+
+    const { useAuthActionNamespaces } = await loadAuthComposables()
+    const auth = useAuthActionNamespaces()
+
+    await auth.signIn.oauth2({ providerId: 'seznam' } as never, { onSuccess } as never)
+
+    expect(onSuccess).toHaveBeenCalledOnce()
+    expect(mockClient.getSession).not.toHaveBeenCalled()
+  })
+
+  it('signIn.oauth2 with disableRedirect wraps explicit onSuccess with session sync', async () => {
+    let sessionAuth!: ReturnType<Awaited<ReturnType<typeof loadUseUserSession>>>
+    let sessionAtCallback: unknown
+    const onSuccess = vi.fn(() => {
+      sessionAtCallback = sessionAuth.session.value
+    })
+    mockClient.getSession.mockResolvedValueOnce({
+      data: {
+        session: { id: 'session-1', ipAddress: '127.0.0.1' },
+        user: { id: 'user-1', email: 'user@example.com' },
+      },
+    })
+    mockClient.signIn.oauth2.mockImplementation(async (_data, opts) => {
+      await opts?.onSuccess?.('ctx')
+    })
+
+    const { useAuthActionNamespaces, useUserSession } = await loadAuthComposables()
+    sessionAuth = useUserSession()
+    const auth = useAuthActionNamespaces()
+
+    await auth.signIn.oauth2({ providerId: 'seznam', disableRedirect: true } as never, { onSuccess } as never)
+
+    expect(onSuccess).toHaveBeenCalledOnce()
+    expect(sessionAtCallback).toEqual({ id: 'session-1', ipAddress: '127.0.0.1' })
+  })
+
+  it('signIn.oauth2 with disableRedirect uses fallback redirect when callback is missing', async () => {
+    runtimeConfig.public.auth.redirects = { authenticated: '/app' }
+    mockClient.getSession.mockResolvedValueOnce({
+      data: {
+        session: { id: 'session-1', ipAddress: '127.0.0.1' },
+        user: { id: 'user-1', email: 'user@example.com' },
+      },
+    })
+    mockClient.signIn.oauth2.mockImplementation(async (_data, opts) => {
+      await opts?.onSuccess?.('ctx')
+    })
+
+    const { useAuthActionNamespaces } = await loadAuthComposables()
+    const auth = useAuthActionNamespaces()
+
+    await auth.signIn.oauth2({ providerId: 'seznam', disableRedirect: true } as never)
+
+    expect(mockClient.getSession).toHaveBeenCalledOnce()
+    expect(navigateTo).toHaveBeenCalledWith('/app')
+  })
+
+  it('signIn.email still syncs session after a successful call', async () => {
+    let sessionAuth!: ReturnType<Awaited<ReturnType<typeof loadUseUserSession>>>
+    let sessionAtCallback: unknown
+    const onSuccess = vi.fn(() => {
+      sessionAtCallback = sessionAuth.session.value
+    })
+    mockClient.getSession.mockResolvedValueOnce({
+      data: {
+        session: { id: 'session-1', ipAddress: '127.0.0.1' },
+        user: { id: 'user-1', email: 'user@example.com' },
+      },
+    })
+    mockClient.signIn.email.mockImplementation(async (_data, opts) => {
+      await opts?.onSuccess?.('ctx')
+    })
+
+    const { useAuthActionNamespaces, useUserSession } = await loadAuthComposables()
+    sessionAuth = useUserSession()
+    const auth = useAuthActionNamespaces()
+
+    await auth.signIn.email({ email: 'user@example.com', password: 'password' }, { onSuccess } as never)
+
+    expect(onSuccess).toHaveBeenCalledOnce()
+    expect(mockClient.getSession).toHaveBeenCalledOnce()
+    expect(sessionAtCallback).toEqual({ id: 'session-1', ipAddress: '127.0.0.1' })
   })
 
   it('signUp does not auto-navigate to authenticated redirect when session is unresolved', async () => {


### PR DESCRIPTION
## Summary
- Treat `signIn.oauth2` like `signIn.social`: skip `fetchSession` / `waitForSession` on the default redirect path (`disableRedirect` is not `true`), so `useSignIn('oauth2').execute()` does not hang for ~5s before the provider redirect.
- Keep session sync for `disableRedirect: true` (popup / manual redirect) and for email/password and other non-redirect methods.
- Reuse the social `callbackURL` fallback for generic OAuth, and document `useSignIn('oauth2')` in the OAuth providers guide.

Account linking (`oauth2.link` / `POST /oauth2/link`) goes through the unwrapped `useAuthClient()` / `useAuthClientAction()` path, so it was left unchanged.

## Test plan
- [x] `pnpm exec vitest run test/use-signin.test.ts test/use-user-session.test.ts test/wrap-auth-method.test.ts` (79 passed)
- [ ] `useSignIn('oauth2').execute({ providerId })` redirects immediately and does not wait for a session
- [ ] `{ url, redirect: true }` keeps action status `pending` (same as social)
- [ ] `{ disableRedirect: true }` still syncs session
- [ ] `useSignIn('email')` still syncs session after success
