### PR TITLE
fix: support versioned auth secrets

### DIFF
--- a/docs/content/1.getting-started/0.index.md
+++ b/docs/content/1.getting-started/0.index.md
@@ -20,7 +20,7 @@ After this guide you should have:
 
 - `server/auth.config.ts` and `app/auth.config.ts`
 - Better Auth handlers mounted at `/api/auth/*`
-- a valid `NUXT_BETTER_AUTH_SECRET`
+- a valid auth secret configuration
 - a reactive `useUserSession()` composable in your app
 
 ## Before you begin
@@ -47,7 +47,7 @@ Create or update `.env`:
 NUXT_BETTER_AUTH_SECRET="replace-with-a-random-32-character-secret"
 ```
 
-Use a high-entropy value. The module also accepts `BETTER_AUTH_SECRET` as a fallback, but `NUXT_BETTER_AUTH_SECRET` is the recommended variable.
+Use a high-entropy value. The module also accepts `BETTER_AUTH_SECRET` as a fallback, or Better Auth's versioned `BETTER_AUTH_SECRETS`/`secrets` configuration for rotation. `NUXT_BETTER_AUTH_SECRET` remains the recommended default.
 
 ### Create the server config
 

--- a/docs/content/1.getting-started/0.index.md
+++ b/docs/content/1.getting-started/0.index.md
@@ -20,7 +20,7 @@ After this guide you should have:
 
 - `server/auth.config.ts` and `app/auth.config.ts`
 - Better Auth handlers mounted at `/api/auth/*`
-- a valid auth secret configuration
+- a valid `NUXT_BETTER_AUTH_SECRET`
 - a reactive `useUserSession()` composable in your app
 
 ## Before you begin

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -11,7 +11,7 @@ Install @onmax/nuxt-better-auth in my Nuxt 4 app.
 
 - Read the raw installation documentation first: https://better-auth.nuxt.dev/raw/getting-started/installation.md
 - Run `npx nuxi module add @onmax/nuxt-better-auth`
-- Set `BETTER_AUTH_SECRET` in `.env` (at least 32 chars, high entropy). Optionally prefix with `NUXT_` for runtime config
+- Set `NUXT_BETTER_AUTH_SECRET` or `BETTER_AUTH_SECRETS` in `.env` (at least 32 chars per current secret, high entropy)
 - Optionally set `NUXT_PUBLIC_SITE_URL` for non-auto-detected platforms
 - Create `server/auth.config.ts` using `defineServerAuth` from `@onmax/nuxt-better-auth/config`
 - Create `app/auth.config.ts` using `defineClientAuth` from `@onmax/nuxt-better-auth/config`
@@ -42,7 +42,7 @@ npx nuxi module add @onmax/nuxt-better-auth
 ### Set environment variables
 
 ::tip{icon="i-lucide-sparkles"}
-When you install the module with `nuxi module add`, it prompts you to generate `NUXT_BETTER_AUTH_SECRET` and can append it to your `.env`. `BETTER_AUTH_SECRET` still works as a compatibility fallback. In CI/test environments it auto-generates the secret.
+When you install the module with `nuxi module add`, it prompts you to generate `NUXT_BETTER_AUTH_SECRET` and can append it to your `.env`. The prompt is skipped when `NUXT_BETTER_AUTH_SECRET`, `BETTER_AUTH_SECRET`, or `BETTER_AUTH_SECRETS` is already configured. In CI/test environments it auto-generates the singular secret.
 ::
 
 Add these environment variables to `.env`:
@@ -67,6 +67,12 @@ openssl rand -base64 32
 ::tip
 Use `NUXT_BETTER_AUTH_SECRET` for Nuxt runtime config and multi-environment deployments. `BETTER_AUTH_SECRET` remains supported as a fallback.
 ::
+
+For non-destructive rotation, use Better Auth's versioned environment variable instead:
+
+```txt [.env]
+BETTER_AUTH_SECRETS=2:current-secret-must-be-at-least-32-characters,1:previous-secret-must-be-at-least-32-characters
+```
 
 2. **Base URL** (Optional)
 
@@ -112,7 +118,7 @@ Confirm all of the following:
 - Nuxt starts without missing-config errors
 - `server/auth.config.ts` exists
 - `app/auth.config.ts` or your `srcDir` equivalent exists
-- `NUXT_BETTER_AUTH_SECRET` is available at runtime
+- a singular or versioned auth secret is available at runtime
 
 ## Next steps
 

--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -186,8 +186,9 @@ export default defineServerAuth((ctx) => ({
 ```
 
 ::note
-The module automatically injects `secret` and `baseURL`. You don't need to configure these in `defineServerAuth`.
+The module automatically injects the singular `secret` and `baseURL`. Use Better Auth's `secrets` option only when you need versioned rotation.
 - **Secret**: Priority: `nuxt.config.ts` runtimeConfig > `NUXT_BETTER_AUTH_SECRET` > `BETTER_AUTH_SECRET`
+- **Versioned secrets**: Set `secrets` in `defineServerAuth` or use `BETTER_AUTH_SECRETS`. When present, the singular secret is a legacy decryption fallback.
 - **Base URL**: The module auto-detects the base URL on Vercel/Cloudflare/Netlify. For other platforms, set `NUXT_PUBLIC_SITE_URL`
 ::
 
@@ -278,6 +279,8 @@ NUXT_PUBLIC_SITE_URL="https://your-domain.com" # Optional on Vercel/Cloudflare/N
 ::tip
 Use `NUXT_BETTER_AUTH_SECRET` as the primary secret variable. `BETTER_AUTH_SECRET` remains supported as a fallback for existing setups.
 ::
+
+For non-destructive rotation, use `BETTER_AUTH_SECRETS=2:current-secret-must-be-at-least-32-characters,1:previous-secret-must-be-at-least-32-characters` or configure `secrets` in `defineServerAuth`.
 
 ## For Module Authors
 

--- a/docs/content/3.guides/4.database-less-mode.md
+++ b/docs/content/3.guides/4.database-less-mode.md
@@ -14,7 +14,7 @@ See the official **Better Auth documentation** for database-less setup.
 Database-less mode uses **JWE (JSON Web Encryption)** sessions. Instead of storing sessions in a database, the session data is encrypted and stored entirely in the cookie.
 
 **How it works:**
-- Session data is encrypted with your `NUXT_BETTER_AUTH_SECRET` (`BETTER_AUTH_SECRET` is also supported as a fallback)
+- Session data is encrypted with your singular secret or the current key in `BETTER_AUTH_SECRETS`/`secrets`
 - The encrypted token is stored in a cookie
 - On each request, the server decrypts the cookie to get session data
 - No database queries needed for session validation

--- a/docs/content/3.guides/5.external-auth-backend.md
+++ b/docs/content/3.guides/5.external-auth-backend.md
@@ -57,7 +57,7 @@ export default defineNuxtConfig({
 |---------|-----------|-------------|
 | `server/auth.config.ts` | Required | Not needed |
 | `/api/auth/**` handlers | Auto-registered | Skipped |
-| `NUXT_BETTER_AUTH_SECRET` | Required | Not needed |
+| Auth secret configuration | Required | Not needed |
 | Server middleware | Enabled | Skipped |
 | Schema generation | Enabled | Skipped |
 | Devtools | Enabled | Skipped |

--- a/docs/content/3.guides/6.migrate-from-nuxt-auth-utils.md
+++ b/docs/content/3.guides/6.migrate-from-nuxt-auth-utils.md
@@ -307,7 +307,7 @@ See **Schema Generation** to set up database tables.
 ## Troubleshooting
 
 ### Sessions not persisting
-Ensure `NUXT_BETTER_AUTH_SECRET` is set and database is configured.
+Ensure a singular or versioned auth secret is configured and the database is available.
 
 ### OAuth redirect errors
 Auto-detected on Vercel/Cloudflare/Netlify. For other platforms, set `NUXT_PUBLIC_SITE_URL`.

--- a/docs/content/3.guides/9.production-deployment.md
+++ b/docs/content/3.guides/9.production-deployment.md
@@ -7,11 +7,14 @@ Use this guide when your auth flow works locally and you are preparing to ship i
 
 ## Environment Variables
 
-Production requires these environment variables at runtime:
+Production requires a singular or versioned auth secret at runtime:
 
 ```ini [.env.production]
 # Required: 32+ character secret for session encryption
 NUXT_BETTER_AUTH_SECRET="your-32-character-secret-here-minimum"
+
+# Alternative for non-destructive rotation
+# BETTER_AUTH_SECRETS="2:current-secret-must-be-at-least-32-characters,1:previous-secret-must-be-at-least-32-characters"
 
 # Optional: Auto-detected on Vercel/Cloudflare/Netlify
 NUXT_PUBLIC_SITE_URL="https://your-app.com"
@@ -33,7 +36,7 @@ The secret must be at least 32 characters. Shorter secrets will cause auth initi
 
 ### Before Deploying
 
-- [ ] `NUXT_BETTER_AUTH_SECRET` is set and 32+ characters
+- [ ] `NUXT_BETTER_AUTH_SECRET`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_SECRETS`, or `defineServerAuth({ secrets })` is configured
 - [ ] `NUXT_PUBLIC_SITE_URL` set (or using Vercel/Cloudflare/Netlify auto-detection)
 - [ ] `trustedOrigins` includes every active frontend origin (primary domain and preview domain, if used)
 - [ ] OAuth redirect URIs configured for production domain
@@ -83,7 +86,7 @@ For production, consider using Cloudflare rate limiting or a Redis-backed soluti
 
 ### Separate Build and Runtime Environments
 
-Some platforms, including Cloudflare Workers Builds, expose build-time and runtime environment variables separately. `NUXT_BETTER_AUTH_SECRET` must be available to the deployed runtime, but it does not need to be present in the build container.
+Some platforms, including Cloudflare Workers Builds, expose build-time and runtime environment variables separately. Your singular or versioned auth secret must be available to the deployed runtime, but it does not need to be present in the build container.
 
 ### Trusted Origins for Preview Environments
 
@@ -125,9 +128,9 @@ export default defineNuxtConfig({
 
 Your secret is too short. Generate a new one using the command above. This error is raised when auth initializes at runtime. `BETTER_AUTH_SECRET` is still accepted as a fallback, but `NUXT_BETTER_AUTH_SECRET` is the recommended variable.
 
-### "NUXT_BETTER_AUTH_SECRET is required in production"
+### "An auth secret is required in production"
 
-The deployed server runtime could not resolve an auth secret. Set `NUXT_BETTER_AUTH_SECRET` or `BETTER_AUTH_SECRET` in the runtime environment for your app.
+The deployed server runtime could not resolve an auth secret. Set `NUXT_BETTER_AUTH_SECRET`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_SECRETS`, or `secrets` in `defineServerAuth`.
 
 ### "siteUrl required in production"
 

--- a/docs/content/3.guides/9.production-deployment.md
+++ b/docs/content/3.guides/9.production-deployment.md
@@ -30,7 +30,7 @@ GOOGLE_CLIENT_SECRET="..."
 node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 ```
 
-The secret must be at least 32 characters. Shorter secrets will cause auth initialization to throw an error at runtime.
+Singular secrets must be at least 32 characters. Shorter `NUXT_BETTER_AUTH_SECRET` or `BETTER_AUTH_SECRET` values cause auth initialization to throw at runtime. Better Auth validates versioned `BETTER_AUTH_SECRETS`/`secrets` entries and warns when the current key is too short.
 
 ## Security Checklist
 

--- a/docs/content/3.guides/9.production-deployment.md
+++ b/docs/content/3.guides/9.production-deployment.md
@@ -124,9 +124,9 @@ export default defineNuxtConfig({
 
 ## Common Issues
 
-### "NUXT_BETTER_AUTH_SECRET must be at least 32 characters"
+### "Singular auth secret must be at least 32 characters"
 
-Your secret is too short. Generate a new one using the command above. This error is raised when auth initializes at runtime. `BETTER_AUTH_SECRET` is still accepted as a fallback, but `NUXT_BETTER_AUTH_SECRET` is the recommended variable.
+Your `NUXT_BETTER_AUTH_SECRET` or `BETTER_AUTH_SECRET` is too short. Generate a new one using the command above. This error is raised when auth initializes at runtime. `NUXT_BETTER_AUTH_SECRET` remains the recommended variable.
 
 ### "An auth secret is required in production"
 

--- a/src/module/secret.ts
+++ b/src/module/secret.ts
@@ -6,6 +6,7 @@ import { isCI, isTest } from 'std-env'
 
 const DEFAULT_SECRET_ENV = 'NUXT_BETTER_AUTH_SECRET'
 const FALLBACK_SECRET_ENV = 'BETTER_AUTH_SECRET'
+const VERSIONED_SECRET_ENV = 'BETTER_AUTH_SECRETS'
 
 const generateSecret = () => randomBytes(32).toString('hex')
 
@@ -16,7 +17,7 @@ function readEnvFile(rootDir: string): string {
 
 function hasEnvSecret(rootDir: string): boolean {
   const envFile = readEnvFile(rootDir)
-  return [DEFAULT_SECRET_ENV, FALLBACK_SECRET_ENV].some((name) => {
+  return [DEFAULT_SECRET_ENV, FALLBACK_SECRET_ENV, VERSIONED_SECRET_ENV].some((name) => {
     const match = envFile.match(new RegExp(`^${name}=(.+)$`, 'm'))
     return !!match && !!match[1] && match[1].trim().length > 0
   })
@@ -41,12 +42,12 @@ export async function promptForSecret(rootDir: string, consola: ConsolaInstance,
   if (configuredSecret)
     return undefined
 
-  if (process.env.NUXT_BETTER_AUTH_SECRET || process.env.BETTER_AUTH_SECRET || hasEnvSecret(rootDir))
+  if (process.env.NUXT_BETTER_AUTH_SECRET || process.env.BETTER_AUTH_SECRET || process.env.BETTER_AUTH_SECRETS || hasEnvSecret(rootDir))
     return undefined
 
   const hasTty = Boolean(process.stdin.isTTY && process.stdout.isTTY)
   if (options.prepare || !hasTty) {
-    consola.warn('[nuxt-better-auth] Skipping NUXT_BETTER_AUTH_SECRET prompt (non-interactive). Set NUXT_BETTER_AUTH_SECRET or BETTER_AUTH_SECRET.')
+    consola.warn('[nuxt-better-auth] Skipping auth secret prompt (non-interactive). Set NUXT_BETTER_AUTH_SECRET, BETTER_AUTH_SECRET, or BETTER_AUTH_SECRETS.')
     return undefined
   }
 
@@ -57,7 +58,7 @@ export async function promptForSecret(rootDir: string, consola: ConsolaInstance,
     return secret
   }
 
-  consola.box('NUXT_BETTER_AUTH_SECRET is required for authentication.\nThis will be appended to your .env file.\nBETTER_AUTH_SECRET is still supported as a fallback.')
+  consola.box('An auth secret is required for authentication.\nThis will add NUXT_BETTER_AUTH_SECRET to your .env file.\nBETTER_AUTH_SECRET and BETTER_AUTH_SECRETS are also supported.')
   const choice = await consola.prompt('How do you want to set it?', {
     type: 'select',
     options: [
@@ -69,7 +70,7 @@ export async function promptForSecret(rootDir: string, consola: ConsolaInstance,
   }) as 'generate' | 'paste' | 'skip' | symbol
 
   if (typeof choice === 'symbol' || choice === 'skip') {
-    consola.warn('Skipping NUXT_BETTER_AUTH_SECRET. Auth will fail without it in production.')
+    consola.warn('Skipping auth secret setup. Auth will fail without a configured secret in production.')
     return undefined
   }
 

--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -275,12 +275,19 @@ function withDevTrustedOrigins(
 /** Returns Better Auth instance. Caches per resolved host (or single instance when siteUrl is explicit). */
 export function serverAuth(event?: ServerEvent): AuthInstance {
   const runtimeConfig = useRuntimeConfig()
-  const betterAuthSecret = runtimeConfig.betterAuthSecret || ''
+  const betterAuthSecret = runtimeConfig.betterAuthSecret || env.BETTER_AUTH_SECRET || ''
   if (betterAuthSecret && betterAuthSecret.length < 32)
     throw new Error('[nuxt-better-auth] NUXT_BETTER_AUTH_SECRET must be at least 32 characters for security')
 
-  const siteUrl = getBaseURL(event)
   const requestOrigin = resolveEventOrigin(event)
+  let userConfig: UserAuthConfig | undefined
+  if (!import.meta.dev && !betterAuthSecret && !env.BETTER_AUTH_SECRETS) {
+    userConfig = createServerAuth({ runtimeConfig, db, requestOrigin }) as UserAuthConfig
+    if (userConfig.secrets === undefined)
+      throw new Error('[nuxt-better-auth] An auth secret is required in production. Set NUXT_BETTER_AUTH_SECRET, BETTER_AUTH_SECRET, BETTER_AUTH_SECRETS, or defineServerAuth({ secrets }).')
+  }
+
+  const siteUrl = getBaseURL(event)
   const hasExplicitSiteUrl = runtimeConfig.public.siteUrl && typeof runtimeConfig.public.siteUrl === 'string'
   const cacheKey = hasExplicitSiteUrl ? '__explicit__' : siteUrl
   const requestContext = event ? getRequestAuthContext(event) : undefined
@@ -288,9 +295,7 @@ export function serverAuth(event?: ServerEvent): AuthInstance {
   if (requestContext?.[requestAuthKey])
     return requestContext[requestAuthKey]
 
-  const userConfig = createServerAuth({ runtimeConfig, db, requestOrigin }) as UserAuthConfig
-  if (!import.meta.dev && !betterAuthSecret && userConfig.secrets === undefined && !env.BETTER_AUTH_SECRETS)
-    throw new Error('[nuxt-better-auth] An auth secret is required in production. Set NUXT_BETTER_AUTH_SECRET, BETTER_AUTH_SECRET, BETTER_AUTH_SECRETS, or defineServerAuth({ secrets }).')
+  userConfig ??= createServerAuth({ runtimeConfig, db, requestOrigin }) as UserAuthConfig
 
   const database = createDatabase(event)
   const trustedOrigins = withDevTrustedOrigins(userConfig.trustedOrigins)

--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -275,8 +275,6 @@ function withDevTrustedOrigins(
 export function serverAuth(event?: ServerEvent): AuthInstance {
   const runtimeConfig = useRuntimeConfig()
   const betterAuthSecret = runtimeConfig.betterAuthSecret || ''
-  if (!import.meta.dev && !betterAuthSecret)
-    throw new Error('[nuxt-better-auth] NUXT_BETTER_AUTH_SECRET is required in production. Set NUXT_BETTER_AUTH_SECRET or BETTER_AUTH_SECRET environment variable.')
   if (betterAuthSecret && betterAuthSecret.length < 32)
     throw new Error('[nuxt-better-auth] NUXT_BETTER_AUTH_SECRET must be at least 32 characters for security')
 

--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -277,7 +277,7 @@ export function serverAuth(event?: ServerEvent): AuthInstance {
   const runtimeConfig = useRuntimeConfig()
   const betterAuthSecret = runtimeConfig.betterAuthSecret || env.BETTER_AUTH_SECRET || ''
   if (betterAuthSecret && betterAuthSecret.length < 32)
-    throw new Error('[nuxt-better-auth] NUXT_BETTER_AUTH_SECRET must be at least 32 characters for security')
+    throw new Error('[nuxt-better-auth] Singular auth secret must be at least 32 characters for security')
 
   const requestOrigin = resolveEventOrigin(event)
   let userConfig: UserAuthConfig | undefined

--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -1,6 +1,6 @@
 import type { BetterAuthOptions } from 'better-auth'
 import type { ServerEvent } from '../internal/nitro-compat'
-import { betterAuth } from 'better-auth'
+import { betterAuth, env } from 'better-auth'
 import { withoutProtocol } from 'ufo'
 import { createDatabase, db } from '#auth/database'
 import { createSecondaryStorage } from '#auth/secondary-storage'
@@ -10,6 +10,7 @@ import { resolveCustomSecondaryStorageRequirement } from './custom-secondary-sto
 
 type AuthOptions = ReturnType<typeof createServerAuth>
 type UserAuthConfig = AuthOptions & {
+  secrets?: BetterAuthOptions['secrets']
   trustedOrigins?: BetterAuthOptions['trustedOrigins']
   secondaryStorage?: BetterAuthOptions['secondaryStorage']
 }
@@ -287,8 +288,11 @@ export function serverAuth(event?: ServerEvent): AuthInstance {
   if (requestContext?.[requestAuthKey])
     return requestContext[requestAuthKey]
 
-  const database = createDatabase(event)
   const userConfig = createServerAuth({ runtimeConfig, db, requestOrigin }) as UserAuthConfig
+  if (!import.meta.dev && !betterAuthSecret && userConfig.secrets === undefined && !env.BETTER_AUTH_SECRETS)
+    throw new Error('[nuxt-better-auth] An auth secret is required in production. Set NUXT_BETTER_AUTH_SECRET, BETTER_AUTH_SECRET, BETTER_AUTH_SECRETS, or defineServerAuth({ secrets }).')
+
+  const database = createDatabase(event)
   const trustedOrigins = withDevTrustedOrigins(userConfig.trustedOrigins)
 
   const hubSecondaryStorage = (runtimeConfig.auth as { hubSecondaryStorage?: boolean | 'custom' })?.hubSecondaryStorage

--- a/test/non-tty-secret-prompt.test.ts
+++ b/test/non-tty-secret-prompt.test.ts
@@ -25,6 +25,8 @@ const consola = {
 }
 
 const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nuxt-better-auth-secret-'))
+if (process.env.TEST_ENV_FILE_CONTENT)
+  fs.writeFileSync(path.join(rootDir, '.env'), process.env.TEST_ENV_FILE_CONTENT)
 await promptForSecret(rootDir, consola, { prepare: true })
 console.log('PROMPT_CALLS=' + promptCalls)
 `
@@ -45,7 +47,9 @@ function createNonTestEnv(): NodeJS.ProcessEnv {
 
   // Ensure no secret is configured via env.
   delete env.BETTER_AUTH_SECRET
+  delete env.BETTER_AUTH_SECRETS
   delete env.NUXT_BETTER_AUTH_SECRET
+  delete env.TEST_ENV_FILE_CONTENT
 
   env.FORCE_COLOR = '0'
 
@@ -68,7 +72,7 @@ describe('promptForSecret', () => {
 
     expect(run.status, `node script failed:\n${run.stdout}\n${run.stderr}`).toBe(0)
     const output = `${run.stdout}\n${run.stderr}`
-    expect(output).toContain('Skipping NUXT_BETTER_AUTH_SECRET prompt')
+    expect(output).toContain('Skipping auth secret prompt')
     expect(output).toContain('PROMPT_CALLS=0')
   })
 
@@ -79,7 +83,7 @@ describe('promptForSecret', () => {
 
     expect(run.status, `node script failed:\n${run.stdout}\n${run.stderr}`).toBe(0)
     const output = `${run.stdout}\n${run.stderr}`
-    expect(output).not.toContain('Skipping NUXT_BETTER_AUTH_SECRET prompt')
+    expect(output).not.toContain('Skipping auth secret prompt')
     expect(output).toContain('PROMPT_CALLS=0')
   })
 
@@ -90,7 +94,29 @@ describe('promptForSecret', () => {
 
     expect(run.status, `node script failed:\n${run.stdout}\n${run.stderr}`).toBe(0)
     const output = `${run.stdout}\n${run.stderr}`
-    expect(output).not.toContain('Skipping NUXT_BETTER_AUTH_SECRET prompt')
+    expect(output).not.toContain('Skipping auth secret prompt')
+    expect(output).toContain('PROMPT_CALLS=0')
+  })
+
+  it('skips prompting when BETTER_AUTH_SECRETS is already set', () => {
+    const env = createNonTestEnv()
+    env.BETTER_AUTH_SECRETS = '2:current-secret-for-testing-only-32chars,1:previous-secret-for-testing-only-32chars'
+    const run = runPromptScript(env)
+
+    expect(run.status, `node script failed:\n${run.stdout}\n${run.stderr}`).toBe(0)
+    const output = `${run.stdout}\n${run.stderr}`
+    expect(output).not.toContain('Skipping auth secret prompt')
+    expect(output).toContain('PROMPT_CALLS=0')
+  })
+
+  it('skips prompting when BETTER_AUTH_SECRETS exists in .env', () => {
+    const env = createNonTestEnv()
+    env.TEST_ENV_FILE_CONTENT = 'BETTER_AUTH_SECRETS=2:current-secret-for-testing-only-32chars,1:previous-secret-for-testing-only-32chars\n'
+    const run = runPromptScript(env)
+
+    expect(run.status, `node script failed:\n${run.stdout}\n${run.stderr}`).toBe(0)
+    const output = `${run.stdout}\n${run.stderr}`
+    expect(output).not.toContain('Skipping auth secret prompt')
     expect(output).toContain('PROMPT_CALLS=0')
   })
 })

--- a/test/server-auth-database-cache.test.ts
+++ b/test/server-auth-database-cache.test.ts
@@ -1,5 +1,5 @@
 import type { H3Event } from 'h3'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const betterAuthMock = vi.fn()
 const createDatabaseMock = vi.fn()
@@ -21,6 +21,7 @@ vi.mock('#auth/server', () => ({
 
 vi.mock('better-auth', () => ({
   betterAuth: betterAuthMock,
+  env: process.env,
 }))
 
 vi.mock('../src/runtime/server/internal/nitro-compat', () => ({
@@ -47,6 +48,7 @@ describe('serverAuth database cache and secret validation', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    vi.stubEnv('BETTER_AUTH_SECRETS', '')
 
     useRuntimeConfigMock.mockReturnValue({
       public: {
@@ -64,6 +66,24 @@ describe('serverAuth database cache and secret validation', () => {
       options,
       marker: Symbol('auth-instance'),
     }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('rejects missing singular and versioned secrets before creating auth', async () => {
+    useRuntimeConfigMock.mockReturnValue({
+      public: { siteUrl: 'https://example.com' },
+      auth: {},
+      betterAuthSecret: '',
+    })
+
+    const { serverAuth } = await import('../src/runtime/server/utils/auth')
+
+    expect(() => serverAuth()).toThrow('An auth secret is required in production')
+    expect(createDatabaseMock).not.toHaveBeenCalled()
+    expect(betterAuthMock).not.toHaveBeenCalled()
   })
 
   it('forwards versioned secrets without requiring a singular secret', async () => {
@@ -85,6 +105,20 @@ describe('serverAuth database cache and secret validation', () => {
 
     expect(() => serverAuth()).not.toThrow()
     expect(betterAuthMock).toHaveBeenCalledWith(expect.objectContaining({ secret: '', secrets }))
+  })
+
+  it('allows BETTER_AUTH_SECRETS without requiring a singular secret', async () => {
+    vi.stubEnv('BETTER_AUTH_SECRETS', '2:current-secret-for-testing-only-32chars,1:previous-secret-for-testing-only-32chars')
+    useRuntimeConfigMock.mockReturnValue({
+      public: { siteUrl: 'https://example.com' },
+      auth: {},
+      betterAuthSecret: '',
+    })
+
+    const { serverAuth } = await import('../src/runtime/server/utils/auth')
+
+    expect(() => serverAuth()).not.toThrow()
+    expect(betterAuthMock).toHaveBeenCalledWith(expect.objectContaining({ secret: '' }))
   })
 
   it('rejects a short runtime secret before creating auth', async () => {

--- a/test/server-auth-database-cache.test.ts
+++ b/test/server-auth-database-cache.test.ts
@@ -48,6 +48,7 @@ describe('serverAuth database cache and secret validation', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    vi.stubEnv('BETTER_AUTH_SECRET', '')
     vi.stubEnv('BETTER_AUTH_SECRETS', '')
 
     useRuntimeConfigMock.mockReturnValue({
@@ -119,6 +120,55 @@ describe('serverAuth database cache and secret validation', () => {
 
     expect(() => serverAuth()).not.toThrow()
     expect(betterAuthMock).toHaveBeenCalledWith(expect.objectContaining({ secret: '' }))
+  })
+
+  it('allows a runtime-only BETTER_AUTH_SECRET', async () => {
+    vi.stubEnv('BETTER_AUTH_SECRET', 'runtime-secret-for-testing-only-32chars')
+    useRuntimeConfigMock.mockReturnValue({
+      public: { siteUrl: 'https://example.com' },
+      auth: {},
+      betterAuthSecret: '',
+    })
+
+    const { serverAuth } = await import('../src/runtime/server/utils/auth')
+
+    expect(() => serverAuth()).not.toThrow()
+    expect(betterAuthMock).toHaveBeenCalledWith(expect.objectContaining({
+      secret: 'runtime-secret-for-testing-only-32chars',
+    }))
+  })
+
+  it('rejects a short runtime-only BETTER_AUTH_SECRET', async () => {
+    vi.stubEnv('BETTER_AUTH_SECRET', 'too-short')
+    useRuntimeConfigMock.mockReturnValue({
+      public: { siteUrl: 'https://example.com' },
+      auth: {},
+      betterAuthSecret: '',
+    })
+
+    const { serverAuth } = await import('../src/runtime/server/utils/auth')
+
+    expect(() => serverAuth()).toThrow('must be at least 32 characters')
+    expect(betterAuthMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects missing secrets before resolving siteUrl', async () => {
+    vi.stubEnv('NITRO_HOST', '')
+    vi.stubEnv('HOST', '')
+    vi.stubEnv('VERCEL_URL', '')
+    vi.stubEnv('CF_PAGES_URL', '')
+    vi.stubEnv('URL', '')
+    useRuntimeConfigMock.mockReturnValue({
+      public: {},
+      auth: {},
+      betterAuthSecret: '',
+    })
+
+    const { serverAuth } = await import('../src/runtime/server/utils/auth')
+
+    expect(() => serverAuth()).toThrow('An auth secret is required in production')
+    expect(createDatabaseMock).not.toHaveBeenCalled()
+    expect(betterAuthMock).not.toHaveBeenCalled()
   })
 
   it('rejects a short runtime secret before creating auth', async () => {

--- a/test/server-auth-database-cache.test.ts
+++ b/test/server-auth-database-cache.test.ts
@@ -148,7 +148,7 @@ describe('serverAuth database cache and secret validation', () => {
 
     const { serverAuth } = await import('../src/runtime/server/utils/auth')
 
-    expect(() => serverAuth()).toThrow('must be at least 32 characters')
+    expect(() => serverAuth()).toThrow('Singular auth secret must be at least 32 characters')
     expect(betterAuthMock).not.toHaveBeenCalled()
   })
 
@@ -180,7 +180,7 @@ describe('serverAuth database cache and secret validation', () => {
 
     const { serverAuth } = await import('../src/runtime/server/utils/auth')
 
-    expect(() => serverAuth()).toThrow('NUXT_BETTER_AUTH_SECRET must be at least 32 characters')
+    expect(() => serverAuth()).toThrow('Singular auth secret must be at least 32 characters')
     expect(betterAuthMock).not.toHaveBeenCalled()
   })
 

--- a/test/server-auth-database-cache.test.ts
+++ b/test/server-auth-database-cache.test.ts
@@ -66,17 +66,25 @@ describe('serverAuth database cache and secret validation', () => {
     }))
   })
 
-  it('rejects a missing runtime secret before creating auth', async () => {
+  it('forwards versioned secrets without requiring a singular secret', async () => {
+    const secrets = [
+      { version: 2, value: 'current-secret-for-testing-only-32chars' },
+      { version: 1, value: 'previous-secret-for-testing-only-32chars' },
+    ]
     useRuntimeConfigMock.mockReturnValue({
       public: { siteUrl: 'https://example.com' },
       auth: {},
       betterAuthSecret: '',
     })
+    createServerAuthMock.mockReturnValue({
+      trustedOrigins: undefined,
+      secrets,
+    })
 
     const { serverAuth } = await import('../src/runtime/server/utils/auth')
 
-    expect(() => serverAuth()).toThrow('NUXT_BETTER_AUTH_SECRET is required in production')
-    expect(betterAuthMock).not.toHaveBeenCalled()
+    expect(() => serverAuth()).not.toThrow()
+    expect(betterAuthMock).toHaveBeenCalledWith(expect.objectContaining({ secret: '', secrets }))
   })
 
   it('rejects a short runtime secret before creating auth', async () => {


### PR DESCRIPTION
Closes #392

The module previously treated an empty singular runtime secret as fatal before Better Auth could resolve versioned secrets. This keeps the fail-fast production check while accepting every supported source: the recommended `NUXT_BETTER_AUTH_SECRET`, runtime-only `BETTER_AUTH_SECRET`, `BETTER_AUTH_SECRETS`, or `secrets` from `defineServerAuth`.

The module's hard 32-character check remains scoped to singular secrets. Better Auth continues to parse and validate versioned secrets.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxt-better-auth-392](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-better-auth-392/nuxt-better-auth-392?startScript=verify) | ❌ `/api/check` returns 500 |
| Fix | [nuxt-better-auth-392-fix](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-better-auth-392/nuxt-better-auth-392-fix?startScript=verify) | ✅ `/api/check` returns 200 |

## CLI reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxt-better-auth-392 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxt-better-auth-392
cd nuxt-better-auth-392 && pnpm install && pnpm verify
```

## Verify fix

```bash
git sparse-checkout add nuxt-better-auth-392-fix
cd ../nuxt-better-auth-392-fix && pnpm install && pnpm verify
```

The fixed fixture uses `pnpm patch` against published `@onmax/nuxt-better-auth@0.1.2`.

## Test plan

- [x] Secret validation unit tests: 11 passed
- [x] Focused auth/build suite, including those unit tests: 18 passed
- [x] Published-package repro returns HTTP 500
- [x] Patched-package repro accepts `BETTER_AUTH_SECRETS` and returns HTTP 200
- [x] `pnpm lint`
- [x] `pnpm typecheck`
