### PR TITLE
fix(auth): avoid deep session snapshot watches

### DIFF
--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -163,7 +163,7 @@ export function useUserSession(): UseUserSessionReturn {
         if (!authReady.value && !newSession?.isPending && !newSession?.isRefetching)
           authReady.value = true
       },
-      { immediate: true, deep: true },
+      { immediate: true },
     )
   }
 

--- a/test/use-user-session.test.ts
+++ b/test/use-user-session.test.ts
@@ -859,6 +859,28 @@ describe('useUserSession hydration bootstrap', () => {
     expect(auth.user.value).toEqual({ id: 'user-3', email: 'user3@example.com' })
   })
 
+  it('does not re-sync session for nested mutations within the current Better Auth snapshot', async () => {
+    sessionAtom.value = {
+      data: {
+        session: { id: 'session-1', metadata: { role: 'member' } },
+        user: { id: 'user-1', email: 'user@example.com' },
+      },
+      isPending: false,
+      isRefetching: false,
+      error: null,
+    }
+
+    const useUserSession = await loadUseUserSession()
+    const auth = useUserSession()
+    const bridgedSession = auth.session.value
+
+    const metadata = sessionAtom.value.data!.session.metadata as { role: string }
+    metadata.role = 'admin'
+    await flushPromises()
+
+    expect(auth.session.value).toBe(bridgedSession)
+  })
+
   it('signOut navigates to redirects.logout when configured (and no onSuccess)', async () => {
     runtimeConfig.public.auth.redirects = { logout: '/logged-out' }
 


### PR DESCRIPTION
The client session bridge now watches Better Auth snapshot replacements without traversing the snapshot deeply. Nested session mutations no longer retrigger the bridge and replace Nuxt session state, while normal Better Auth refreshes still synchronize because the session atom publishes a new top-level snapshot.

## Tests

- `corepack pnpm exec vitest run test/use-user-session.test.ts --maxWorkers=1`
- `corepack pnpm exec vitest run test/define-server-auth-literal-inference.test.ts --maxWorkers=1`
- `corepack pnpm lint`
- `corepack pnpm typecheck`
- `corepack pnpm prepack`