### PR TITLE
fix(types): narrow config extension hook

### DIFF
--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -299,7 +299,7 @@ After configuration changes:
 - confirm your app boots without missing-config errors
 - confirm route protection works on at least one protected page and one protected API route
 
-Other Nuxt modules can extend the authentication configuration:
+Other Nuxt modules can add plugin schemas during database schema generation:
 
 ```ts
 // In your Nuxt module
@@ -311,6 +311,11 @@ export default defineNuxtModule({
   }
 })
 ```
+
+`better-auth:config:extend` is a build-time schema hook. It accepts only `plugins` and does not
+install them in the running Better Auth instance. Register each runtime plugin separately in
+`server/auth.config.ts`. A Nuxt layer can provide that config when the layer owns the application's
+auth setup.
 
 Access sessions from server handlers:
 

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,5 +1,5 @@
 import type { Nuxt } from '@nuxt/schema'
-import type { BetterAuthOptions } from 'better-auth'
+import type { BetterAuthPlugin } from 'better-auth'
 import type { DbDialect } from '../module/hub'
 import type { BetterAuthModuleOptions } from '../runtime/config'
 
@@ -29,11 +29,12 @@ export interface BetterAuthDatabaseProviderDefinition {
 declare module '@nuxt/schema' {
   interface NuxtHooks {
     /**
-     * Extend better-auth config with additional plugins or options.
-     * Called after user's auth.config.ts is loaded.
-     * @param config - Partial config to merge into the auth options
+     * Add plugin schemas to generated Better Auth database tables.
+     * This build-time hook does not install plugins in the runtime auth instance.
+     * @param config - Plugins to include during schema generation
+     * @param config.plugins - Better Auth plugins whose schemas should be generated
      */
-    'better-auth:config:extend': (config: Partial<BetterAuthOptions>) => void | Promise<void>
+    'better-auth:config:extend': (config: { plugins?: BetterAuthPlugin[] }) => void | Promise<void>
 
     /**
      * Register or override Better Auth database providers.

--- a/test/config-extend-hook.test.ts
+++ b/test/config-extend-hook.test.ts
@@ -1,0 +1,41 @@
+import type { BetterAuthPlugin } from 'better-auth'
+import type { NuxtHooks } from 'nuxt/schema'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { expect, it } from 'vitest'
+import '../src/types/hooks'
+
+type SchemaExtension = Parameters<NuxtHooks['better-auth:config:extend']>[0]
+
+it('accepts only schema plugin contributions', () => {
+  const pluginConfig = { plugins: [] as BetterAuthPlugin[] } satisfies SchemaExtension
+  // @ts-expect-error The build hook does not extend runtime auth options.
+  const runtimeConfig = { appName: 'runtime option' } satisfies SchemaExtension
+
+  expect(pluginConfig.plugins).toEqual([])
+  expect(runtimeConfig.appName).toBe('runtime option')
+})
+
+it('rejects runtime options during typechecking', () => {
+  const typecheck = spawnSync('pnpm', [
+    'exec',
+    'tsc',
+    '--noEmit',
+    '--module',
+    'esnext',
+    '--moduleResolution',
+    'bundler',
+    '--target',
+    'esnext',
+    '--strict',
+    '--skipLibCheck',
+    '--types',
+    'node',
+    fileURLToPath(import.meta.url),
+  ], {
+    cwd: import.meta.dirname,
+    encoding: 'utf8',
+  })
+
+  expect(typecheck.status, `tsc failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)
+})

--- a/test/config-extend-hook.test.ts
+++ b/test/config-extend-hook.test.ts
@@ -16,7 +16,7 @@ it('accepts only schema plugin contributions', () => {
   expect(runtimeConfig.appName).toBe('runtime option')
 })
 
-it('rejects runtime options during typechecking', () => {
+it('rejects runtime options during typechecking', { timeout: 30_000 }, () => {
   const typecheck = spawnSync('pnpm', [
     'exec',
     'tsc',


### PR DESCRIPTION
`better-auth:config:extend` has always consumed only `plugins` during schema generation, but its public type accepted every `Partial<BetterAuthOptions>` key and the docs implied a runtime effect. Narrow the payload and document the build-time boundary so unsupported options fail typechecking instead of disappearing silently. Runtime plugins remain in `server/auth.config.ts`.

Closes #420

Runnable reproduction: https://github.com/jd-solanki/reproductions/tree/nuxtjs-better-auth-config-extend-hook-incomplete--2026-08-29

## Test plan

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (56 files, 330 tests)
- `pnpm prepack`
- packed-consumer control: published 0.2.2 accepts `config.user`; the patched package rejects it with `Property user does not exist on type { plugins?: BetterAuthPlugin[] }`