### PR TITLE
feat: expose request session setter

### DIFF
--- a/docs/content/2.core-concepts/1.server-auth.md
+++ b/docs/content/2.core-concepts/1.server-auth.md
@@ -12,6 +12,7 @@ Use server-side auth utilities in @nuxtjs/better-auth.
 - `getUserSession(event)` — get current session (auto-imported in `server/`)
 - `requireUserSession(event, options?)` — throws 401 if not authenticated, supports role matching
 - `getRequestSession(event)` — request-cached session, preferred over repeated `getUserSession` in same request
+- `setRequestSession(event, session)` — supply an authenticated session to downstream helpers for the current request
 - `refreshSessionCookieCache(event)` — refresh Better Auth's cached session cookie after server-side session data changes
 - All server utils are auto-imported, no import statements needed
 ```
@@ -27,6 +28,7 @@ Use this page when you need authentication state or Better Auth APIs inside Nitr
 | Task | Use | Example |
 |------|-----|---------|
 | Get request-cached session context | `getRequestSession(event)` | Cache once per request with context-backed storage when available |
+| Supply a request session | `setRequestSession(event, session)` | Reuse a session resolved by trusted server authentication |
 | Get current session | `getUserSession(event)` | Check if user is logged in |
 | Refresh cached session cookie | `refreshSessionCookieCache(event)` | Use after updating data returned by Better Auth session helpers |
 | Require authentication | `requireUserSession(event)` | Protect an API route |

--- a/docs/content/2.core-concepts/4.auto-imports-aliases.md
+++ b/docs/content/2.core-concepts/4.auto-imports-aliases.md
@@ -9,7 +9,7 @@ description: What the module registers for you.
 Use auto-imported utilities from @nuxtjs/better-auth.
 
 - Client (auto-imported in Vue): `useUserSession()`, `useUserSessionState()`, `useAuthClient()`, `useSignIn()`, `useSignUp()`, `useAuthClientAction()`, `runWithSessionRefresh()`
-- Server (auto-imported in `server/`): `serverAuth(event?)`, `getRequestSession(event)`, `getUserSession(event)`, `refreshSessionCookieCache(event)`, `createSession(event, userId)`, `setSessionCookie(event, token)`, `requireUserSession(event, options?)`
+- Server (auto-imported in `server/`): `serverAuth(event?)`, `getRequestSession(event)`, `setRequestSession(event, session)`, `getUserSession(event)`, `refreshSessionCookieCache(event)`, `createSession(event, userId)`, `setSessionCookie(event, token)`, `requireUserSession(event, options?)`
 - Component: `<BetterAuthState>` for auth-ready rendering
 - Alias `#nuxt-better-auth` exports types: `AuthUser`, `AuthSession`, `AuthSocialProviderId`
 - Use `getRequestSession(event)` over repeated `getUserSession(event)` calls — it caches per request
@@ -35,6 +35,7 @@ Use this page when you want a quick inventory of what the module registers for y
 
 - `serverAuth(event?)`
 - `getRequestSession(event)`
+- `setRequestSession(event, session)`
 - `getUserSession(event)`
 - `refreshSessionCookieCache(event)`
 - `createSession(event, userId)`
