### PR TITLE
fix(docs): remove extra scrollbar in landing hero

### DIFF
--- a/docs/app/components/content/landing/LandingHero.vue
+++ b/docs/app/components/content/landing/LandingHero.vue
@@ -123,7 +123,7 @@ function getLang(filename: string) {
 
 <template>
   <AnnouncementBanner />
-  <section class="relative w-full flex overflow-x-hidden md:items-end md:justify-center bg-white/96 dark:bg-black/[0.96] antialiased min-h-[40rem] md:min-h-[50rem] lg:min-h-[40rem]">
+  <section class="relative w-full flex overflow-x-clip md:items-end md:justify-center bg-white/96 dark:bg-black/[0.96] antialiased min-h-[40rem] md:min-h-[50rem] lg:min-h-[40rem]">
     <!-- Spotlight Effect -->
     <LandingSpotlight />
 
@@ -283,7 +283,7 @@ function getLang(filename: string) {
                         </UCollapsible>
 
                         <ScrollAreaRoot class="w-full min-w-0 overflow-hidden">
-                          <ScrollAreaViewport class="w-full min-w-0 overflow-x-auto overscroll-x-contain">
+                          <ScrollAreaViewport class="w-full min-w-0 overflow-x-auto overflow-y-hidden overscroll-x-contain">
                             <!-- All files rendered for SSR, animated with CSS -->
                             <div class="relative">
                               <div


### PR DESCRIPTION
## Summary
- Replace `overflow-x-hidden` with `overflow-x-clip` on the landing hero section to prevent it from becoming a nested scroll container
- Add `overflow-y-hidden` on the code preview `ScrollAreaViewport` so only horizontal scrolling is enabled

## Context
`overflow-x-hidden` causes `overflow-y` to compute to `auto` per CSS overflow rules. Combined with decorative vertical lines extending past the section height, the hero gained its own vertical scrollbar and caused layout misalignment on the homepage.

## Screenshots
<img width="523" height="267" alt="image" src="https://github.com/user-attachments/assets/68aaa57d-7619-4147-a0f3-5730982aa24e" />
<img width="507" height="337" alt="image" src="https://github.com/user-attachments/assets/cb0b7a27-d182-4f08-8ecf-6114550cbceb" />


## Test plan
- [ ] Open the docs landing page and confirm the hero no longer shows an extra vertical scrollbar
- [ ] Verify horizontal scrolling still works in the code preview when content is wider than the viewport
- [ ] Check layout alignment between hero and the sections below on desktop and mobile


