### PR TITLE
feat: support layered Better Auth plugins

### DIFF
--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -282,7 +282,32 @@ Use `NUXT_BETTER_AUTH_SECRET` as the primary secret variable. `BETTER_AUTH_SECRE
 
 For non-destructive rotation, use `BETTER_AUTH_SECRETS=2:current-secret-must-be-at-least-32-characters,1:previous-secret-must-be-at-least-32-characters` or configure `secrets` in `defineServerAuth`.
 
-## For Module Authors
+## Add plugins from a Nuxt layer
+
+A layer can add server and client plugins without changing the app's auth config. Export each plugin as the default value of its own module, then list those modules in the layer config.
+
+```ts [layers/payments/nuxt.config.ts]
+export default defineNuxtConfig({
+  auth: {
+    serverPluginSources: ['./server/polar-auth-plugin'],
+    clientPluginSources: ['./app/polar-auth-plugin'],
+  },
+})
+```
+
+```ts [layers/payments/server/polar-auth-plugin.ts]
+import { polar } from '@polar-sh/better-auth'
+
+export default polar({ /* Polar options */ })
+```
+
+```ts [layers/payments/app/polar-auth-plugin.ts]
+import { polarClient } from '@polar-sh/better-auth/client'
+
+export default polarClient()
+```
+
+Relative source paths resolve from the layer that declares them. The module appends project sources, then extended-layer sources in Nuxt priority order, after the plugins in the app's selected auth config.
 
 ## Recommended order
 
@@ -299,18 +324,26 @@ After configuration changes:
 - confirm your app boots without missing-config errors
 - confirm route protection works on at least one protected page and one protected API route
 
-Other Nuxt modules can extend the authentication configuration:
+## For module authors
+
+Other Nuxt modules can register plugin source files. Resolve the files to absolute paths so registration does not depend on the app's working directory.
 
 ```ts