@@ -59,6 +60,7 @@ export default defineEventHandler(async (event) => {
 ```
 
 Use `getRequestSession(event)` when multiple handlers or middleware in the same request need session data. The helper should be preferred over repeated `getUserSession(event)` calls in the same request chain.
+Use `setRequestSession(event, session)` after trusted server code authenticates a request and resolves a complete `AppSession` that downstream session helpers should reuse. The value applies only to the current request and does not set a session cookie.
 `getUserSession(event)` does not memoize by itself.
 Use `refreshSessionCookieCache(event)` after server-side code updates data returned by the Better Auth session. This refreshes the cached session cookie. It does not update the session or user record; perform that update first.
 

--- a/docs/content/5.api/2.server-utils.md
+++ b/docs/content/5.api/2.server-utils.md
@@ -76,6 +76,27 @@ Use this helper when multiple handlers/middleware in the same request need sessi
 `getRequestSession` stays type-compatible in projects that use narrowed `h3` typings where `H3Event` does not explicitly declare `context`.
 ::
 
+## setRequestSession
+
+Supplies an `AppSession | null` to `getRequestSession`, `getUserSession`, and `requireUserSession` for the rest of the current request. Use it when trusted server code authenticates a request through another mechanism, such as a verified bearer token, and resolves the complete application session itself.
+
+```ts [server/middleware/bearer-session.ts]
+export default defineEventHandler(async (event) => {
+  const claims = await verifyBearerToken(event)
+  const session = await resolveCurrentAppSession(claims)
+
+  await setRequestSession(event, session)
+
+  // Later middleware and handlers reuse the supplied value.
+})
+```
+
+The helper waits for an earlier session lookup to settle before it makes the supplied value authoritative. Pass `null` to cache an unauthenticated result for the current request.
+
+::warning
+`setRequestSession` trusts the supplied value. Authenticate the request and enforce bearer-token audience and scope restrictions before calling it. The helper does not create, update, or clear a Better Auth session cookie.
+::
+
 ## refreshSessionCookieCache
 
 Refreshes Better Auth's cached session cookie on the current response, then refreshes the request-cached session used by `getRequestSession(event)`.

--- a/docs/content/5.api/2.server-utils.md
+++ b/docs/content/5.api/2.server-utils.md
@@ -85,13 +85,13 @@ export default defineEventHandler(async (event) => {
   const claims = await verifyBearerToken(event)
   const session = await resolveCurrentAppSession(claims)
 
-  await setRequestSession(event, session)
+  setRequestSession(event, session)
 
   // Later middleware and handlers reuse the supplied value.
 })
 ```
 
-The helper waits for an earlier session lookup to settle before it makes the supplied value authoritative. Pass `null` to cache an unauthenticated result for the current request.
+The helper makes the supplied value authoritative immediately, so an older session lookup or refresh cannot overwrite it when that work settles. Pass `null` to cache an unauthenticated result for the current request.
 
 ::warning
 `setRequestSession` trusts the supplied value. Authenticate the request and enforce bearer-token audience and scope restrictions before calling it. The helper does not create, update, or clear a Better Auth session cookie.

--- a/docs/public/.well-known/skills/nuxt-better-auth/references/server-auth.md
+++ b/docs/public/.well-known/skills/nuxt-better-auth/references/server-auth.md
@@ -48,7 +48,7 @@ Use `setRequestSession(event, session)` when another server authentication layer
 const claims = await verifyBearerToken(event)
 const session = await resolveCurrentAppSession(claims)
 
-await setRequestSession(event, session)
+setRequestSession(event, session)
 await requireUserSession(event)
 ```
 

--- a/docs/public/.well-known/skills/nuxt-better-auth/references/server-auth.md
+++ b/docs/public/.well-known/skills/nuxt-better-auth/references/server-auth.md
@@ -7,6 +7,7 @@ These helpers are auto-imported inside `server/` in full mode:
 - `serverAuth(event?)`
 - `getUserSession(event)`
 - `getRequestSession(event)`
+- `setRequestSession(event, session)`
 - `refreshSessionCookieCache(event)`
 - `requireUserSession(event, options?)`
 - `createSession(event, userId)`
@@ -19,6 +20,7 @@ These helpers are auto-imported inside `server/` in full mode:
 | Access raw Better Auth APIs | `serverAuth(event)` |
 | Read session if it exists | `getUserSession(event)` |
 | Reuse the same session lookup in one request | `getRequestSession(event)` |
+| Supply a session resolved by trusted server authentication | `setRequestSession(event, session)` |
 | Refresh Better Auth's cached session cookie after server-side updates | `refreshSessionCookieCache(event)` |
 | Enforce auth | `requireUserSession(event, options?)` |
 | Create a session in a custom flow | `createSession(event, userId)` |
@@ -37,6 +39,20 @@ export default defineEventHandler(async (event) => {
 ```
 
 `requireUserSession(event)` throws `401` when unauthenticated and `403` when the user match or custom rule fails.
+
+## Supply a verified request session
+
+Use `setRequestSession(event, session)` when another server authentication layer verifies the request and resolves a complete `AppSession` for existing session helpers to reuse.
+
+```ts
+const claims = await verifyBearerToken(event)
+const session = await resolveCurrentAppSession(claims)
+
+await setRequestSession(event, session)
+await requireUserSession(event)
+```
+
+The supplied value applies only to the current request and does not set a session cookie. Authenticate the value and enforce bearer-token audience and scope restrictions before calling the helper.
 
 ## Refresh cached session data
 

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -343,13 +343,11 @@ export async function getUserSession(event: ServerEvent): Promise<AppSession | n
 export async function setRequestSession(event: ServerEvent, session: AppSession | null): Promise<void> {
   const context = getRequestSessionContext(event)
   const inFlight = context[requestSessionLoadKey]
-  const write = (async () => {
-    if (inFlight)
-      await inFlight.catch(() => undefined)
-
-    context.requestSession = session
+  const write = (inFlight ?? Promise.resolve(null)).catch(() => undefined).then(() => {
+    if (context[requestSessionLoadKey] === write)
+      context.requestSession = session
     return session
-  })()
+  })
 
   context[requestSessionLoadKey] = write
   try {
@@ -364,15 +362,16 @@ export async function setRequestSession(event: ServerEvent, session: AppSession 
 export async function refreshSessionCookieCache(event: ServerEvent): Promise<AppSession | null> {
   const context = getRequestSessionContext(event)
   const inFlight = context[requestSessionLoadKey]
-  if (inFlight)
-    await inFlight.catch(() => undefined)
+  const load = (async () => {
+    if (inFlight)
+      await inFlight.catch(() => undefined)
 
-  delete context.requestSession
-  const load = loadFreshSession(event).then(({ headers, response }) => {
+    delete context.requestSession
+    const { headers, response } = await loadFreshSession(event)
     appendSetCookieHeaders(event, headers)
     context.requestSession = response
     return response
-  })
+  })()
 
   context[requestSessionLoadKey] = load
   try {

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -340,38 +340,29 @@ export async function getUserSession(event: ServerEvent): Promise<AppSession | n
   return loadSession(event)
 }
 
-export async function setRequestSession(event: ServerEvent, session: AppSession | null): Promise<void> {
+export function setRequestSession(event: ServerEvent, session: AppSession | null): void {
   const context = getRequestSessionContext(event)
-  const inFlight = context[requestSessionLoadKey]
-  const write = (inFlight ?? Promise.resolve(null)).catch(() => undefined).then(() => {
-    if (context[requestSessionLoadKey] === write)
-      context.requestSession = session
-    return session
-  })
-
-  context[requestSessionLoadKey] = write
-  try {
-    await write
-  }
-  finally {
-    if (context[requestSessionLoadKey] === write)
-      delete context[requestSessionLoadKey]
-  }
+  context.requestSession = session
+  delete context[requestSessionLoadKey]
 }
 
 export async function refreshSessionCookieCache(event: ServerEvent): Promise<AppSession | null> {
   const context = getRequestSessionContext(event)
   const inFlight = context[requestSessionLoadKey]
-  const load = (async () => {
-    if (inFlight)
-      await inFlight.catch(() => undefined)
+  const load = (inFlight ?? Promise.resolve(null)).catch(() => undefined).then(async () => {
+    if (context[requestSessionLoadKey] !== load)
+      return context.requestSession ?? null
 
     delete context.requestSession
     const { headers, response } = await loadFreshSession(event)
+
+    if (context[requestSessionLoadKey] !== load)
+      return context.requestSession ?? null
+
     appendSetCookieHeaders(event, headers)
     context.requestSession = response
     return response
-  })()
+  })
 
   context[requestSessionLoadKey] = load
   try {

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -306,36 +306,59 @@ function updateRequestHeaders(event: ServerEvent, sessionCookie: string, cleared
 
 export async function getRequestSession(event: ServerEvent): Promise<AppSession | null> {
   const context = getRequestSessionContext(event)
-  if (context.requestSession !== undefined)
-    return context.requestSession
-
   const inFlight = context[requestSessionLoadKey]
   if (inFlight)
     return inFlight
+
+  if (context.requestSession !== undefined)
+    return context.requestSession
 
   const load = loadSession(event)
 
   context[requestSessionLoadKey] = load
   try {
     const session = await load
-    context.requestSession = session
+    if (context[requestSessionLoadKey] === load)
+      context.requestSession = session
     return session
   }
   finally {
-    delete context[requestSessionLoadKey]
+    if (context[requestSessionLoadKey] === load)
+      delete context[requestSessionLoadKey]
   }
 }
 
 export async function getUserSession(event: ServerEvent): Promise<AppSession | null> {
   const context = getRequestSessionContext(event)
-  if (context.requestSession !== undefined)
-    return context.requestSession
-
   const inFlight = context[requestSessionLoadKey]
   if (inFlight)
     return inFlight
 
+  if (context.requestSession !== undefined)
+    return context.requestSession
+
   return loadSession(event)
+}
+
+export async function setRequestSession(event: ServerEvent, session: AppSession | null): Promise<void> {
+  const context = getRequestSessionContext(event)
+  const inFlight = context[requestSessionLoadKey]
+  const write = (async () => {
+    if (inFlight)
+      await inFlight.catch(() => undefined)
+
+    context.requestSession = session
+    return session
+  })()
+
+  context[requestSessionLoadKey] = write
+  try {
+    await write
+  }
+  finally {
+    if (context[requestSessionLoadKey] === write)
+      delete context[requestSessionLoadKey]
+  }
 }
 
 export async function refreshSessionCookieCache(event: ServerEvent): Promise<AppSession | null> {

--- a/test/get-request-session.test.ts
+++ b/test/get-request-session.test.ts
@@ -370,6 +370,42 @@ describe('setRequestSession', () => {
     await expect(getRequestSession(event)).resolves.toBe(suppliedSession)
   })
 
+  it('does not restore the supplied session after a newer session cookie is set', async () => {
+    let resolveSession: ((value: unknown) => void) | undefined
+    const staleSession = {
+      user: { id: 'cookie-user' },
+      session: { id: 'cookie-session' },
+    }
+    const suppliedSession = {
+      user: { id: 'bearer-user' },
+      session: { id: 'bearer-session' },
+    }
+    const cookieSession = {
+      user: { id: 'new-cookie-user' },
+      session: { id: 'new-cookie-session' },
+    }
+    getSessionMock
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveSession = resolve
+      }))
+      .mockResolvedValueOnce(cookieSession)
+
+    const { getRequestSession, setRequestSession, setSessionCookie } = await import('../src/runtime/server/utils/session')
+    const event = createEvent()
+
+    const earlierLookup = getRequestSession(event)
+    const setting = setRequestSession(event, suppliedSession as any)
+    await setSessionCookie(event, 'session-token')
+
+    resolveSession?.(staleSession)
+
+    await expect(earlierLookup).resolves.toEqual(staleSession)
+    await expect(setting).resolves.toBeUndefined()
+    await expect(getRequestSession(event)).resolves.toBe(cookieSession)
+    expect(event.context.requestSession).toBe(cookieSession)
+    expect(getSessionMock).toHaveBeenCalledTimes(2)
+  })
+
   it('supports events without a context object', async () => {
     const suppliedSession = {
       user: { id: 'bearer-user' },
@@ -429,6 +465,43 @@ describe('refreshSessionCookieCache', () => {
       sessionDataCookie,
       sessionTokenCookie,
     ])
+  })
+
+  it('cannot overwrite a request session supplied after the refresh starts', async () => {
+    let resolveSession: ((value: unknown) => void) | undefined
+    const staleSession = {
+      user: { id: 'stale-cookie-user' },
+      session: { id: 'stale-cookie-session' },
+    }
+    const freshSession = {
+      user: { id: 'fresh-cookie-user' },
+      session: { id: 'fresh-cookie-session' },
+    }
+    const suppliedSession = {
+      user: { id: 'bearer-user' },
+      session: { id: 'bearer-session' },
+    }
+    getSessionMock
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveSession = resolve
+      }))
+      .mockResolvedValueOnce({ headers: new Headers(), response: freshSession })
+
+    const { getRequestSession, refreshSessionCookieCache, setRequestSession } = await import('../src/runtime/server/utils/session')
+    const event = createEvent()
+
+    const earlierLookup = getRequestSession(event)
+    const refreshing = refreshSessionCookieCache(event)
+    const setting = setRequestSession(event, suppliedSession as any)
+
+    resolveSession?.(staleSession)
+
+    await expect(earlierLookup).resolves.toEqual(staleSession)
+    await expect(refreshing).resolves.toEqual(freshSession)
+    await expect(setting).resolves.toBeUndefined()
+    await expect(getRequestSession(event)).resolves.toBe(suppliedSession)
+    expect(event.context.requestSession).toBe(suppliedSession)
+    expect(getSessionMock).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/test/get-request-session.test.ts
+++ b/test/get-request-session.test.ts
@@ -286,7 +286,7 @@ describe('setRequestSession', () => {
     const { getRequestSession, getUserSession, requireUserSession, setRequestSession } = await import('../src/runtime/server/utils/session')
     const event = createEvent()
 
-    await setRequestSession(event, suppliedSession as any)
+    setRequestSession(event, suppliedSession as any)
 
     await expect(getRequestSession(event)).resolves.toBe(suppliedSession)
     await expect(getUserSession(event)).resolves.toBe(suppliedSession)
@@ -300,7 +300,7 @@ describe('setRequestSession', () => {
     const { getRequestSession, getUserSession, requireUserSession, setRequestSession } = await import('../src/runtime/server/utils/session')
     const event = createEvent()
 
-    await setRequestSession(event, null)
+    setRequestSession(event, null)
 
     await expect(getRequestSession(event)).resolves.toBeNull()
     await expect(getUserSession(event)).resolves.toBeNull()
@@ -329,7 +329,9 @@ describe('setRequestSession', () => {
     const event = createEvent()
 
     const earlierLookup = getRequestSession(event)
-    const setting = setRequestSession(event, suppliedSession as any)
+    setRequestSession(event, suppliedSession as any)
+    expect(event.context.requestSession).toBe(suppliedSession)
+
     const laterRequestLookup = getRequestSession(event)
     const laterUserLookup = getUserSession(event)
     const laterRequiredLookup = requireUserSession(event)
@@ -337,7 +339,6 @@ describe('setRequestSession', () => {
     resolveSession?.(staleSession)
 
     await expect(earlierLookup).resolves.toEqual(staleSession)
-    await expect(setting).resolves.toBeUndefined()
     await expect(laterRequestLookup).resolves.toBe(suppliedSession)
     await expect(laterUserLookup).resolves.toBe(suppliedSession)
     await expect(laterRequiredLookup).resolves.toBe(suppliedSession)
@@ -359,13 +360,12 @@ describe('setRequestSession', () => {
     const event = createEvent()
 
     const earlierLookup = getRequestSession(event)
-    const setting = setRequestSession(event, suppliedSession as any)
+    setRequestSession(event, suppliedSession as any)
     const laterLookup = getRequestSession(event)
 
     rejectSession?.(new Error('session lookup failed'))
 
     await expect(earlierLookup).rejects.toThrow('session lookup failed')
-    await expect(setting).resolves.toBeUndefined()
     await expect(laterLookup).resolves.toBe(suppliedSession)
     await expect(getRequestSession(event)).resolves.toBe(suppliedSession)
   })
@@ -394,13 +394,12 @@ describe('setRequestSession', () => {
     const event = createEvent()
 
     const earlierLookup = getRequestSession(event)
-    const setting = setRequestSession(event, suppliedSession as any)
+    setRequestSession(event, suppliedSession as any)
     await setSessionCookie(event, 'session-token')
 
     resolveSession?.(staleSession)
 
     await expect(earlierLookup).resolves.toEqual(staleSession)
-    await expect(setting).resolves.toBeUndefined()
     await expect(getRequestSession(event)).resolves.toBe(cookieSession)
     expect(event.context.requestSession).toBe(cookieSession)
     expect(getSessionMock).toHaveBeenCalledTimes(2)
@@ -414,7 +413,7 @@ describe('setRequestSession', () => {
     const { getRequestSession, setRequestSession } = await import('../src/runtime/server/utils/session')
     const event = createEventWithoutContext()
 
-    await setRequestSession(event, suppliedSession as any)
+    setRequestSession(event, suppliedSession as any)
 
     await expect(getRequestSession(event)).resolves.toBe(suppliedSession)
     expect(getSessionMock).not.toHaveBeenCalled()
@@ -468,11 +467,7 @@ describe('refreshSessionCookieCache', () => {
   })
 
   it('cannot overwrite a request session supplied after the refresh starts', async () => {
-    let resolveSession: ((value: unknown) => void) | undefined
-    const staleSession = {
-      user: { id: 'stale-cookie-user' },
-      session: { id: 'stale-cookie-session' },
-    }
+    let resolveRefresh: ((value: unknown) => void) | undefined
     const freshSession = {
       user: { id: 'fresh-cookie-user' },
       session: { id: 'fresh-cookie-session' },
@@ -481,27 +476,59 @@ describe('refreshSessionCookieCache', () => {
       user: { id: 'bearer-user' },
       session: { id: 'bearer-session' },
     }
-    getSessionMock
-      .mockImplementationOnce(() => new Promise((resolve) => {
-        resolveSession = resolve
-      }))
-      .mockResolvedValueOnce({ headers: new Headers(), response: freshSession })
+    const staleCacheCookie = 'better-auth.session_data=stale; Path=/; HttpOnly'
+    const staleHeaders = new Headers({ 'set-cookie': staleCacheCookie })
+    getSessionMock.mockImplementation(() => new Promise((resolve) => {
+      resolveRefresh = resolve
+    }))
 
     const { getRequestSession, refreshSessionCookieCache, setRequestSession } = await import('../src/runtime/server/utils/session')
     const event = createEvent()
 
-    const earlierLookup = getRequestSession(event)
     const refreshing = refreshSessionCookieCache(event)
-    const setting = setRequestSession(event, suppliedSession as any)
+    await vi.waitFor(() => expect(getSessionMock).toHaveBeenCalledOnce())
 
-    resolveSession?.(staleSession)
+    setRequestSession(event, suppliedSession as any)
+    resolveRefresh?.({ headers: staleHeaders, response: freshSession })
 
-    await expect(earlierLookup).resolves.toEqual(staleSession)
-    await expect(refreshing).resolves.toEqual(freshSession)
-    await expect(setting).resolves.toBeUndefined()
+    await expect(refreshing).resolves.toBe(suppliedSession)
     await expect(getRequestSession(event)).resolves.toBe(suppliedSession)
     expect(event.context.requestSession).toBe(suppliedSession)
+    expect(getSessionMock).toHaveBeenCalledTimes(1)
+    expect(event.node.res.getHeader('set-cookie')).toBeUndefined()
+  })
+
+  it('does not let an older refresh overwrite a newer session cookie', async () => {
+    let resolveRefresh: ((value: unknown) => void) | undefined
+    const staleSession = {
+      user: { id: 'stale-cookie-user' },
+      session: { id: 'stale-cookie-session' },
+    }
+    const newCookieSession = {
+      user: { id: 'new-cookie-user' },
+      session: { id: 'new-cookie-session' },
+    }
+    const staleCacheCookie = 'better-auth.session_data=stale; Path=/; HttpOnly'
+    const staleHeaders = new Headers({ 'set-cookie': staleCacheCookie })
+    getSessionMock
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveRefresh = resolve
+      }))
+      .mockResolvedValueOnce(newCookieSession)
+
+    const { getRequestSession, refreshSessionCookieCache, setSessionCookie } = await import('../src/runtime/server/utils/session')
+    const event = createEvent()
+
+    const refreshing = refreshSessionCookieCache(event)
+    await setSessionCookie(event, 'new-session-token')
+
+    resolveRefresh?.({ headers: staleHeaders, response: staleSession })
+
+    await expect(refreshing).resolves.toBeNull()
+    await expect(getRequestSession(event)).resolves.toBe(newCookieSession)
+    expect(event.context.requestSession).toBe(newCookieSession)
     expect(getSessionMock).toHaveBeenCalledTimes(2)
+    expect(event.node.res.getHeader('set-cookie')).not.toContain(staleCacheCookie)
   })
 })
 

--- a/test/get-request-session.test.ts
+++ b/test/get-request-session.test.ts
@@ -271,6 +271,121 @@ describe('getUserSession', () => {
   })
 })
 
+describe('setRequestSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getSessionMock.mockReset()
+    createSessionMock.mockReset()
+  })
+
+  it('makes a supplied session authoritative for downstream helpers without setting cookies', async () => {
+    const suppliedSession = {
+      user: { id: 'bearer-user', role: 'member' },
+      session: { id: 'bearer-session' },
+    }
+    const { getRequestSession, getUserSession, requireUserSession, setRequestSession } = await import('../src/runtime/server/utils/session')
+    const event = createEvent()
+
+    await setRequestSession(event, suppliedSession as any)
+
+    await expect(getRequestSession(event)).resolves.toBe(suppliedSession)
+    await expect(getUserSession(event)).resolves.toBe(suppliedSession)
+    await expect(requireUserSession(event)).resolves.toBe(suppliedSession)
+    expect(getSessionMock).not.toHaveBeenCalled()
+    expect(event.context.requestSession).toBe(suppliedSession)
+    expect(event.node.res.getHeader('set-cookie')).toBeUndefined()
+  })
+
+  it('treats null as an authoritative request session value', async () => {
+    const { getRequestSession, getUserSession, requireUserSession, setRequestSession } = await import('../src/runtime/server/utils/session')
+    const event = createEvent()
+
+    await setRequestSession(event, null)
+
+    await expect(getRequestSession(event)).resolves.toBeNull()
+    await expect(getUserSession(event)).resolves.toBeNull()
+    await expect(requireUserSession(event)).rejects.toMatchObject({
+      statusCode: 401,
+      statusMessage: 'Authentication required',
+    })
+    expect(getSessionMock).not.toHaveBeenCalled()
+  })
+
+  it('takes ownership from an earlier in-flight session lookup', async () => {
+    let resolveSession: ((value: unknown) => void) | undefined
+    getSessionMock.mockImplementation(() => new Promise((resolve) => {
+      resolveSession = resolve
+    }))
+
+    const staleSession = {
+      user: { id: 'cookie-user' },
+      session: { id: 'cookie-session' },
+    }
+    const suppliedSession = {
+      user: { id: 'bearer-user' },
+      session: { id: 'bearer-session' },
+    }
+    const { getRequestSession, getUserSession, requireUserSession, setRequestSession } = await import('../src/runtime/server/utils/session')
+    const event = createEvent()
+
+    const earlierLookup = getRequestSession(event)
+    const setting = setRequestSession(event, suppliedSession as any)
+    const laterRequestLookup = getRequestSession(event)
+    const laterUserLookup = getUserSession(event)
+    const laterRequiredLookup = requireUserSession(event)
+
+    resolveSession?.(staleSession)
+
+    await expect(earlierLookup).resolves.toEqual(staleSession)
+    await expect(setting).resolves.toBeUndefined()
+    await expect(laterRequestLookup).resolves.toBe(suppliedSession)
+    await expect(laterUserLookup).resolves.toBe(suppliedSession)
+    await expect(laterRequiredLookup).resolves.toBe(suppliedSession)
+    await expect(getRequestSession(event)).resolves.toBe(suppliedSession)
+    expect(event.context.requestSession).toBe(suppliedSession)
+  })
+
+  it('supplies the session when an earlier lookup rejects', async () => {
+    let rejectSession: ((reason?: unknown) => void) | undefined
+    getSessionMock.mockImplementation(() => new Promise((_resolve, reject) => {
+      rejectSession = reject
+    }))
+
+    const suppliedSession = {
+      user: { id: 'bearer-user' },
+      session: { id: 'bearer-session' },
+    }
+    const { getRequestSession, setRequestSession } = await import('../src/runtime/server/utils/session')
+    const event = createEvent()
+
+    const earlierLookup = getRequestSession(event)
+    const setting = setRequestSession(event, suppliedSession as any)
+    const laterLookup = getRequestSession(event)
+
+    rejectSession?.(new Error('session lookup failed'))
+
+    await expect(earlierLookup).rejects.toThrow('session lookup failed')
+    await expect(setting).resolves.toBeUndefined()
+    await expect(laterLookup).resolves.toBe(suppliedSession)
+    await expect(getRequestSession(event)).resolves.toBe(suppliedSession)
+  })
+
+  it('supports events without a context object', async () => {
+    const suppliedSession = {
+      user: { id: 'bearer-user' },
+      session: { id: 'bearer-session' },
+    }
+    const { getRequestSession, setRequestSession } = await import('../src/runtime/server/utils/session')
+    const event = createEventWithoutContext()
+
+    await setRequestSession(event, suppliedSession as any)
+
+    await expect(getRequestSession(event)).resolves.toBe(suppliedSession)
+    expect(getSessionMock).not.toHaveBeenCalled()
+    expect('context' in event).toBe(false)
+  })
+})
+
 describe('refreshSessionCookieCache', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/test/require-user-session-typing.test.ts
+++ b/test/require-user-session-typing.test.ts
@@ -100,8 +100,8 @@ export async function check(event: H3Event) {
     rule: ({ user }) => Boolean(user.address),
   })
 
-  await setRequestSession(event, session)
-  await setRequestSession(event, null)
+  setRequestSession(event, session)
+  setRequestSession(event, null)
 
   return session.user.address
 }

--- a/test/require-user-session-typing.test.ts
+++ b/test/require-user-session-typing.test.ts
@@ -92,13 +92,16 @@ export type UserMatch<T> = { [K in keyof T]?: T[K] | T[K][] }
 `)
 
       writeFileSync(join(testDir, 'check.ts'), `import type { H3Event } from 'h3'
-import { requireUserSession } from './runtime/server/utils/session'
+import { requireUserSession, setRequestSession } from './runtime/server/utils/session'
 
 export async function check(event: H3Event) {
   const session = await requireUserSession(event, {
     user: { address: 'NQ12...' },
     rule: ({ user }) => Boolean(user.address),
   })
+
+  await setRequestSession(event, session)
+  await setRequestSession(event, null)
 
   return session.user.address
 }


### PR DESCRIPTION
Bearer-authenticated H3 requests can resolve a complete `AppSession`, but the module only exposed readers for its request cache. Integrations therefore had to assign `event.context.requestSession` directly, which also allowed an older in-flight cookie-session lookup to overwrite the supplied value.

This adds the server-only `setRequestSession(event, session)` helper so trusted authentication middleware can pass an `AppSession | null` to existing `getRequestSession`, `getUserSession`, and `requireUserSession` consumers.

## Request-session contract

- The explicit value becomes authoritative for the current request without creating, updating, or clearing a session cookie.
- When a lookup is already running, later session readers join the setter while it waits. The older lookup only writes or clears state while it still owns the in-flight marker.
- `null` is an authoritative negative cache value.
- Rejected earlier lookups do not prevent trusted middleware from supplying its resolved session.
- Context-less/narrowed H3 events continue through the existing request-session fallback.

The helper intentionally does not verify bearer tokens or interpret claims. The API reference requires callers to authenticate the value and enforce OAuth audience and scope restrictions before injection.

Closes #408

## Verification

- `corepack pnpm exec vitest run test/get-request-session.test.ts test/require-user-session-typing.test.ts test/public-skill.test.ts` — 24 tests passed on `19c4f83`
- Full `corepack pnpm test` with a temporary Corepack pnpm shim — 317 tests passed
- `corepack pnpm lint`
- `corepack pnpm typecheck`
- `corepack pnpm build:docs`
- `git diff --check`
