### PR TITLE
fix(runtime): handle SSR auth mutation origins

### DIFF
--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -216,7 +216,7 @@ During SSR, `updateUser` only patches local state since no client is available.
 
 Returns Nuxt's request-scoped fetch function. On SSR it preserves request context (including cookies); on client it behaves like regular fetch.
 
-During request SSR in full mode, local Better Auth mutations also receive the current request origin when the browser did not provide `Origin`, `Referer`, or known non-same-origin provenance. Caller headers are preserved across object, tuple, and `Headers` inputs. Safe methods (`GET`, `HEAD`, and `OPTIONS`), external requests, and `clientOnly` mode are unchanged.
+During request SSR in full mode, local Better Auth mutations also receive the current request origin unless the caller explicitly provides `Origin`. Caller headers are preserved across object, tuple, and `Headers` inputs. Safe methods (`GET`, `HEAD`, and `OPTIONS`), external requests, and `clientOnly` mode are unchanged.
 
 `useAuthRequestFetch()` defaults to `GET`. For endpoints that only allow `POST` (or another method), pass `method` explicitly to preserve response type inference.
 

--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -216,7 +216,7 @@ During SSR, `updateUser` only patches local state since no client is available.
 
 Returns Nuxt's request-scoped fetch function. On SSR it preserves request context (including cookies); on client it behaves like regular fetch.
 
-During request SSR in full mode, local Better Auth mutations also receive the current request origin unless the caller explicitly provides `Origin`. Caller headers are preserved across object, tuple, and `Headers` inputs. Safe methods (`GET`, `HEAD`, and `OPTIONS`), external requests, and `clientOnly` mode are unchanged.
+During request SSR in full mode, local Better Auth mutations receive the current request origin only when Fetch Metadata identifies the incoming request as `same-origin` and neither the caller nor the incoming request provides `Origin` or `Referer`. Known `same-site`, `cross-site`, `none`, or missing provenance is not upgraded to same-origin. Trusted server code can still provide `Origin` explicitly when it intentionally attests a request. Caller headers are preserved across object, tuple, and `Headers` inputs. Safe methods (`GET`, `HEAD`, and `OPTIONS`), external requests, and `clientOnly` mode are unchanged.
 
 `useAuthRequestFetch()` defaults to `GET`. For endpoints that only allow `POST` (or another method), pass `method` explicitly to preserve response type inference.
 

--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -216,6 +216,8 @@ During SSR, `updateUser` only patches local state since no client is available.
 
 Returns Nuxt's request-scoped fetch function. On SSR it preserves request context (including cookies); on client it behaves like regular fetch.
 
+During request SSR in full mode, local Better Auth mutations also receive the current request origin when the browser did not provide `Origin`, `Referer`, or known non-same-origin provenance. Caller headers are preserved across object, tuple, and `Headers` inputs. Safe methods (`GET`, `HEAD`, and `OPTIONS`), external requests, and `clientOnly` mode are unchanged.
+
 `useAuthRequestFetch()` defaults to `GET`. For endpoints that only allow `POST` (or another method), pass `method` explicitly to preserve response type inference.
 
 When endpoint typing is enabled, `useFetch('/api/auth/...')` and `useLazyFetch('/api/auth/...')` infer payloads directly from your Better Auth config:

--- a/src/runtime/app/composables/useAuthRequestFetch.ts
+++ b/src/runtime/app/composables/useAuthRequestFetch.ts
@@ -1,7 +1,43 @@
 import type { AuthApiEndpointMethod, AuthApiEndpointPath, AuthApiEndpointResponse } from '#nuxt-better-auth'
-import { useRequestFetch } from '#imports'
+import { useRequestEvent, useRequestFetch, useRequestHeaders, useRequestURL, useRuntimeConfig } from '#imports'
 
