### PR TITLE
fix(auth): defer initial session bridge

### DIFF
--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -120,9 +120,31 @@ export function useUserSession(): UseUserSessionReturn {
     }
   }
 
+  function queueHydrationReconciliation() {
+    if (hydrationReconcileQueued.value)
+      return
+
+    hydrationReconcileQueued.value = true
+    nuxtApp.hook('app:mounted', async () => {
+      await fetchSession({ force: true })
+      hydrationReconcileQueued.value = false
+    })
+  }
+
   // On client, subscribe to better-auth's reactive session store
   if (runtimeFlags.client && rawClient) {
     const clientSession = rawClient.useSession()
+    const initialClientSession = clientSession.value
+
+    const shouldReconcileInitialHydration
+      = nuxtApp.isHydrating
+        && nuxtApp.payload.serverRendered
+        && Boolean(session.value && user.value)
+        && !initialClientSession?.data?.session
+        && !initialClientSession?.data?.user
+
+    if (shouldReconcileInitialHydration)
+      queueHydrationReconciliation()
 
     watch(
       () => clientSession.value,
@@ -148,13 +170,7 @@ export function useUserSession(): UseUserSessionReturn {
               && !newSession?.data?.user
 
           if (isHydrationEmptySnapshot) {
-            if (!hydrationReconcileQueued.value) {
-              hydrationReconcileQueued.value = true
-              nuxtApp.hook('app:mounted', async () => {
-                await fetchSession({ force: true })
-                hydrationReconcileQueued.value = false
-              })
-            }
+            queueHydrationReconciliation()
             return
           }
 
@@ -163,7 +179,6 @@ export function useUserSession(): UseUserSessionReturn {
         if (!authReady.value && !newSession?.isPending && !newSession?.isRefetching)
           authReady.value = true
       },
-      { immediate: true },
     )
   }
 

--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -142,6 +142,8 @@ export function useUserSession(): UseUserSessionReturn {
         && Boolean(session.value && user.value)
         && !initialClientSession?.data?.session
         && !initialClientSession?.data?.user
+        && !initialClientSession?.isPending
+        && !initialClientSession?.isRefetching
 
     if (shouldReconcileInitialHydration)
       queueHydrationReconciliation()

--- a/test/use-user-session.test.ts
+++ b/test/use-user-session.test.ts
@@ -182,14 +182,16 @@ describe('useUserSession hydration bootstrap', () => {
     delete (globalThis as { __NUXT_BETTER_AUTH_TEST_FLAGS__?: { client: boolean, server: boolean } }).__NUXT_BETTER_AUTH_TEST_FLAGS__
   })
 
-  it('bootstraps client session by default even when SSR payload is hydrated', async () => {
+  it('subscribes without synchronously bridging the initial client snapshot', async () => {
     payload.serverRendered = true
     seedHydratedState()
 
     const useUserSession = await loadUseUserSession()
     const auth = useUserSession()
 
-    expect(auth.ready.value).toBe(true)
+    expect(auth.ready.value).toBe(false)
+    expect(auth.session.value).toEqual({ id: 'session-1' })
+    expect(auth.user.value).toEqual({ id: 'user-1' })
     expect(mockClient.useSession).toHaveBeenCalledOnce()
   })
 
@@ -850,16 +852,20 @@ describe('useUserSession hydration bootstrap', () => {
     const useUserSession = await loadUseUserSession()
     const auth = useUserSession()
 
-    expect(auth.ready.value).toBe(true)
+    expect(auth.ready.value).toBe(false)
 
     sessionAtom.value = refreshedSession
     await flushPromises()
 
+    expect(auth.ready.value).toBe(true)
     expect(auth.session.value).toEqual({ id: 'session-3', ipAddress: '127.0.0.1' })
     expect(auth.user.value).toEqual({ id: 'user-3', email: 'user3@example.com' })
   })
 
   it('does not re-sync session for nested mutations within the current Better Auth snapshot', async () => {
+    const useUserSession = await loadUseUserSession()
+    const auth = useUserSession()
+
     sessionAtom.value = {
       data: {
         session: { id: 'session-1', metadata: { role: 'member' } },
@@ -869,9 +875,7 @@ describe('useUserSession hydration bootstrap', () => {
       isRefetching: false,
       error: null,
     }
-
-    const useUserSession = await loadUseUserSession()
-    const auth = useUserSession()
+    await flushPromises()
     const bridgedSession = auth.session.value
 
     const metadata = sessionAtom.value.data!.session.metadata as { role: string }

--- a/test/use-user-session.test.ts
+++ b/test/use-user-session.test.ts
@@ -285,6 +285,7 @@ describe('useUserSession hydration bootstrap', () => {
     payload.serverRendered = true
     nuxtApp.isHydrating = true
     seedHydratedState()
+    sessionAtom.value.isPending = true
 
     mockClient.getSession.mockResolvedValueOnce({
       data: {
@@ -298,8 +299,14 @@ describe('useUserSession hydration bootstrap', () => {
     await flushPromises()
 
     expect(mockClient.getSession).not.toHaveBeenCalled()
+    expect(nuxtHooks.get('app:mounted')).toBeUndefined()
     expect(auth.session.value).toEqual({ id: 'session-1' })
     expect(auth.user.value).toEqual({ id: 'user-1' })
+
+    sessionAtom.value = { ...sessionAtom.value, isPending: false }
+    await flushPromises()
+
+    expect((nuxtHooks.get('app:mounted') || [])).toHaveLength(1)
 
     nuxtApp.isHydrating = false
     await triggerNuxtHook('app:mounted')


### PR DESCRIPTION
The client session watcher now waits for Better Auth snapshot changes instead of synchronously bridging the initial snapshot during `useUserSession()` setup. This prevents authenticated Nuxt consumers from stalling while preserving the existing post-mount reconciliation for hydrated SSR state.

This reproduces in [quiverdk/portal#965](https://github.com/quiverdk/portal/pull/965). Without the eager callback, the previously hanging authenticated Playwright test passed in 54.9 seconds and the full preview suite passed in 6 minutes 18 seconds: [preview run](https://github.com/quiverdk/portal/actions/runs/32952956434/job/98130527946).

## Test plan

- `pnpm lint`
- `pnpm typecheck`
- `pnpm prepack`
- `pnpm dev:build`
- `pnpm build:docs`
- `pnpm test` (320 passed)