-// In your Nuxt module
+import { fileURLToPath } from 'node:url'
+
 export default defineNuxtModule({
-  setup(options, nuxt) {
-    nuxt.hook('better-auth:config:extend', (config) => {
-      config.plugins = [...(config.plugins || []), myPlugin()]
+  setup(_options, nuxt) {
+    nuxt.hook('better-auth:plugins:extend', (sources) => {
+      sources.server ||= []
+      sources.client ||= []
+      sources.server.push(fileURLToPath(new URL('./runtime/server-plugin', import.meta.url)))
+      sources.client.push(fileURLToPath(new URL('./runtime/client-plugin', import.meta.url)))
     })
-  }
+  },
 })
 ```
+
+The module collects registrations after all Nuxt modules install, then appends them after layer sources. Schema generation, the running auth instances, and generated types import the same ordered plugin modules.
 
 Access sessions from server handlers:
 

--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -309,6 +309,8 @@ export default polarClient()
 
 Relative source paths resolve from the layer that declares them. The module appends project sources, then extended-layer sources in Nuxt priority order, after the plugins in the app's selected auth config.
 
+Contributions are additive and are not deduplicated. Declare each plugin in one place. Do not repeat a plugin in the app auth config, a layer source, or a module registration.
+
 ## Recommended order
 
 1. Configure the module in `nuxt.config.ts`.
@@ -326,7 +328,7 @@ After configuration changes:
 
 ## For module authors
 
-Other Nuxt modules can register plugin source files. Resolve the files to absolute paths so registration does not depend on the app's working directory.
+Other Nuxt modules can register plugin source files. Register the hook during the module's `setup` function and resolve each file to an absolute path. Registering the hook from `modules:done` is too late because Better Auth collects the sources from its own `modules:done` callback.
 
 ```ts
 import { fileURLToPath } from 'node:url'
@@ -343,7 +345,7 @@ export default defineNuxtModule({
 })
 ```
 
-The module collects registrations after all Nuxt modules install, then appends them after layer sources. Schema generation, the running auth instances, and generated types import the same ordered plugin modules.
+The module collects registrations after all Nuxt modules install, then appends them after layer sources. Schema generation, the running auth instances, and generated types import the same ordered plugin modules. Module registrations are additive and are not deduplicated.
 
 The existing `better-auth:config:extend` hook remains available for schema-only contributions:
 

--- a/docs/public/.well-known/skills/nuxt-better-auth/references/plugins.md
+++ b/docs/public/.well-known/skills/nuxt-better-auth/references/plugins.md
@@ -70,3 +70,5 @@ export default defineNuxtConfig({
 ```
 
 Relative paths resolve from the declaring layer. The module includes these plugins in schema generation, runtime auth instances, and inferred types.
+
+Plugin contributions are additive and are not deduplicated. Declare each plugin once, either in the app auth config, a layer source, or a module registration.

--- a/docs/public/.well-known/skills/nuxt-better-auth/references/plugins.md
+++ b/docs/public/.well-known/skills/nuxt-better-auth/references/plugins.md
@@ -55,3 +55,18 @@ await client?.multiSession.listDeviceSessions()
 ```
 
 Types from plugins are inferred automatically. See [references/types.md](types.md) for type augmentation.
+
+## Plugins supplied by layers
+
+Export each plugin as the default value of a source file and list the source paths in the layer's `nuxt.config.ts`:
+
+```ts
+export default defineNuxtConfig({
+  auth: {
+    serverPluginSources: ['./server/auth-plugin'],
+    clientPluginSources: ['./app/auth-plugin'],
+  },
+})
+```
+
+Relative paths resolve from the declaring layer. The module includes these plugins in schema generation, runtime auth instances, and inferred types.

--- a/src/module.ts
+++ b/src/module.ts
@@ -216,7 +216,7 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
           serverConfigPath: serverConfigPath!,
           hasHubDb: setup.serverTypes.hasHubDb,
           runtimeTypesPath: resolver.resolve('./runtime/types'),
-          sharedServerConfigSafe: isServerConfigSharedTypeSafe(setup.configs.server.path),
+          sharedServerConfigSafe: [setup.configs.server.path, ...setup.pluginSources.server].every(isServerConfigSharedTypeSafe),
           h3TypesPath: nitroImports.h3,
           nitroTypesPath: nitroImports.types,
         })

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,12 +1,12 @@
 import type { Nuxt } from '@nuxt/schema'
 import type { DbDialect } from './module/hub'
 import type { BetterAuthModuleOptions } from './runtime/config'
-import type { BetterAuthDatabaseProviderSetupContext } from './types/hooks'
+import type { BetterAuthDatabaseProviderSetupContext, BetterAuthPluginSources } from './types/hooks'
 import { existsSync, readFileSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { addTemplate, createResolver, defineNuxtModule } from '@nuxt/kit'
 import { consola as _consola } from 'consola'
-import { dirname, join, relative } from 'pathe'
+import { dirname, isAbsolute, join, relative } from 'pathe'
 import { version } from '../package.json'
 import { resolveAuthConfigDescriptors } from './module/config-paths'
 import { resolveNitroCompatibilityImports } from './module/compatibility'
@@ -14,7 +14,7 @@ import { registerAuthMiddlewareHook, registerDevtools, registerNuxtHubDatabaseEx
 import { setupBetterAuthSchema } from './module/schema'
 import { promptForSecret } from './module/secret'
 import { collectAuthRouteRules, resolveAuthModuleSetup } from './module/setup'
-import { buildAuthRouteRulesCode, buildSchemaExportCode, buildSecondaryStorageCode } from './module/templates'
+import { buildAuthRouteRulesCode, buildExtendedClientAuthCode, buildExtendedServerAuthCode, buildSchemaExportCode, buildSecondaryStorageCode } from './module/templates'
 import { registerServerTypeTemplates, registerSharedTypeTemplates } from './module/type-templates'
 
 import './types/hooks'
@@ -115,109 +115,140 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
 
     await createDefaultAuthConfigFiles(nuxt)
   },
-  async setup(options, nuxt) {
-    const resolver = createResolver(import.meta.url)
-    const nitroImports = resolveNitroCompatibilityImports(nuxt._version)
-    nuxt.options.alias['#better-auth/nitro-compat'] = resolver.resolve(`./runtime/server/internal/${nitroImports.runtime}`)
+  setup(options, nuxt) {
+    nuxt.hook('modules:done', async () => {
+      const resolver = createResolver(import.meta.url)
+      const nitroImports = resolveNitroCompatibilityImports(nuxt._version)
+      nuxt.options.alias['#better-auth/nitro-compat'] = resolver.resolve(`./runtime/server/internal/${nitroImports.runtime}`)
 
-    const setup = await resolveAuthModuleSetup({
-      nuxt,
-      options,
-      runtimeTypesAugmentPath: resolver.resolve('./runtime/types/augment'),
-      consola,
-    })
-
-    if (setup.aliases['#auth/server'])
-      nuxt.options.alias['#auth/server'] = setup.aliases['#auth/server']
-    nuxt.options.alias['#auth/client'] = setup.aliases['#auth/client']
-
-    if (!setup.clientOnly) {
-      const secondaryStorageTemplate = addTemplate({
-        filename: 'better-auth/secondary-storage.mjs',
-        getContents: () => buildSecondaryStorageCode(setup.runtime.useHubKV),
-        write: true,
-      })
-      nuxt.options.alias['#auth/secondary-storage'] = secondaryStorageTemplate.dst
-
-      const databaseTemplate = addTemplate({
-        filename: 'better-auth/database.mjs',
-        getContents: () => setup.database.providerDefinition!.buildDatabaseCode(setup.database.buildContext!),
-        write: true,
-      })
-      nuxt.options.alias['#auth/database'] = databaseTemplate.dst
-
-      const schemaTemplate = addTemplate({
-        filename: 'better-auth/schema.mjs',
-        getContents: () => buildSchemaExportCode(setup.database.hasHubDb, setup.database.buildContext?.hubDialect ?? 'sqlite'),
-        write: true,
-      })
-      nuxt.options.alias['#auth/schema'] = schemaTemplate.dst
-
-      if (setup.schemaGeneration)
-        await ensureSchemaBootstrap(schemaTemplate.dst, setup.database.buildContext?.hubDialect ?? 'sqlite')
-    }
-
-    if (setup.prepareTypes) {
-      registerPrepareTypesHook({
-        nuxt,
-        serverDir: setup.prepareTypes.serverDir,
-        hasHubDb: setup.prepareTypes.hasHubDb,
-      })
-    }
-
-    if (setup.database.providerDefinition) {
-      const setupCtx: BetterAuthDatabaseProviderSetupContext = {
-        nuxt,
-        options,
-        clientOnly: setup.clientOnly,
+      const registeredPluginSources: BetterAuthPluginSources = {}
+      await nuxt.callHook('better-auth:plugins:extend', registeredPluginSources)
+      for (const source of [...(registeredPluginSources.server || []), ...(registeredPluginSources.client || [])]) {
+        if (!isAbsolute(source))
+          throw new Error(`[nuxt-better-auth] Modules must register absolute plugin source paths. Received: ${source}`)
       }
-      await setup.database.providerDefinition.setup?.(setupCtx)
-    }
 
-    const authRouteRulesTemplate = addTemplate({
-      filename: 'better-auth/route-rules.mjs',
-      getContents: () => buildAuthRouteRulesCode(collectAuthRouteRules(nuxt)),
-      write: true,
-    })
-    nuxt.options.alias['#auth/route-rules'] = authRouteRulesTemplate.dst
-
-    if (setup.serverTypes) {
-      registerServerTypeTemplates({
-        serverConfigPath: setup.serverTypes.serverConfigPath,
-        hasHubDb: setup.serverTypes.hasHubDb,
-        runtimeTypesPath: resolver.resolve('./runtime/types'),
-        sharedServerConfigSafe: isServerConfigSharedTypeSafe(setup.serverTypes.serverConfigPath),
-        h3TypesPath: nitroImports.h3,
-        nitroTypesPath: nitroImports.types,
-      })
-    }
-
-    if (setup.schemaGeneration) {
-      if (setup.schemaGeneration.externalizeNuxtHubDatabase)
-        registerNuxtHubDatabaseExternalHook(nuxt)
-
-      await setupBetterAuthSchema(
+      const setup = await resolveAuthModuleSetup({
         nuxt,
-        setup.schemaGeneration.serverConfigPath,
         options,
+        runtimeTypesAugmentPath: resolver.resolve('./runtime/types/augment'),
         consola,
-        setup.schemaGeneration.hubSecondaryStorage,
-      )
-    }
+        registeredPluginSources,
+      })
 
-    registerSharedTypeTemplates({
-      runtimeTypesAugmentPath: setup.sharedTypes.runtimeTypesAugmentPath,
-      runtimeTypesPath: resolver.resolve('./runtime/types'),
-      clientConfigPath: setup.sharedTypes.clientConfigPath,
-      h3TypesPath: nitroImports.h3,
+      let serverConfigPath = setup.aliases['#auth/server']
+      let clientConfigPath = setup.aliases['#auth/client']
+
+      if (serverConfigPath && setup.pluginSources.server.length) {
+        const serverConfigCode = buildExtendedServerAuthCode(setup.configs.server.path, setup.pluginSources.server)
+        serverConfigPath = addTemplate({
+          filename: 'better-auth/server.config.ts',
+          getContents: () => serverConfigCode,
+          write: true,
+        }).dst
+        await mkdir(dirname(serverConfigPath), { recursive: true })
+        await writeFile(serverConfigPath, serverConfigCode)
+      }
+      if (setup.pluginSources.client.length) {
+        clientConfigPath = addTemplate({
+          filename: 'better-auth/client.config.ts',
+          getContents: () => buildExtendedClientAuthCode(setup.configs.client.path, setup.pluginSources.client),
+          write: true,
+        }).dst
+      }
+
+      if (serverConfigPath)
+        nuxt.options.alias['#auth/server'] = serverConfigPath
+      nuxt.options.alias['#auth/client'] = clientConfigPath
+
+      if (!setup.clientOnly) {
+        const secondaryStorageTemplate = addTemplate({
+          filename: 'better-auth/secondary-storage.mjs',
+          getContents: () => buildSecondaryStorageCode(setup.runtime.useHubKV),
+          write: true,
+        })
+        nuxt.options.alias['#auth/secondary-storage'] = secondaryStorageTemplate.dst
+
+        const databaseTemplate = addTemplate({
+          filename: 'better-auth/database.mjs',
+          getContents: () => setup.database.providerDefinition!.buildDatabaseCode(setup.database.buildContext!),
+          write: true,
+        })
+        nuxt.options.alias['#auth/database'] = databaseTemplate.dst
+
+        const schemaTemplate = addTemplate({
+          filename: 'better-auth/schema.mjs',
+          getContents: () => buildSchemaExportCode(setup.database.hasHubDb, setup.database.buildContext?.hubDialect ?? 'sqlite'),
+          write: true,
+        })
+        nuxt.options.alias['#auth/schema'] = schemaTemplate.dst
+
+        if (setup.schemaGeneration)
+          await ensureSchemaBootstrap(schemaTemplate.dst, setup.database.buildContext?.hubDialect ?? 'sqlite')
+      }
+
+      if (setup.prepareTypes) {
+        registerPrepareTypesHook({
+          nuxt,
+          serverDir: setup.prepareTypes.serverDir,
+          hasHubDb: setup.prepareTypes.hasHubDb,
+        })
+      }
+
+      if (setup.database.providerDefinition) {
+        const setupCtx: BetterAuthDatabaseProviderSetupContext = {
+          nuxt,
+          options,
+          clientOnly: setup.clientOnly,
+        }
+        await setup.database.providerDefinition.setup?.(setupCtx)
+      }
+
+      const authRouteRulesTemplate = addTemplate({
+        filename: 'better-auth/route-rules.mjs',
+        getContents: () => buildAuthRouteRulesCode(collectAuthRouteRules(nuxt)),
+        write: true,
+      })
+      nuxt.options.alias['#auth/route-rules'] = authRouteRulesTemplate.dst
+
+      if (setup.serverTypes) {
+        registerServerTypeTemplates({
+          serverConfigPath: serverConfigPath!,
+          hasHubDb: setup.serverTypes.hasHubDb,
+          runtimeTypesPath: resolver.resolve('./runtime/types'),
+          sharedServerConfigSafe: isServerConfigSharedTypeSafe(setup.configs.server.path),
+          h3TypesPath: nitroImports.h3,
+          nitroTypesPath: nitroImports.types,
+        })
+      }
+
+      if (setup.schemaGeneration) {
+        if (setup.schemaGeneration.externalizeNuxtHubDatabase)
+          registerNuxtHubDatabaseExternalHook(nuxt)
+
+        await setupBetterAuthSchema(
+          nuxt,
+          serverConfigPath!,
+          options,
+          consola,
+          setup.schemaGeneration.hubSecondaryStorage,
+        )
+      }
+
+      registerSharedTypeTemplates({
+        runtimeTypesAugmentPath: setup.sharedTypes.runtimeTypesAugmentPath,
+        runtimeTypesPath: resolver.resolve('./runtime/types'),
+        clientConfigPath,
+        h3TypesPath: nitroImports.h3,
+      })
+
+      registerTemplateHmrHook(nuxt)
+      registerServerRuntime({ clientOnly: setup.clientOnly, resolve: resolver.resolve })
+      registerAuthMiddlewareHook(nuxt, resolver.resolve)
+
+      await registerDevtools({ nuxt, clientOnly: setup.clientOnly, hasHubDb: setup.database.hasHubDb, resolve: resolver.resolve })
+      registerRouteRulesMetaHook(nuxt)
     })
-
-    registerTemplateHmrHook(nuxt)
-    registerServerRuntime({ clientOnly: setup.clientOnly, resolve: resolver.resolve })
-    registerAuthMiddlewareHook(nuxt, resolver.resolve)
-
-    await registerDevtools({ nuxt, clientOnly: setup.clientOnly, hasHubDb: setup.database.hasHubDb, resolve: resolver.resolve })
-    registerRouteRulesMetaHook(nuxt)
   },
 })
 

--- a/src/module/config-paths.ts
+++ b/src/module/config-paths.ts
@@ -2,7 +2,7 @@ import type { Nuxt } from '@nuxt/schema'
 import type { BetterAuthModuleOptions } from '../runtime/config'
 import { existsSync } from 'node:fs'
 import { getLayerDirectories } from '@nuxt/kit'
-import { isAbsolute, join, relative } from 'pathe'
+import { isAbsolute, join, relative, resolve } from 'pathe'
 
 export type ModuleConfigKind = 'server' | 'client'
 
@@ -31,6 +31,10 @@ const DEFAULT_CONFIG_FILES = {
 const OPTION_KEY_BY_KIND = {
   server: 'serverConfig',
   client: 'clientConfig',
+} satisfies Record<ModuleConfigKind, keyof BetterAuthModuleOptions>
+const PLUGIN_OPTION_KEY_BY_KIND = {
+  server: 'serverPluginSources',
+  client: 'clientPluginSources',
 } satisfies Record<ModuleConfigKind, keyof BetterAuthModuleOptions>
 
 function stripConfigExtension(path: string): string {
@@ -171,4 +175,20 @@ export function resolveAuthConfigDescriptors(
     server: resolveAuthConfigDescriptor(nuxt, 'server', files.server, dependencies),
     client: resolveAuthConfigDescriptor(nuxt, 'client', files.client, dependencies),
   }
+}
+
+export function resolveAuthPluginSources(nuxt: Nuxt): Record<ModuleConfigKind, string[]> {
+  const resolved = { server: [], client: [] } as Record<ModuleConfigKind, string[]>
+
+  for (const { directory, layer } of getLayerDirectoriesWithConfigs(nuxt)) {
+    for (const kind of ['server', 'client'] as const) {
+      const sources = layer?.config?.auth?.[PLUGIN_OPTION_KEY_BY_KIND[kind]]
+      if (!Array.isArray(sources))
+        continue
+
+      resolved[kind].push(...sources.map(source => isAbsolute(source) ? source : resolve(directory.root, source)))
+    }
+  }
+
+  return resolved
 }

--- a/src/module/schema.ts
+++ b/src/module/schema.ts
@@ -18,6 +18,7 @@ interface SchemaContext {
 type HubSecondaryStorageMode = BetterAuthModuleOptions['hubSecondaryStorage']
 
 const NODE_MODULES_SEGMENT_RE = /[\\/]/
+const CONFIG_EXTENSION_RE = /\.[cm]?[jt]s$/
 
 export function resolveSchemaSecondaryStorageInjection(
   hubSecondaryStorage: HubSecondaryStorageMode,
@@ -67,7 +68,7 @@ export function resolveHubSchemaPath(
 
 async function loadAuthOptions(context: SchemaContext) {
   const isProduction = !context.nuxt.options.dev
-  const configFile = `${context.serverConfigPath}.ts`
+  const configFile = CONFIG_EXTENSION_RE.test(context.serverConfigPath) ? context.serverConfigPath : `${context.serverConfigPath}.ts`
   const alias = Object.fromEntries(
     Object.entries(context.nuxt.options.alias)
       .filter(([, value]) => typeof value === 'string')

--- a/src/module/setup.ts
+++ b/src/module/setup.ts
@@ -4,13 +4,14 @@ import type {
   BetterAuthDatabaseProviderBuildContext,
   BetterAuthDatabaseProviderDefinition,
   BetterAuthDatabaseProviderEnabledContext,
+  BetterAuthPluginSources,
 } from '../types/hooks'
 import type { AuthConfigDescriptor } from './config-paths'
 import type { NuxtHubOptions } from './hub'
 import { hasNuxtModule } from '@nuxt/kit'
 import { dirname } from 'pathe'
 import { resolveDatabaseProvider } from '../database-provider'
-import { resolveAuthConfigDescriptors } from './config-paths'
+import { resolveAuthConfigDescriptors, resolveAuthPluginSources } from './config-paths'
 import { getHubCasing, getHubDialect } from './hub'
 import { setupRuntimeConfig } from './runtime'
 import { buildDatabaseCode } from './templates'
@@ -24,6 +25,10 @@ export interface ResolvedAuthModuleSetup {
   aliases: {
     '#auth/server'?: string
     '#auth/client': string
+  }
+  pluginSources: {
+    server: string[]
+    client: string[]
   }
   hub: {
     hasNuxtHub: boolean
@@ -64,6 +69,7 @@ interface ResolveAuthModuleSetupInput {
   options: BetterAuthModuleOptions
   runtimeTypesAugmentPath: string
   consola: Parameters<typeof setupRuntimeConfig>[0]['consola']
+  registeredPluginSources?: BetterAuthPluginSources
 }
 
 interface ResolveAuthModuleSetupDependencies {
@@ -135,6 +141,10 @@ export async function resolveAuthModuleSetup(
 
   assertConfigPresence(configs, clientOnly)
 
+  const pluginSources = resolveAuthPluginSources(nuxt)
+  pluginSources.server.push(...(input.registeredPluginSources?.server || []))
+  pluginSources.client.push(...(input.registeredPluginSources?.client || []))
+
   const aliases: ResolvedAuthModuleSetup['aliases'] = {
     '#auth/server': clientOnly ? undefined : configs.server.path,
     '#auth/client': configs.client.path,
@@ -198,6 +208,7 @@ export async function resolveAuthModuleSetup(
     clientOnly,
     configs,
     aliases,
+    pluginSources,
     hub: {
       hasNuxtHub,
       options: hub,

--- a/src/module/templates.ts
+++ b/src/module/templates.ts
@@ -1,5 +1,32 @@
 import type { DbDialect } from './hub'
 
+function buildImports(sources: string[]): { imports: string, names: string } {
+  return {
+    imports: sources.map((source, index) => `import plugin${index} from ${JSON.stringify(source)}`).join('\n'),
+    names: sources.map((_, index) => `plugin${index}`).join(', '),
+  }
+}
+
+export function buildExtendedServerAuthCode(configPath: string, sources: string[]): string {
+  const plugins = buildImports(sources)
+  return `import createAppAuth from ${JSON.stringify(configPath)}
+import { extendServerAuth } from '@nuxtjs/better-auth/config'
+${plugins.imports}
+
+export default extendServerAuth(createAppAuth, [${plugins.names}])
+`
+}
+
+export function buildExtendedClientAuthCode(configPath: string, sources: string[]): string {
+  const plugins = buildImports(sources)
+  return `import createAppAuthClient from ${JSON.stringify(configPath)}
+import { extendClientAuth } from '@nuxtjs/better-auth/config'
+${plugins.imports}
+
+export default extendClientAuth(createAppAuthClient, [${plugins.names}])
+`
+}
+
 export function buildSecondaryStorageCode(useHubKV: boolean): string {
   if (!useHubKV)
     return 'export function createSecondaryStorage() { return undefined }'

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -1,5 +1,5 @@
 import type { BetterAuthOptions, BetterAuthPlugin } from 'better-auth'
-import type { BetterAuthClientOptions } from 'better-auth/client'
+import type { BetterAuthClientOptions, BetterAuthClientPlugin } from 'better-auth/client'
 import type { ServerAuthContext as BaseServerAuthContext } from './types/augment'
 import { createAuthClient } from 'better-auth/vue'
 
@@ -18,6 +18,14 @@ export type ClientAuthConfig = Omit<BetterAuthClientOptions, 'baseURL'> & { base
 
 export type ServerAuthConfigFn = (ctx: ServerAuthContext) => ServerAuthConfig
 export type ClientAuthConfigFn = (ctx: ClientAuthContext) => ClientAuthConfig
+type ServerPlugins<T> = T extends { plugins: infer P extends readonly BetterAuthPlugin[] } ? P : []
+type ClientPlugins<T> = T extends { plugins: infer P extends BetterAuthClientPlugin[] } ? P : []
+type ExtendedServerAuthConfig<T, P extends readonly BetterAuthPlugin[]> = Omit<T, 'plugins'> & { plugins: [...ServerPlugins<T>, ...P] }
+type ExtendedClientAuthConfig<T, P extends BetterAuthClientPlugin[]> = Omit<T, 'plugins'> & { plugins: [...ClientPlugins<T>, ...P] }
+
+export type ClientAuthFactory<T extends ClientAuthConfig> = ((baseURL: string) => ReturnType<typeof createAuthClient<T>>) & {
+  resolveOptions: (baseURL: string) => T & { baseURL: string }
+}
 export type ModuleDatabaseProviderId = 'none' | 'nuxthub' | (string & {})
 export type EffectiveDatabaseProviderId = 'user' | ModuleDatabaseProviderId
 
@@ -29,6 +37,10 @@ export interface BetterAuthModuleOptions {
   serverConfig?: string
   /** Client config path. Relative paths resolve from the layer that declares them. Default: 'app/auth.config' */
   clientConfig?: string
+  /** Server plugin modules. Relative paths resolve from the layer that declares them. */
+  serverPluginSources?: string[]
+  /** Client plugin modules. Relative paths resolve from the layer that declares them. */
+  clientPluginSources?: string[]
   redirects?: {
     /** Where to redirect unauthenticated users. Default: '/login' */
     login?: string
@@ -91,12 +103,39 @@ export function defineServerAuth(config: ServerAuthConfig | ((ctx: ServerAuthCon
   return typeof config === 'function' ? config : () => config
 }
 
-export function defineClientAuth<T extends ClientAuthConfig>(config: T | ((ctx: ClientAuthContext) => T)): (baseURL: string) => ReturnType<typeof createAuthClient<T>> {
-  return (baseURL: string) => {
+export function extendServerAuth<const R extends ServerAuthConfig, const P extends readonly BetterAuthPlugin[]>(
+  createConfig: (ctx: ServerAuthContext) => R,
+  plugins: P,
+): (ctx: ServerAuthContext) => ExtendedServerAuthConfig<R, P> {
+  return (ctx) => {
+    const config = createConfig(ctx)
+    const basePlugins = (config.plugins || []) as ServerPlugins<R>
+    return { ...config, plugins: [...basePlugins, ...plugins] } as ExtendedServerAuthConfig<R, P>
+  }
+}
+
+function createClientAuthFactory<T extends ClientAuthConfig>(resolveOptions: (baseURL: string) => T & { baseURL: string }): ClientAuthFactory<T> {
+  const factory = ((baseURL: string) => createAuthClient(resolveOptions(baseURL))) as ClientAuthFactory<T>
+  factory.resolveOptions = resolveOptions
+  return factory
+}
+
+export function defineClientAuth<T extends ClientAuthConfig>(config: T | ((ctx: ClientAuthContext) => T)): ClientAuthFactory<T> {
+  return createClientAuthFactory((baseURL) => {
     const ctx: ClientAuthContext = { siteUrl: baseURL }
     const resolved = typeof config === 'function' ? config(ctx) : config
     const { baseURL: configuredBaseURL, ...resolvedOptions } = resolved
-    const clientOptions = { ...resolvedOptions, baseURL: configuredBaseURL ?? baseURL } as T
-    return createAuthClient(clientOptions)
-  }
+    return { ...resolvedOptions, baseURL: configuredBaseURL ?? baseURL } as T & { baseURL: string }
+  })
+}
+
+export function extendClientAuth<T extends ClientAuthConfig, const P extends BetterAuthClientPlugin[]>(
+  createClient: ClientAuthFactory<T>,
+  plugins: P,
+): ClientAuthFactory<ExtendedClientAuthConfig<T, P>> {
+  return createClientAuthFactory((baseURL) => {
+    const config = createClient.resolveOptions(baseURL)
+    const basePlugins = (config.plugins || []) as ClientPlugins<T>
+    return { ...config, plugins: [...basePlugins, ...plugins] } as ExtendedClientAuthConfig<T, P> & { baseURL: string }
+  })
 }

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -37,9 +37,9 @@ export interface BetterAuthModuleOptions {
   serverConfig?: string
   /** Client config path. Relative paths resolve from the layer that declares them. Default: 'app/auth.config' */
   clientConfig?: string
-  /** Server plugin modules. Relative paths resolve from the layer that declares them. */
+  /** Server plugin modules. Relative paths resolve from the declaring layer. Sources are additive and are not deduplicated. */
   serverPluginSources?: string[]
-  /** Client plugin modules. Relative paths resolve from the layer that declares them. */
+  /** Client plugin modules. Relative paths resolve from the declaring layer. Sources are additive and are not deduplicated. */
   clientPluginSources?: string[]
   redirects?: {
     /** Where to redirect unauthenticated users. Default: '/login' */

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -33,7 +33,7 @@ export interface BetterAuthDatabaseProviderDefinition {
 
 declare module '@nuxt/schema' {
   interface NuxtHooks {
-    /** Register absolute server and client plugin module paths. */
+    /** Register absolute plugin module paths during module setup. Sources are additive and are not deduplicated. */
     'better-auth:plugins:extend': (sources: BetterAuthPluginSources) => void | Promise<void>
 
     /**

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -3,6 +3,11 @@ import type { BetterAuthOptions } from 'better-auth'
 import type { DbDialect } from '../module/hub'
 import type { BetterAuthModuleOptions } from '../runtime/config'
 
+export interface BetterAuthPluginSources {
+  server?: string[]
+  client?: string[]
+}
+
 export interface BetterAuthDatabaseProviderBuildContext {
   hubDialect: DbDialect
   usePlural: boolean
@@ -28,6 +33,9 @@ export interface BetterAuthDatabaseProviderDefinition {
 
 declare module '@nuxt/schema' {
   interface NuxtHooks {
+    /** Register absolute server and client plugin module paths. */
+    'better-auth:plugins:extend': (sources: BetterAuthPluginSources) => void | Promise<void>
+
     /**
      * Extend better-auth config with additional plugins or options.
      * Called after user's auth.config.ts is loaded.

--- a/test/cases/layer-plugin-contributions-base/app/layer-plugin.ts
+++ b/test/cases/layer-plugin-contributions-base/app/layer-plugin.ts
@@ -1,0 +1,3 @@
+import { usernameClient } from 'better-auth/client/plugins'
+
+export default usernameClient()

--- a/test/cases/layer-plugin-contributions-base/nuxt.config.ts
+++ b/test/cases/layer-plugin-contributions-base/nuxt.config.ts
@@ -1,0 +1,6 @@
+export default defineNuxtConfig({
+  auth: {
+    serverPluginSources: ['./server/layer-plugin'],
+    clientPluginSources: ['./app/layer-plugin'],
+  },
+})

--- a/test/cases/layer-plugin-contributions-base/server/layer-plugin.ts
+++ b/test/cases/layer-plugin-contributions-base/server/layer-plugin.ts
@@ -1,0 +1,26 @@
+import { createAuthEndpoint } from 'better-auth/api'
+
+export default {
+  id: 'layer-server-plugin',
+  endpoints: {
+    layerProof: createAuthEndpoint('/layer-proof', { method: 'GET' }, async () => ({ source: 'layer' as const })),
+  },
+  schema: {
+    layerRecord: {
+      fields: {
+        value: {
+          type: 'string',
+          required: true,
+        },
+      },
+    },
+    user: {
+      fields: {
+        layerField: {
+          type: 'string',
+          required: false,
+        },
+      },
+    },
+  },
+} as const

--- a/test/cases/layer-plugin-contributions-runtime/app/app.vue
+++ b/test/cases/layer-plugin-contributions-runtime/app/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>layer plugin runtime</div>
+</template>

--- a/test/cases/layer-plugin-contributions-runtime/late-module.ts
+++ b/test/cases/layer-plugin-contributions-runtime/late-module.ts
@@ -1,0 +1,11 @@
+import { fileURLToPath } from 'node:url'
+import { defineNuxtModule } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  setup(_options, nuxt) {
+    nuxt.hook('better-auth:plugins:extend', (sources) => {
+      sources.server ||= []
+      sources.server.push(fileURLToPath(new URL('./server/module-plugin', import.meta.url)))
+    })
+  },
+})

--- a/test/cases/layer-plugin-contributions-runtime/nuxt.config.ts
+++ b/test/cases/layer-plugin-contributions-runtime/nuxt.config.ts
@@ -1,0 +1,4 @@
+export default defineNuxtConfig({
+  extends: ['../core-auth', '../layer-plugin-contributions-base'],
+  modules: ['@nuxthub/core', '../../../src/module', './late-module'],
+})

--- a/test/cases/layer-plugin-contributions-runtime/server/api/test/layer-plugin.get.ts
+++ b/test/cases/layer-plugin-contributions-runtime/server/api/test/layer-plugin.get.ts
@@ -1,0 +1,6 @@
+import * as schema from '#auth/schema'
+
+export default defineEventHandler(() => ({
+  hasLayerField: Boolean(schema.user && 'layerField' in schema.user),
+  hasLayerTable: Boolean(schema.layerRecord),
+}))

--- a/test/cases/layer-plugin-contributions-runtime/server/module-plugin.ts
+++ b/test/cases/layer-plugin-contributions-runtime/server/module-plugin.ts
@@ -1,0 +1,8 @@
+import { createAuthEndpoint } from 'better-auth/api'
+
+export default {
+  id: 'module-server-plugin',
+  endpoints: {
+    moduleProof: createAuthEndpoint('/module-proof', { method: 'GET' }, async () => ({ source: 'module' as const })),
+  },
+} as const

--- a/test/cases/layer-plugin-contributions/app/app-plugin.ts
+++ b/test/cases/layer-plugin-contributions/app/app-plugin.ts
@@ -1,0 +1,1 @@
+export default { id: 'app-client-plugin' }

--- a/test/cases/layer-plugin-contributions/app/app.vue
+++ b/test/cases/layer-plugin-contributions/app/app.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import type { AuthUser } from '#nuxt-better-auth'
+import { useFetch } from 'nuxt/app'
+
+declare const user: AuthUser
+
+const layerField: string | null | undefined = user.layerField
+const client = useAuthClient()
+const signInUsername = client?.signIn.username
+const { data } = useFetch('/api/auth/layer-proof', { method: 'GET' })
+const source: 'layer' | undefined = data.value?.source
+
+void layerField
+void signInUsername
+void source
+</script>
+
+<template>
+  <div>layer plugin contributions</div>
+</template>

--- a/test/cases/layer-plugin-contributions/nuxt.config.ts
+++ b/test/cases/layer-plugin-contributions/nuxt.config.ts
@@ -1,0 +1,7 @@
+export default defineNuxtConfig({
+  extends: ['../_base-module', '../layer-plugin-contributions-base'],
+  auth: {
+    serverPluginSources: ['./server/app-plugin'],
+    clientPluginSources: ['./app/app-plugin'],
+  },
+})

--- a/test/cases/layer-plugin-contributions/server/app-plugin.ts
+++ b/test/cases/layer-plugin-contributions/server/app-plugin.ts
@@ -1,1 +1,3 @@
-export default { id: 'app-server-plugin' }
+import { appServerPluginId } from '#server/plugin-id'
+
+export default { id: appServerPluginId }

--- a/test/cases/layer-plugin-contributions/server/app-plugin.ts
+++ b/test/cases/layer-plugin-contributions/server/app-plugin.ts
@@ -1,0 +1,1 @@
+export default { id: 'app-server-plugin' }

--- a/test/cases/layer-plugin-contributions/server/plugin-id.ts
+++ b/test/cases/layer-plugin-contributions/server/plugin-id.ts
@@ -1,0 +1,1 @@
+export const appServerPluginId = 'app-server-plugin'

--- a/test/client-auth-config.test.ts
+++ b/test/client-auth-config.test.ts
@@ -8,7 +8,7 @@ vi.mock('better-auth/vue', () => ({
   createAuthClient,
 }))
 
-const { defineClientAuth } = await import('../src/runtime/config')
+const { defineClientAuth, extendClientAuth } = await import('../src/runtime/config')
 
 describe('defineClientAuth', () => {
   it('passes the inferred siteUrl to function syntax', () => {
@@ -59,6 +59,16 @@ describe('defineClientAuth', () => {
 
     expect(client).toMatchObject({
       baseURL: 'https://derived.example/api/auth',
+    })
+  })
+
+  it('appends contributed plugins after the app plugins', () => {
+    const appPlugin = { id: 'app' }
+    const layerPlugin = { id: 'layer' }
+    const factory = extendClientAuth(defineClientAuth({ plugins: [appPlugin] }), [layerPlugin])
+
+    expect(factory('https://example.test')).toMatchObject({
+      plugins: [appPlugin, layerPlugin],
     })
   })
 })

--- a/test/config-paths.test.ts
+++ b/test/config-paths.test.ts
@@ -2,7 +2,7 @@ import type { Nuxt } from '@nuxt/schema'
 import { fileURLToPath } from 'node:url'
 import { loadNuxt } from '@nuxt/kit'
 import { afterEach, describe, expect, it } from 'vitest'
-import { resolveAuthConfigDescriptor, resolveAuthConfigDescriptors } from '../src/module/config-paths'
+import { resolveAuthConfigDescriptor, resolveAuthConfigDescriptors, resolveAuthPluginSources } from '../src/module/config-paths'
 
 const loadedNuxtInstances: Nuxt[] = []
 
@@ -25,6 +25,21 @@ afterEach(async () => {
 })
 
 describe('resolveAuthConfigDescriptor', () => {
+  it('resolves plugin sources from each declaring layer in Nuxt priority order', async () => {
+    const nuxt = await loadCase('layer-plugin-contributions')
+
+    expect(resolveAuthPluginSources(nuxt)).toEqual({
+      server: [
+        expect.stringContaining('/test/cases/layer-plugin-contributions/server/app-plugin'),
+        expect.stringContaining('/test/cases/layer-plugin-contributions-base/server/layer-plugin'),
+      ],
+      client: [
+        expect.stringContaining('/test/cases/layer-plugin-contributions/app/app-plugin'),
+        expect.stringContaining('/test/cases/layer-plugin-contributions-base/app/layer-plugin'),
+      ],
+    })
+  })
+
   it('discovers default configs from an extended layer', async () => {
     const nuxt = await loadCase('layer-default-configs')
     const configs = resolveAuthConfigDescriptors(nuxt)

--- a/test/layer-plugin-contributions.test.ts
+++ b/test/layer-plugin-contributions.test.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { $fetch, setup } from '@nuxt/test-utils/e2e'
 import { describe, expect, it } from 'vitest'
@@ -35,6 +36,10 @@ describe('layer plugin contributions', async () => {
       env,
       encoding: 'utf8',
     })
-    expect(typecheck.status, `vue-tsc failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)
+    expect(typecheck.status, `app vue-tsc failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)
+
+    const sharedTypes = readFileSync(`${fixtureDir}/.nuxt/nuxt.shared.d.ts`, 'utf8')
+    expect(sharedTypes).not.toContain('types/nuxt-better-auth-infer.d.ts')
+    expect(sharedTypes).not.toContain('types/nuxt-better-auth-social-providers.d.ts')
   }, 60_000)
 })

--- a/test/layer-plugin-contributions.test.ts
+++ b/test/layer-plugin-contributions.test.ts
@@ -1,0 +1,40 @@
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { $fetch, setup } from '@nuxt/test-utils/e2e'
+import { describe, expect, it } from 'vitest'
+
+const fixtureDir = fileURLToPath(new URL('./cases/layer-plugin-contributions', import.meta.url))
+const runtimeFixtureDir = fileURLToPath(new URL('./cases/layer-plugin-contributions-runtime', import.meta.url))
+const env = {
+  ...process.env,
+  BETTER_AUTH_SECRET: 'test-secret-for-testing-only-32chars',
+}
+
+describe('layer plugin contributions', async () => {
+  await setup({ rootDir: runtimeFixtureDir })
+
+  it('uses the contributed plugin in the schema and running auth instance', async () => {
+    await expect($fetch('/api/auth/layer-proof')).resolves.toEqual({ source: 'layer' })
+    await expect($fetch('/api/auth/module-proof')).resolves.toEqual({ source: 'module' })
+    await expect($fetch('/api/test/layer-plugin')).resolves.toEqual({
+      hasLayerField: true,
+      hasLayerTable: true,
+    })
+  })
+
+  it('includes contributed server fields, endpoints, and client actions in app types', () => {
+    const prepare = spawnSync('npx', ['nuxi', 'prepare'], {
+      cwd: fixtureDir,
+      env,
+      encoding: 'utf8',
+    })
+    expect(prepare.status, `nuxi prepare failed:\n${prepare.stdout}\n${prepare.stderr}`).toBe(0)
+
+    const typecheck = spawnSync('npx', ['vue-tsc', '--noEmit', '--pretty', 'false', '-p', '.nuxt/tsconfig.app.json'], {
+      cwd: fixtureDir,
+      env,
+      encoding: 'utf8',
+    })
+    expect(typecheck.status, `vue-tsc failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)
+  }, 60_000)
+})