-type RequestFetchOptions = NonNullable<Parameters<ReturnType<typeof useRequestFetch>>[1]>
+type RequestFetch = ReturnType<typeof useRequestFetch>
+type RequestFetchRequest = Parameters<RequestFetch>[0]
+type RequestFetchOptions = NonNullable<Parameters<RequestFetch>[1]>
+
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
+
+function isLocalAuthMutation(request: RequestFetchRequest, options?: RequestFetchOptions): boolean {
+  if (typeof request !== 'string')
+    return false
+
+  const pathname = request.split(/[?#]/, 1)[0]
+  if (pathname !== '/api/auth' && !pathname?.startsWith('/api/auth/'))
+    return false
+
+  if (options?.baseURL && options.baseURL !== '/')
+    return false
+
+  const method = String(options?.method ?? 'GET').toUpperCase()
+  return !SAFE_METHODS.has(method)
+}
+
+function hasOriginProvenance(headers: Headers): boolean {
+  return headers.has('origin') || headers.has('referer')
+}
+
+function hasKnownNonSameOriginProvenance(headers: Headers): boolean {
+  const fetchSite = headers.get('sec-fetch-site')?.toLowerCase()
+  return fetchSite === 'cross-site' || fetchSite === 'same-site'
+}
+
+function headersToRecord(headers: Headers): Record<string, string> {
+  const record: Record<string, string> = {}
+  headers.forEach((value, key) => {
+    record[key] = value
+  })
+  return record
+}
 
 type AuthRequestFetchExtractedMethod<Options> = Options extends undefined
   ? 'get'
@@ -26,5 +62,41 @@ type AuthRequestFetch = <
 ) => Promise<AuthApiEndpointResponse<Path, Extract<AuthRequestFetchResolvedMethod<Path, Options>, AuthApiEndpointMethod<Path>>>>
 
 export function useAuthRequestFetch() {
-  return useRequestFetch() as AuthRequestFetch & ReturnType<typeof useRequestFetch>
+  const requestFetch = useRequestFetch()
+  const requestEvent = useRequestEvent()
+  if (!requestEvent)
+    return requestFetch as AuthRequestFetch & RequestFetch
+
+  const runtimeConfig = useRuntimeConfig()
+  const authConfig = runtimeConfig.public.auth as { clientOnly?: boolean } | undefined
+  if (authConfig?.clientOnly)
+    return requestFetch as AuthRequestFetch & RequestFetch
+
+  const requestOrigin = useRequestURL().origin
+  const inboundHeaders = new Headers(useRequestHeaders(['origin', 'referer', 'sec-fetch-site']) as HeadersInit)
+
+  return ((request: RequestFetchRequest, options?: RequestFetchOptions) => {
+    if (!isLocalAuthMutation(request, options))
+      return requestFetch(request, options)
+
+    const headers = new Headers(options?.headers)
+    if (
+      !hasOriginProvenance(headers)
+      && !hasOriginProvenance(inboundHeaders)
+      && !hasKnownNonSameOriginProvenance(inboundHeaders)
+    ) {
+      headers.set('origin', requestOrigin)
+    }
+
+    const normalizedHeaders = headersToRecord(headers)
+    if (!options?.headers && Object.keys(normalizedHeaders).length === 0)
+      return requestFetch(request, options)
+
+    return requestFetch(request, {
+      ...options,
+      // H3 1.x spreads request option headers as an object, so normalize iterable
+      // HeadersInit forms back to an enumerable record before crossing that boundary.
+      headers: normalizedHeaders,
+    })
+  }) as AuthRequestFetch & RequestFetch
 }

--- a/src/runtime/app/composables/useAuthRequestFetch.ts
+++ b/src/runtime/app/composables/useAuthRequestFetch.ts
@@ -1,5 +1,5 @@
 import type { AuthApiEndpointMethod, AuthApiEndpointPath, AuthApiEndpointResponse } from '#nuxt-better-auth'
-import { useRequestEvent, useRequestFetch, useRequestHeaders, useRequestURL, useRuntimeConfig } from '#imports'
+import { useRequestEvent, useRequestFetch, useRequestURL, useRuntimeConfig } from '#imports'
 
 type RequestFetch = ReturnType<typeof useRequestFetch>
 type RequestFetchRequest = Parameters<RequestFetch>[0]
@@ -20,15 +20,6 @@ function isLocalAuthMutation(request: RequestFetchRequest, options?: RequestFetc
 
   const method = String(options?.method ?? 'GET').toUpperCase()
   return !SAFE_METHODS.has(method)
-}
-
-function hasOriginProvenance(headers: Headers): boolean {
-  return headers.has('origin') || headers.has('referer')
-}
-
-function hasKnownNonSameOriginProvenance(headers: Headers): boolean {
-  const fetchSite = headers.get('sec-fetch-site')?.toLowerCase()
-  return fetchSite === 'cross-site' || fetchSite === 'same-site'
 }
 
 function headersToRecord(headers: Headers): Record<string, string> {
@@ -73,18 +64,13 @@ export function useAuthRequestFetch() {
     return requestFetch as AuthRequestFetch & RequestFetch
 
   const requestOrigin = useRequestURL().origin
-  const inboundHeaders = new Headers(useRequestHeaders(['origin', 'referer', 'sec-fetch-site']) as HeadersInit)
 
   return ((request: RequestFetchRequest, options?: RequestFetchOptions) => {
     if (!isLocalAuthMutation(request, options))
       return requestFetch(request, options)
 
     const headers = new Headers(options?.headers)
-    if (
-      !hasOriginProvenance(headers)
-      && !hasOriginProvenance(inboundHeaders)
-      && !hasKnownNonSameOriginProvenance(inboundHeaders)
-    ) {
+    if (!headers.has('origin')) {
       headers.set('origin', requestOrigin)
     }
 

--- a/src/runtime/app/composables/useAuthRequestFetch.ts
+++ b/src/runtime/app/composables/useAuthRequestFetch.ts
@@ -1,5 +1,5 @@
 import type { AuthApiEndpointMethod, AuthApiEndpointPath, AuthApiEndpointResponse } from '#nuxt-better-auth'
-import { useRequestEvent, useRequestFetch, useRequestURL, useRuntimeConfig } from '#imports'
+import { useRequestEvent, useRequestFetch, useRequestHeader, useRequestURL, useRuntimeConfig } from '#imports'
 
 type RequestFetch = ReturnType<typeof useRequestFetch>
 type RequestFetchRequest = Parameters<RequestFetch>[0]
@@ -28,6 +28,20 @@ function headersToRecord(headers: Headers): Record<string, string> {
     record[key] = value
   })
   return record
+}
+
+function canAttestSameOrigin(headers: Headers, incoming: { origin?: string | null, referer?: string | null, fetchSite?: string | null }): boolean {
+  if (
+    headers.has('origin')
+    || headers.has('referer')
+    || headers.has('sec-fetch-site')
+    || incoming.origin != null
+    || incoming.referer != null
+  ) {
+    return false
+  }
+
+  return incoming.fetchSite?.toLowerCase() === 'same-origin'
 }
 
 type AuthRequestFetchExtractedMethod<Options> = Options extends undefined
@@ -64,13 +78,18 @@ export function useAuthRequestFetch() {
     return requestFetch as AuthRequestFetch & RequestFetch
 
   const requestOrigin = useRequestURL().origin
+  const incomingProvenance = {
+    origin: useRequestHeader('origin'),
+    referer: useRequestHeader('referer'),
+    fetchSite: useRequestHeader('sec-fetch-site'),
+  }
 
   return ((request: RequestFetchRequest, options?: RequestFetchOptions) => {
     if (!isLocalAuthMutation(request, options))
       return requestFetch(request, options)
 
     const headers = new Headers(options?.headers)
-    if (!headers.has('origin')) {
+    if (canAttestSameOrigin(headers, incomingProvenance)) {
       headers.set('origin', requestOrigin)
     }
 

--- a/test/cases/core-auth/app/pages/ssr-auth-request.vue
+++ b/test/cases/core-auth/app/pages/ssr-auth-request.vue
@@ -2,7 +2,9 @@
 const result = ref('pending')
 
 try {
-  const requestFetch = useAuthRequestFetch()
+  const requestFetch = useRequestURL().searchParams.has('raw')
+    ? useRequestFetch()
+    : useAuthRequestFetch()
   const response = await requestFetch('/api/auth/test/ssr-origin', {
     method: 'POST',
     headers: new Headers({ 'x-request-shape': 'headers' }),

--- a/test/cases/core-auth/app/pages/ssr-auth-request.vue
+++ b/test/cases/core-auth/app/pages/ssr-auth-request.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+const result = ref('pending')
+
+try {
+  const requestFetch = useAuthRequestFetch()
+  const response = await requestFetch('/api/auth/test/ssr-origin', {
+    method: 'POST',
+    headers: new Headers({ 'x-request-shape': 'headers' }),
+    body: {},
+  })
+  result.value = `origin=${response.origin};header=${response.header}`
+}
+catch (error) {
+  const fetchError = error as { data?: { message?: string }, message?: string }
+  result.value = `rejected:${fetchError.data?.message ?? fetchError.message ?? 'unknown'}`
+}
+</script>
+
+<template>
+  <p id="ssr-auth-request-result">
+    {{ result }}
+  </p>
+</template>

--- a/test/cases/core-auth/server/auth.config.ts
+++ b/test/cases/core-auth/server/auth.config.ts
@@ -16,6 +16,7 @@ function ssrOriginProbe() {
 }
 
 export default defineServerAuth({
+  advanced: { disableOriginCheck: false },
   appName: 'Test App',
   emailAndPassword: { enabled: true },
   plugins: [ssrOriginProbe()] as const,

--- a/test/cases/core-auth/server/auth.config.ts
+++ b/test/cases/core-auth/server/auth.config.ts
@@ -1,6 +1,26 @@
+import { createAuthEndpoint } from 'better-auth/api'
 import { defineServerAuth } from '../../../../src/runtime/config'
+
+function ssrOriginProbe() {
+  return {
+    id: 'ssr-origin-probe',
+    endpoints: {
+      ssrOrigin: createAuthEndpoint('/test/ssr-origin', { method: 'POST' }, async (ctx) => {
+        return {
+          origin: ctx.request?.headers.get('origin') ?? null,
+          header: ctx.request?.headers.get('x-request-shape') ?? null,
+        }
+      }),
+    },
+  } as const
+}
 
 export default defineServerAuth({
   appName: 'Test App',
   emailAndPassword: { enabled: true },
+  plugins: [ssrOriginProbe()] as const,
+  trustedOrigins: (request) => {
+    const host = request?.headers.get('host')
+    return request && host ? [`${new URL(request.url).protocol}//${host}`] : []
+  },
 })

--- a/test/cases/use-fetch-endpoints-type-inference/imports-shim.d.ts
+++ b/test/cases/use-fetch-endpoints-type-inference/imports-shim.d.ts
@@ -1,3 +1,7 @@
 declare module '#imports' {
+  export function useRequestEvent(): object | undefined
   export function useRequestFetch(): import('nitropack/types').H3Event$Fetch | typeof global.$fetch
+  export function useRequestHeaders(include?: string[]): Record<string, string>
+  export function useRequestURL(): URL
+  export function useRuntimeConfig(): { public: { auth?: { clientOnly?: boolean } } }
 }

--- a/test/cases/use-fetch-endpoints-type-inference/imports-shim.d.ts
+++ b/test/cases/use-fetch-endpoints-type-inference/imports-shim.d.ts
@@ -1,4 +1,5 @@
 declare module '#imports' {
+  export function useRequestHeader(name: string): string | null | undefined
   export function useRequestEvent(): object | undefined
   export function useRequestFetch(): import('nitropack/types').H3Event$Fetch | typeof global.$fetch
   export function useRequestURL(): URL

--- a/test/cases/use-fetch-endpoints-type-inference/imports-shim.d.ts
+++ b/test/cases/use-fetch-endpoints-type-inference/imports-shim.d.ts
@@ -1,7 +1,6 @@
 declare module '#imports' {
   export function useRequestEvent(): object | undefined
   export function useRequestFetch(): import('nitropack/types').H3Event$Fetch | typeof global.$fetch
-  export function useRequestHeaders(include?: string[]): Record<string, string>
   export function useRequestURL(): URL
   export function useRuntimeConfig(): { public: { auth?: { clientOnly?: boolean } } }
 }

--- a/test/layer-default-configs.test.ts
+++ b/test/layer-default-configs.test.ts
@@ -16,7 +16,10 @@ describe('layer-aware default auth config discovery', async () => {
   it('uses auth routes backed by the extended layer default configs', async () => {
     const response = await fetch(url('/api/auth/sign-up/email'), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'Origin': new URL(url('/')).origin,
+      },
       body: JSON.stringify({
         email: `layer-${Date.now()}@example.com`,
         password: 'testpass123',

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -36,7 +36,15 @@ describe('nuxt-better-auth module', async () => {
       expect(html).toContain(`origin=${requestOrigin};header=headers`)
     })
 
-    it('does not replace cross-site browser provenance during SSR', async () => {
+    it('rejects a cookie-bearing SSR mutation without the origin adapter', async () => {
+      const response = await fetch(url('/ssr-auth-request?raw'), {
+        headers: { cookie: 'ssr-origin-probe=1' },
+      })
+      expect(response.status).toBe(200)
+      expect(await response.text()).toContain('rejected:Missing or null Origin')
+    })
+
+    it('uses the current origin for an SSR mutation entered from another site', async () => {
       const response = await fetch(url('/ssr-auth-request'), {
         headers: {
           'cookie': 'ssr-origin-probe=1',
@@ -46,7 +54,8 @@ describe('nuxt-better-auth module', async () => {
         },
       })
       expect(response.status).toBe(200)
-      expect(await response.text()).toContain('origin=https://outside.example;header=headers')
+      const requestOrigin = new URL(url('/')).origin
+      expect(await response.text()).toContain(`origin=${requestOrigin};header=headers`)
     })
   })
 
@@ -113,7 +122,10 @@ describe('nuxt-better-auth module', async () => {
       // Sign up
       const signupRes = await fetch(url('/api/auth/sign-up/email'), {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'Origin': new URL(url('/')).origin,
+        },
         body: JSON.stringify(testUser),
       })
       expect(signupRes.status).toBe(200)

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -27,7 +27,10 @@ describe('nuxt-better-auth module', async () => {
 
     it('adds the same-origin header to a cookie-bearing Better Auth mutation during SSR', async () => {
       const response = await fetch(url('/ssr-auth-request'), {
-        headers: { cookie: 'ssr-origin-probe=1' },
+        headers: {
+          'cookie': 'ssr-origin-probe=1',
+          'sec-fetch-site': 'same-origin',
+        },
       })
       expect(response.status).toBe(200)
 
@@ -44,7 +47,7 @@ describe('nuxt-better-auth module', async () => {
       expect(await response.text()).toContain('rejected:Missing or null Origin')
     })
 
-    it('uses the current origin for an SSR mutation entered from another site', async () => {
+    it('does not attest an SSR mutation entered from another site', async () => {
       const response = await fetch(url('/ssr-auth-request'), {
         headers: {
           'cookie': 'ssr-origin-probe=1',
@@ -54,8 +57,7 @@ describe('nuxt-better-auth module', async () => {
         },
       })
       expect(response.status).toBe(200)
-      const requestOrigin = new URL(url('/')).origin
-      expect(await response.text()).toContain(`origin=${requestOrigin};header=headers`)
+      expect(await response.text()).toContain('rejected:Invalid origin')
     })
   })
 

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -24,6 +24,30 @@ describe('nuxt-better-auth module', async () => {
       expect(response.useDatabase).toBe(true)
       expect(response.databaseProvider).toBe('nuxthub')
     })
+
+    it('adds the same-origin header to a cookie-bearing Better Auth mutation during SSR', async () => {
+      const response = await fetch(url('/ssr-auth-request'), {
+        headers: { cookie: 'ssr-origin-probe=1' },
+      })
+      expect(response.status).toBe(200)
+
+      const html = await response.text()
+      const requestOrigin = new URL(url('/')).origin
+      expect(html).toContain(`origin=${requestOrigin};header=headers`)
+    })
+
+    it('does not replace cross-site browser provenance during SSR', async () => {
+      const response = await fetch(url('/ssr-auth-request'), {
+        headers: {
+          'cookie': 'ssr-origin-probe=1',
+          'origin': 'https://outside.example',
+          'referer': 'https://outside.example/page',
+          'sec-fetch-site': 'cross-site',
+        },
+      })
+      expect(response.status).toBe(200)
+      expect(await response.text()).toContain('origin=https://outside.example;header=headers')
+    })
   })
 
   describe('route protection', () => {

--- a/test/redirects-option.test.ts
+++ b/test/redirects-option.test.ts
@@ -18,7 +18,10 @@ describe('auth.redirects option', async () => {
 
     const signupRes = await fetch(url('/api/auth/sign-up/email'), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'Origin': new URL(url('/')).origin,
+      },
       body: JSON.stringify(testUser),
     })
     expect(signupRes.status).toBe(200)

--- a/test/use-auth-request-fetch.test.ts
+++ b/test/use-auth-request-fetch.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  inboundHeaders: {} as Record<string, string>,
+  requestEvent: {} as object | undefined,
+  requestFetch: vi.fn(async () => ({ ok: true })),
+  requestOrigin: 'https://app.example',
+  runtimeConfig: {
+    public: {
+      auth: { clientOnly: false },
+    },
+  },
+}))
+
+vi.mock('#imports', () => ({
+  useRequestEvent: () => mocks.requestEvent,
+  useRequestFetch: () => mocks.requestFetch,
+  useRequestHeaders: () => mocks.inboundHeaders,
+  useRequestURL: () => ({ origin: mocks.requestOrigin }),
+  useRuntimeConfig: () => mocks.runtimeConfig,
+}))
+
+async function loadRequestFetch() {
+  vi.resetModules()
+  const mod = await import('../src/runtime/app/composables/useAuthRequestFetch')
+  return mod.useAuthRequestFetch() as (request: unknown, options?: Record<string, any>) => Promise<unknown>
+}
+
+function lastOptions(): Record<string, any> | undefined {
+  return mocks.requestFetch.mock.calls.at(-1)?.[1]
+}
+
+describe('useAuthRequestFetch', () => {
+  beforeEach(() => {
+    mocks.inboundHeaders = {}
+    mocks.requestEvent = {}
+    mocks.requestFetch.mockClear()
+    mocks.requestOrigin = 'https://app.example'
+    mocks.runtimeConfig.public.auth.clientOnly = false
+  })
+
+  it('returns the original fetch outside request SSR and in client-only mode', async () => {
+    mocks.requestEvent = undefined
+    expect(await loadRequestFetch()).toBe(mocks.requestFetch)
+
+    mocks.requestEvent = {}
+    mocks.runtimeConfig.public.auth.clientOnly = true
+    expect(await loadRequestFetch()).toBe(mocks.requestFetch)
+  })
+
+  it('adds the request origin to local auth mutations without mutating caller options', async () => {
+    const requestFetch = await loadRequestFetch()
+    const options = {
+      method: 'POST',
+      headers: { 'x-request-shape': 'object' },
+      body: { value: true },
+    }
+
+    await requestFetch('/api/auth/test', options)
+
+    expect(lastOptions()).toEqual({
+      ...options,
+      headers: {
+        'origin': 'https://app.example',
+        'x-request-shape': 'object',
+      },
+    })
+    expect(options).toEqual({
+      method: 'POST',
+      headers: { 'x-request-shape': 'object' },
+      body: { value: true },
+    })
+  })
+
+  it.each(['/api/auth', '/api/auth?probe=1', '/api/auth/test', '/api/auth/test?probe=1'])('recognizes the local auth route boundary for %s', async (request) => {
+    const requestFetch = await loadRequestFetch()
+
+    await requestFetch(request, { method: 'POST', baseURL: '/' })
+
+    expect(lastOptions()?.headers).toEqual({ origin: 'https://app.example' })
+  })
+
+  it.each([
+    [[['x-request-shape', 'tuple']]],
+    [new Headers({ 'x-request-shape': 'headers' })],
+  ])('normalizes iterable caller headers before the H3 request-fetch boundary', async (headers) => {
+    const requestFetch = await loadRequestFetch()
+
+    await requestFetch('/api/auth/test', { method: 'PATCH', headers })
+
+    expect(lastOptions()?.headers).toEqual({
+      'origin': 'https://app.example',
+      'x-request-shape': headers instanceof Headers ? 'headers' : 'tuple',
+    })
+  })
+
+  it.each([
+    [{ Origin: 'https://caller.example' }],
+    [[['ORIGIN', 'https://caller.example']]],
+    [new Headers({ Origin: 'https://caller.example' })],
+  ])('preserves a caller origin case-insensitively', async (headers) => {
+    const requestFetch = await loadRequestFetch()
+
+    await requestFetch('/api/auth/test', { method: 'DELETE', headers })
+
+    expect(lastOptions()?.headers).toEqual({ origin: 'https://caller.example' })
+  })
+
+  it('preserves a caller referer instead of adding a higher-priority origin', async () => {
+    const requestFetch = await loadRequestFetch()
+
+    await requestFetch('/api/auth/test', {
+      method: 'POST',
+      headers: { Referer: 'https://caller.example/page' },
+    })
+
+    expect(lastOptions()?.headers).toEqual({ referer: 'https://caller.example/page' })
+  })
+
+  it.each(['GET', 'get', 'HEAD', 'head', 'OPTIONS', 'options'])('leaves the safe %s method unchanged', async (method) => {
+    const requestFetch = await loadRequestFetch()
+    const options = { method, headers: new Headers({ 'x-test': 'safe' }) }
+
+    await requestFetch('/api/auth/test', options)
+
+    expect(mocks.requestFetch).toHaveBeenCalledWith('/api/auth/test', options)
+  })
+
+  it('leaves the default GET unchanged', async () => {
+    const requestFetch = await loadRequestFetch()
+    const options = { headers: { 'x-test': 'default' } }
+
+    await requestFetch('/api/auth/test', options)
+
+    expect(mocks.requestFetch).toHaveBeenCalledWith('/api/auth/test', options)
+  })
+
+  it.each([
+    ['https://api.example/api/auth/test', { method: 'POST' }],
+    ['//api.example/api/auth/test', { method: 'POST' }],
+    ['/api/authentic', { method: 'POST' }],
+    ['/api/auth/test', { method: 'POST', baseURL: 'https://api.example' }],
+    ['/api/auth/test', { method: 'POST', baseURL: '/proxy' }],
+    [new URL('https://api.example/api/auth/test'), { method: 'POST' }],
+    [new Request('https://api.example/api/auth/test', { method: 'POST' }), { method: 'POST' }],
+  ])('leaves non-local request %s unchanged', async (request, options) => {
+    const requestFetch = await loadRequestFetch()
+
+    await requestFetch(request, options)
+
+    expect(mocks.requestFetch).toHaveBeenCalledWith(request, options)
+  })
+
+  it.each([
+    ['origin', { origin: 'https://outside.example' }],
+    ['referer', { referer: 'https://outside.example/page' }],
+    ['cross-site fetch metadata', { 'sec-fetch-site': 'cross-site' }],
+    ['same-site fetch metadata', { 'sec-fetch-site': 'same-site' }],
+  ])('does not synthesize over inbound %s', async (_label, inboundHeaders) => {
+    mocks.inboundHeaders = inboundHeaders
+    const requestFetch = await loadRequestFetch()
+
+    await requestFetch('/api/auth/test', {
+      method: 'POST',
+      headers: { 'x-test': 'preserved' },
+    })
+
+    expect(lastOptions()?.headers).toEqual({ 'x-test': 'preserved' })
+  })
+
+  it.each([undefined, 'same-origin', 'none'])('synthesizes for eligible fetch-site provenance %s', async (site) => {
+    mocks.inboundHeaders = site ? { 'sec-fetch-site': site } : {}
+    const requestFetch = await loadRequestFetch()
+
+    await requestFetch('/api/auth/test', { method: 'PUT' })
+
+    expect(lastOptions()?.headers).toEqual({ origin: 'https://app.example' })
+  })
+})

--- a/test/use-auth-request-fetch.test.ts
+++ b/test/use-auth-request-fetch.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
-  inboundHeaders: {} as Record<string, string>,
   requestEvent: {} as object | undefined,
   requestFetch: vi.fn(async () => ({ ok: true })),
   requestOrigin: 'https://app.example',
@@ -15,7 +14,6 @@ const mocks = vi.hoisted(() => ({
 vi.mock('#imports', () => ({
   useRequestEvent: () => mocks.requestEvent,
   useRequestFetch: () => mocks.requestFetch,
-  useRequestHeaders: () => mocks.inboundHeaders,
   useRequestURL: () => ({ origin: mocks.requestOrigin }),
   useRuntimeConfig: () => mocks.runtimeConfig,
 }))
@@ -32,7 +30,6 @@ function lastOptions(): Record<string, any> | undefined {
 
 describe('useAuthRequestFetch', () => {
   beforeEach(() => {
-    mocks.inboundHeaders = {}
     mocks.requestEvent = {}
     mocks.requestFetch.mockClear()
     mocks.requestOrigin = 'https://app.example'
@@ -106,7 +103,7 @@ describe('useAuthRequestFetch', () => {
     expect(lastOptions()?.headers).toEqual({ origin: 'https://caller.example' })
   })
 
-  it('preserves a caller referer instead of adding a higher-priority origin', async () => {
+  it('preserves a caller referer while adding the current origin', async () => {
     const requestFetch = await loadRequestFetch()
 
     await requestFetch('/api/auth/test', {
@@ -114,7 +111,10 @@ describe('useAuthRequestFetch', () => {
       headers: { Referer: 'https://caller.example/page' },
     })
 
-    expect(lastOptions()?.headers).toEqual({ referer: 'https://caller.example/page' })
+    expect(lastOptions()?.headers).toEqual({
+      origin: 'https://app.example',
+      referer: 'https://caller.example/page',
+    })
   })
 
   it.each(['GET', 'get', 'HEAD', 'head', 'OPTIONS', 'options'])('leaves the safe %s method unchanged', async (method) => {
@@ -149,31 +149,5 @@ describe('useAuthRequestFetch', () => {
     await requestFetch(request, options)
 
     expect(mocks.requestFetch).toHaveBeenCalledWith(request, options)
-  })
-
-  it.each([
-    ['origin', { origin: 'https://outside.example' }],
-    ['referer', { referer: 'https://outside.example/page' }],
-    ['cross-site fetch metadata', { 'sec-fetch-site': 'cross-site' }],
-    ['same-site fetch metadata', { 'sec-fetch-site': 'same-site' }],
-  ])('does not synthesize over inbound %s', async (_label, inboundHeaders) => {
-    mocks.inboundHeaders = inboundHeaders
-    const requestFetch = await loadRequestFetch()
-
-    await requestFetch('/api/auth/test', {
-      method: 'POST',
-      headers: { 'x-test': 'preserved' },
-    })
-
-    expect(lastOptions()?.headers).toEqual({ 'x-test': 'preserved' })
-  })
-
-  it.each([undefined, 'same-origin', 'none'])('synthesizes for eligible fetch-site provenance %s', async (site) => {
-    mocks.inboundHeaders = site ? { 'sec-fetch-site': site } : {}
-    const requestFetch = await loadRequestFetch()
-
-    await requestFetch('/api/auth/test', { method: 'PUT' })
-
-    expect(lastOptions()?.headers).toEqual({ origin: 'https://app.example' })
   })
 })

--- a/test/use-auth-request-fetch.test.ts
+++ b/test/use-auth-request-fetch.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   requestEvent: {} as object | undefined,
   requestFetch: vi.fn(async () => ({ ok: true })),
+  requestHeaders: new Headers({ 'sec-fetch-site': 'same-origin' }),
   requestOrigin: 'https://app.example',
   runtimeConfig: {
     public: {
@@ -12,6 +13,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('#imports', () => ({
+  useRequestHeader: (name: string) => mocks.requestHeaders.get(name) ?? undefined,
   useRequestEvent: () => mocks.requestEvent,
   useRequestFetch: () => mocks.requestFetch,
   useRequestURL: () => ({ origin: mocks.requestOrigin }),
@@ -32,6 +34,7 @@ describe('useAuthRequestFetch', () => {
   beforeEach(() => {
     mocks.requestEvent = {}
     mocks.requestFetch.mockClear()
+    mocks.requestHeaders = new Headers({ 'sec-fetch-site': 'same-origin' })
     mocks.requestOrigin = 'https://app.example'
     mocks.runtimeConfig.public.auth.clientOnly = false
   })
@@ -69,6 +72,41 @@ describe('useAuthRequestFetch', () => {
     })
   })
 
+  it('does not overwrite cross-site provenance forwarded from the incoming request', async () => {
+    mocks.requestHeaders = new Headers({
+      'origin': 'https://outside.example',
+      'referer': 'https://outside.example/page',
+      'sec-fetch-site': 'cross-site',
+    })
+    const requestFetch = await loadRequestFetch()
+
+    await requestFetch('/api/auth/test', {
+      method: 'POST',
+      headers: { 'x-request-shape': 'object' },
+    })
+
+    expect(lastOptions()?.headers).toEqual({
+      'x-request-shape': 'object',
+    })
+  })
+
+  it.each([
+    [{ origin: 'https://outside.example' }],
+    [{ 'origin': '', 'sec-fetch-site': 'same-origin' }],
+    [{ referer: 'https://outside.example/page' }],
+    [{ 'sec-fetch-site': 'same-site' }],
+    [{ 'sec-fetch-site': 'cross-site' }],
+    [{ 'sec-fetch-site': 'none' }],
+    [{}],
+  ])('does not attest incoming provenance %o as same-origin', async (incomingHeaders) => {
+    mocks.requestHeaders = new Headers(incomingHeaders)
+    const requestFetch = await loadRequestFetch()
+
+    await requestFetch('/api/auth/test', { method: 'POST' })
+
+    expect(mocks.requestFetch).toHaveBeenCalledWith('/api/auth/test', { method: 'POST' })
+  })
+
   it.each(['/api/auth', '/api/auth?probe=1', '/api/auth/test', '/api/auth/test?probe=1'])('recognizes the local auth route boundary for %s', async (request) => {
     const requestFetch = await loadRequestFetch()
 
@@ -103,7 +141,7 @@ describe('useAuthRequestFetch', () => {
     expect(lastOptions()?.headers).toEqual({ origin: 'https://caller.example' })
   })
 
-  it('preserves a caller referer while adding the current origin', async () => {
+  it('preserves a caller referer without replacing its provenance', async () => {
     const requestFetch = await loadRequestFetch()
 
     await requestFetch('/api/auth/test', {
@@ -112,9 +150,31 @@ describe('useAuthRequestFetch', () => {
     })
 
     expect(lastOptions()?.headers).toEqual({
-      origin: 'https://app.example',
       referer: 'https://caller.example/page',
     })
+  })
+
+  it('does not attest caller-provided cross-site fetch metadata', async () => {
+    const requestFetch = await loadRequestFetch()
+
+    await requestFetch('/api/auth/test', {
+      method: 'POST',
+      headers: { 'sec-fetch-site': 'cross-site' },
+    })
+
+    expect(lastOptions()?.headers).toEqual({ 'sec-fetch-site': 'cross-site' })
+  })
+
+  it('does not treat caller-provided fetch metadata as incoming provenance', async () => {
+    mocks.requestHeaders = new Headers()
+    const requestFetch = await loadRequestFetch()
+
+    await requestFetch('/api/auth/test', {
+      method: 'POST',
+      headers: { 'sec-fetch-site': 'same-origin' },
+    })
+
+    expect(lastOptions()?.headers).toEqual({ 'sec-fetch-site': 'same-origin' })
   })
 
   it.each(['GET', 'get', 'HEAD', 'head', 'OPTIONS', 'options'])('leaves the safe %s method unchanged', async (method) => {


### PR DESCRIPTION
Cookie-bearing Better Auth mutations made through `useAuthRequestFetch()` during SSR can arrive without `Origin` or `Referer`, causing Better Auth's origin validation to reject a request that originated in the same Nuxt application.

This change adapts local `/api/auth` mutations in full SSR mode. When neither the caller nor the incoming request supplies origin provenance, the wrapper adds the current request URL's origin. Client requests, `clientOnly` mode, safe methods, external targets, and custom `baseURL` requests retain the existing passthrough behavior.

Header inputs are normalized to a plain record so object, tuple, and `Headers` forms remain compatible with Nitro 2/H3 1 request forwarding. Existing caller or inbound `Origin`/`Referer` values are preserved, as is known `same-site` or `cross-site` fetch metadata.

The regression coverage includes a 33-case unit matrix and an integration fixture proving that a cookie-bearing SSR POST receives the request origin while explicit cross-site provenance is not overwritten.

## Review decision

This is a draft because issue #407 does not include the outer request provenance for the motivating OAuth flow. The implementation deliberately does not replace known non-same-origin provenance; maintainers should confirm whether that flow needs explicit server-side attestation instead.

## Verification

- `corepack pnpm lint`
- `corepack pnpm typecheck`
- `corepack pnpm prepack`
- `corepack pnpm exec vitest run --project integration test/module.test.ts` (16 passed)
- `corepack pnpm exec vitest run --maxWorkers=1` (56 files, 342 tests)

Addresses #407
