### PR TITLE
docs: avoid version-specific setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Nuxt module for [Better Auth](https://better-auth.com) with Nuxt-native route pr
 
 ## Who this is for
 
-The same module release supports Nuxt 4 stable with Nitro 2 and [Nuxt 5 nightly with Nitro 3](https://github.com/nuxt-modules/better-auth/pull/87). Use it when you want the Nuxt-specific pieces handled for you:
+Use this module if you want Better Auth in a Nuxt app and you want the Nuxt-specific pieces handled for you:
 
 - `useUserSession()` for reactive auth state
 - `requireUserSession(event)` and related server helpers
@@ -14,7 +14,7 @@ The same module release supports Nuxt 4 stable with Nitro 2 and [Nuxt 5 nightly 
 
 ## Install the module
 
-For the fastest path in a supported Nuxt app:
+For the fastest path in a Nuxt app:
 
 ```bash
 npx nuxi module add @nuxtjs/better-auth

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Nuxt module for [Better Auth](https://better-auth.com) with Nuxt-native route pr
 
 ## Who this is for
 
-Use this module if you want Better Auth in a Nuxt 4 app and you want the Nuxt-specific pieces handled for you:
+The same module release supports Nuxt 4 stable with Nitro 2 and [Nuxt 5 nightly with Nitro 3](https://github.com/nuxt-modules/better-auth/pull/87). Use it when you want the Nuxt-specific pieces handled for you:
 
 - `useUserSession()` for reactive auth state
 - `requireUserSession(event)` and related server helpers
@@ -14,7 +14,7 @@ Use this module if you want Better Auth in a Nuxt 4 app and you want the Nuxt-sp
 
 ## Install the module
 
-For the fastest path in a Nuxt 4 app:
+For the fastest path in a supported Nuxt app:
 
 ```bash
 npx nuxi module add @nuxtjs/better-auth

--- a/docs/content/1.getting-started/0.index.md
+++ b/docs/content/1.getting-started/0.index.md
@@ -4,7 +4,7 @@ description: Nuxt Better Auth integrates Better Auth with Nuxt for route protect
 navigation.icon: i-lucide-sparkles
 ---
 
-Use this page when you want the fastest path to a working Nuxt 4 stable (Nitro 2) or Nuxt 5 nightly (Nitro 3) setup.
+Use this page when you want the fastest path to a working Nuxt setup.
 
 This quickstart assumes:
 
@@ -25,7 +25,7 @@ After this guide you should have:
 
 ## Before you begin
 
-- Nuxt `4.x` with Nitro 2 or Nuxt 5 nightly with Nitro 3
+- a supported Nuxt version
 - a local `.env` file
 - a development server you can start with `pnpm dev`
 

--- a/docs/content/1.getting-started/0.index.md
+++ b/docs/content/1.getting-started/0.index.md
@@ -25,7 +25,6 @@ After this guide you should have:
 
 ## Before you begin
 
-- a supported Nuxt version
 - a local `.env` file
 - a development server you can start with `pnpm dev`
 

--- a/docs/content/1.getting-started/0.index.md
+++ b/docs/content/1.getting-started/0.index.md
@@ -4,7 +4,7 @@ description: Nuxt Better Auth integrates Better Auth with Nuxt for route protect
 navigation.icon: i-lucide-sparkles
 ---
 
-Use this page when you want the fastest path to a working Nuxt 4 setup.
+Use this page when you want the fastest path to a working Nuxt 4 stable (Nitro 2) or Nuxt 5 nightly (Nitro 3) setup.
 
 This quickstart assumes:
 
@@ -25,7 +25,7 @@ After this guide you should have:
 
 ## Before you begin
 
-- Nuxt `4.x`
+- Nuxt `4.x` with Nitro 2 or Nuxt 5 nightly with Nitro 3
 - a local `.env` file
 - a development server you can start with `pnpm dev`
 

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -7,7 +7,7 @@ navigation.icon: i-lucide-download
 ::code-collapse
 
 ```txt [Prompt]
-Install @nuxtjs/better-auth in my Nuxt 4 app.
+Install @nuxtjs/better-auth in my Nuxt 4 stable (Nitro 2) or Nuxt 5 nightly (Nitro 3) app.
 
 - Read the raw installation documentation first: https://better-auth.nuxt.dev/raw/getting-started/installation.md
 - Run `npx nuxi module add @nuxtjs/better-auth`
@@ -25,7 +25,7 @@ Use this page when you want the full install checklist rather than the shorter q
 
 ## Prerequisites
 
-- Nuxt v4.0+
+- Nuxt 4 stable with Nitro 2 or Nuxt 5 nightly with Nitro 3
 - a package manager configured for your app
 - a local `.env` file or deployment environment variable system
 

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -25,7 +25,6 @@ Use this page when you want the full install checklist rather than the shorter q
 
 ## Prerequisites
 
-- a supported Nuxt version
 - a package manager configured for your app
 - a local `.env` file or deployment environment variable system
 

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -7,7 +7,7 @@ navigation.icon: i-lucide-download
 ::code-collapse
 
 ```txt [Prompt]
-Install @nuxtjs/better-auth in my Nuxt 4 stable (Nitro 2) or Nuxt 5 nightly (Nitro 3) app.
+Install @nuxtjs/better-auth in my Nuxt app.
 
 - Read the raw installation documentation first: https://better-auth.nuxt.dev/raw/getting-started/installation.md
 - Run `npx nuxi module add @nuxtjs/better-auth`
@@ -25,7 +25,7 @@ Use this page when you want the full install checklist rather than the shorter q
 
 ## Prerequisites
 
-- Nuxt 4 stable with Nitro 2 or Nuxt 5 nightly with Nitro 3
+- a supported Nuxt version
 - a package manager configured for your app
 - a local `.env` file or deployment environment variable system
 

--- a/docs/public/.well-known/skills/nuxt-better-auth/SKILL.md
+++ b/docs/public/.well-known/skills/nuxt-better-auth/SKILL.md
@@ -6,7 +6,7 @@ license: MIT
 
 # Nuxt Better Auth
 
-Authentication module for Nuxt 4+ built on [Better Auth](https://www.better-auth.com/). It adds Nuxt-specific setup, route protection, server helpers, and typed auth state.
+Authentication module for Nuxt 4 stable with Nitro 2 and Nuxt 5 nightly with Nitro 3, built on [Better Auth](https://www.better-auth.com/). It adds Nuxt-specific setup, route protection, server helpers, and typed auth state.
 
 > Alpha status: the package is still pre-stable. Verify behavior against the current docs and source before relying on edge cases.
 

--- a/docs/public/.well-known/skills/nuxt-better-auth/SKILL.md
+++ b/docs/public/.well-known/skills/nuxt-better-auth/SKILL.md
@@ -6,7 +6,7 @@ license: MIT
 
 # Nuxt Better Auth
 
-Authentication module for Nuxt 4 stable with Nitro 2 and Nuxt 5 nightly with Nitro 3, built on [Better Auth](https://www.better-auth.com/). It adds Nuxt-specific setup, route protection, server helpers, and typed auth state.
+Authentication module for Nuxt built on [Better Auth](https://www.better-auth.com/). It adds Nuxt-specific setup, route protection, server helpers, and typed auth state.
 
 > Alpha status: the package is still pre-stable. Verify behavior against the current docs and source before relying on edge cases.
 


### PR DESCRIPTION
Nuxt 3 reached EOL, no need to specify Nuxt 4 specifically since this module also support Nuxt 5