### PR TITLE
docs: correct rate limiting guidance

### DIFF
--- a/docs/content/2.core-concepts/5.security-caveats.md
+++ b/docs/content/2.core-concepts/5.security-caveats.md
@@ -77,12 +77,9 @@ If your `redirectTo` target does not exist, users will be redirected to a 404 pa
 
 ## Rate limiting
 
-This module does not include built-in rate limiting. Authentication endpoints can be targeted by brute force attacks.
+Better Auth includes a [built-in rate limiter](https://www.better-auth.com/docs/concepts/rate-limit). It is enabled by default in production with a 60-second window and a maximum of 100 requests. It is disabled by default in development.
 
-**Recommendations:**
-- Use Cloudflare rate limiting rules
-- Implement server middleware with Redis-backed rate limiting
-- Configure your reverse proxy (nginx, Caddy) to limit requests
+Rate-limit data is stored in memory by default. For serverless or multi-instance deployments, configure Better Auth to use database, secondary storage, or custom storage so instances do not rely on separate in-memory counters.
 
 :read-more{to="/guides/production-deployment" title="Production Deployment"}
 

--- a/docs/content/3.guides/9.production-deployment.md
+++ b/docs/content/3.guides/9.production-deployment.md
@@ -55,34 +55,9 @@ export default defineEventHandler(async (event) => {
 
 ### Rate Limiting
 
-The module does not include built-in rate limiting. Implement rate limiting at the infrastructure level or use a middleware:
+Better Auth enables its [built-in rate limiter](https://www.better-auth.com/docs/concepts/rate-limit) by default in production with a 60-second window and a maximum of 100 requests. It is disabled by default in development.
 
-```ts [server/middleware/rate-limit.ts]
-import { getRequestIP } from 'h3'
-
-const requests = new Map<string, number[]>()
-const WINDOW_MS = 60_000 // 1 minute
-const MAX_REQUESTS = 100
-
-export default defineEventHandler((event) => {
-  if (!event.path.startsWith('/api/auth'))
-    return
-
-  const ip = getRequestIP(event) || 'unknown'
-  const now = Date.now()
-  const windowStart = now - WINDOW_MS
-
-  const timestamps = (requests.get(ip) || []).filter(t => t > windowStart)
-  timestamps.push(now)
-  requests.set(ip, timestamps)
-
-  if (timestamps.length > MAX_REQUESTS) {
-    throw createError({ statusCode: 429, message: 'Too many requests' })
-  }
-})
-```
-
-For production, consider using Cloudflare rate limiting or a Redis-backed solution.
+Better Auth stores rate-limit data in memory by default. For serverless or multi-instance deployments, configure database, secondary storage, or custom storage instead of relying on separate per-instance counters.
 
 ### Separate Build and Runtime Environments
 


### PR DESCRIPTION
Nuxt Better Auth currently says rate limiting is absent and recommends custom middleware, but Better Auth enables its own limiter in production.

- Documents the 60-second/100-request production defaults and disabled development default.
- Warns that the default in-memory store may not suit serverless or multi-instance deployments, with an upstream configuration link.
- Removes the duplicate middleware example from the linked production guide.
- Verification: `pnpm build:docs` on Node 24, `git diff --check`