--- a/test/server-auth-config.test.ts
+++ b/test/server-auth-config.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { defineServerAuth, extendServerAuth } from '../src/runtime/config'
+
+describe('extendServerAuth', () => {
+  it('appends contributed plugins after the app plugins', () => {
+    const appPlugin = { id: 'app' }
+    const layerPlugin = { id: 'layer' }
+    const factory = extendServerAuth(defineServerAuth({ plugins: [appPlugin] }), [layerPlugin])
+
+    expect(factory({} as never).plugins).toEqual([appPlugin, layerPlugin])
+  })
+})


### PR DESCRIPTION
Nuxt layers can now ship server and client Better Auth plugins. Each source path resolves from the layer that declared it. Nuxt modules can add absolute source paths through `better-auth:plugins:extend`.

A layer can own an auth-backed feature without asking the app to edit either auth config. Schema generation, the running auth instances, endpoint inference, and client types now read the same ordered plugin lists.

Closes #421.

### Why generated configs

Better Auth plugins contain functions and change its inferred types. `app.config` and serialized `runtimeConfig` values cannot carry them. A later module also cannot reliably mutate `nuxt.options.auth`, because module setup receives resolved options rather than a live reference.

Nuxt I18n solves the same layer ownership problem in much the same way. It [keeps relative sources tied to their layer root](https://github.com/nuxt-modules/i18n/blob/c5e1edabecf32848d12b1e789c8e4f0c13a02f75/src/layers.ts#L46-L95), accepts additions through a module hook, and [builds its runtime and type inputs at `modules:done`](https://github.com/nuxt-modules/i18n/blob/c5e1edabecf32848d12b1e789c8e4f0c13a02f75/src/module.ts#L160-L188). The generated Better Auth files statically import the final plugin lists, which keeps schema, runtime, and types in sync.

### Ordering and contribution contract

Plugin order is stable:

1. Plugins from the app auth config.
2. Layer sources in Nuxt priority order.
3. Module contributions in hook registration order.

Modules must register `better-auth:plugins:extend` during module setup. The module does not deduplicate source paths. Declaring the same source twice runs that plugin twice.

### Scope

GitHub reports a net `+375` lines. Only `+137` is shipped source. Documentation accounts for `+57`; tests and fixtures account for `+181`. The source change resolves layer paths, generates the two effective configs, exposes the typed hook, and points the existing consumers at those configs.

### Verification

The published-package reproduction uses a standalone Nuxt 4.5.2 app with `@nuxtjs/better-auth@0.2.2`. Without the patch, the app plugin endpoint returned `200` and the layer plugin endpoint returned `404`. After applying the built package with `pnpm patch` and adding the layer's `serverPluginSources`, both returned `200`.

Checks run:

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm prepack`
- `pnpm build:docs`
- `BETTER_AUTH_SECRET=ci-test-secret-12345678901234567890 pnpm dev:build`
- The [layer contribution regression fixture](https://github.com/nuxt-modules/better-auth/tree/e45db66c63d50982573c85dff8f109feb3d6058f/test/cases/layer-plugin-contributions-runtime) verifies a contributed table, user column, endpoint, late module plugin, and client types.
