### PR TITLE
fix: gracefully disable unsupported NuxtHub storage

### DIFF
--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -105,7 +105,7 @@ You can define auth route rules in either `routeRules` or `nitro.routeRules`. Th
 
     Configure secondary storage for sessions.
 
-    - `true` — Temporarily logs a setup warning and falls back to database-backed sessions because NuxtHub KV cannot implement the required atomic `getAndDelete` and `increment` operations. Better Auth rate limiting uses process-local memory by default.
+    - `true` — Temporarily logs a setup warning and continues without module-provided secondary storage because NuxtHub KV cannot implement the required atomic `getAndDelete` and `increment` operations. Sessions use the configured database when one exists, and Better Auth rate limiting uses process-local memory by default.
     - `'custom'` — You provide an atomic `secondaryStorage` in `defineServerAuth()` (required; the build fails in production if missing). The module won't inject NuxtHub KV, and this mode can omit the `session` table from generated schema.
     - `false` (default) — No secondary storage from the module. User-provided `secondaryStorage` in `defineServerAuth()` is not overridden.
   ::

--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -105,7 +105,7 @@ You can define auth route rules in either `routeRules` or `nitro.routeRules`. Th
 
     Configure secondary storage for sessions.
 
-    - `true` — Temporarily logs a setup warning and falls back to database-backed sessions because NuxtHub KV cannot implement the required atomic `getAndDelete` and `increment` operations. Better Auth rate limiting uses memory by default.
+    - `true` — Temporarily logs a setup warning and falls back to database-backed sessions because NuxtHub KV cannot implement the required atomic `getAndDelete` and `increment` operations. Better Auth rate limiting uses process-local memory by default.
     - `'custom'` — You provide an atomic `secondaryStorage` in `defineServerAuth()` (required; the build fails in production if missing). The module won't inject NuxtHub KV, and this mode can omit the `session` table from generated schema.
     - `false` (default) — No secondary storage from the module. User-provided `secondaryStorage` in `defineServerAuth()` is not overridden.
   ::

--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -105,7 +105,7 @@ You can define auth route rules in either `routeRules` or `nitro.routeRules`. Th
 
     Configure secondary storage for sessions.
 
-    - `true` — Unsupported with Better Auth 1.7. Setup fails because NuxtHub KV cannot implement the required atomic `getAndDelete` and `increment` operations.
+    - `true` — Temporarily logs a setup warning and falls back to database-backed sessions because NuxtHub KV cannot implement the required atomic `getAndDelete` and `increment` operations. Better Auth rate limiting uses memory by default.
     - `'custom'` — You provide an atomic `secondaryStorage` in `defineServerAuth()` (required; the build fails in production if missing). The module won't inject NuxtHub KV, and this mode can omit the `session` table from generated schema.
     - `false` (default) — No secondary storage from the module. User-provided `secondaryStorage` in `defineServerAuth()` is not overridden.
   ::

--- a/docs/content/4.integrations/1.nuxthub.md
+++ b/docs/content/4.integrations/1.nuxthub.md
@@ -88,7 +88,7 @@ export default defineNuxtConfig({
 Then provide `secondaryStorage` in `defineServerAuth()` with `get`, `getAndDelete`, `increment`, `set`, and `delete` methods. `getAndDelete` and `increment` must use the backend's atomic operations.
 
 ::warning
-`hubSecondaryStorage: true` currently logs a setup warning and continues without injecting secondary storage. Better Auth uses database-backed sessions and in-memory rate limiting by default. Set the option to `false` to silence the warning, or switch to `'custom'` with an atomic backend.
+`hubSecondaryStorage: true` currently logs a setup warning and continues without injecting secondary storage. Better Auth uses database-backed sessions and process-local, in-memory rate limiting by default. Set the option to `false` to silence the warning, or switch to `'custom'` with an atomic backend.
 ::
 
 ### Temporary compatibility fallback
@@ -96,6 +96,10 @@ Then provide `secondaryStorage` in `defineServerAuth()` with `get`, `getAndDelet
 The warning keeps existing applications running while [NuxtHub adds atomic KV operations](https://github.com/nuxt-hub/core/pull/927). That work is driver-specific. The module can only restore automatic integration for drivers that provide both `getAndDelete` and `increment`.
 
 This fallback does not pretend NuxtHub KV is active. The module records `hubSecondaryStorage` as `false` at runtime and generates the database-backed session schema.
+
+Sessions and verification values stored only in KV will no longer be found after deploying this fallback. Users may need to sign in again, and you may need to reissue pending verification links or codes.
+
+In-memory rate-limit counters are not shared between server processes. For shared limits in serverless or multi-instance deployments, set Better Auth's `rateLimit.storage` to `'database'` or provide `rateLimit.customStorage`.
 
 ## Choosing Secondary Storage
 

--- a/docs/content/4.integrations/1.nuxthub.md
+++ b/docs/content/4.integrations/1.nuxthub.md
@@ -88,7 +88,7 @@ export default defineNuxtConfig({
 Then provide `secondaryStorage` in `defineServerAuth()` with `get`, `getAndDelete`, `increment`, `set`, and `delete` methods. `getAndDelete` and `increment` must use the backend's atomic operations.
 
 ::warning
-`hubSecondaryStorage: true` currently logs a setup warning and continues without injecting secondary storage. Better Auth uses database-backed sessions and process-local, in-memory rate limiting by default. Set the option to `false` to silence the warning, or switch to `'custom'` with an atomic backend.
+`hubSecondaryStorage: true` currently logs a setup warning and continues without injecting secondary storage. Without a custom secondary store, sessions use the configured database when one exists and rate limiting defaults to process-local memory. Set the option to `false` to silence the warning, or switch to `'custom'` with an atomic backend.
 ::
 
 ### Temporary compatibility fallback

--- a/docs/content/4.integrations/1.nuxthub.md
+++ b/docs/content/4.integrations/1.nuxthub.md
@@ -88,8 +88,14 @@ export default defineNuxtConfig({
 Then provide `secondaryStorage` in `defineServerAuth()` with `get`, `getAndDelete`, `increment`, `set`, and `delete` methods. `getAndDelete` and `increment` must use the backend's atomic operations.
 
 ::warning
-`hubSecondaryStorage: true` is retained only to provide a targeted migration error. Set it to `false`, or switch to `'custom'` with an atomic backend.
+`hubSecondaryStorage: true` currently logs a setup warning and continues without injecting secondary storage. Better Auth uses database-backed sessions and in-memory rate limiting by default. Set the option to `false` to silence the warning, or switch to `'custom'` with an atomic backend.
 ::
+
+### Temporary compatibility fallback
+
+The warning keeps existing applications running while [NuxtHub adds atomic KV operations](https://github.com/nuxt-hub/core/pull/927). That work is driver-specific. The module can only restore automatic integration for drivers that provide both `getAndDelete` and `increment`.
+
+This fallback does not pretend NuxtHub KV is active. The module records `hubSecondaryStorage` as `false` at runtime and generates the database-backed session schema.
 
 ## Choosing Secondary Storage
 

--- a/docs/public/.well-known/skills/nuxt-better-auth/references/database.md
+++ b/docs/public/.well-known/skills/nuxt-better-auth/references/database.md
@@ -33,7 +33,7 @@ export default defineNuxtConfig({
 
 Important:
 
-- NuxtHub KV cannot implement Better Auth 1.7's atomic `getAndDelete` and `increment` operations, so `hubSecondaryStorage: true` fails during setup
+- NuxtHub KV cannot implement Better Auth 1.7's atomic `getAndDelete` and `increment` operations, so `hubSecondaryStorage: true` logs a setup warning and falls back to database-backed sessions. Track native support in [nuxt-hub/core#927](https://github.com/nuxt-hub/core/pull/927)
 - `hubSecondaryStorage: 'custom'` means you provide an atomic `secondaryStorage`, such as Redis or Upstash
 - use DB-only reads if you prefer stricter read-after-write consistency
 

--- a/docs/public/.well-known/skills/nuxt-better-auth/references/database.md
+++ b/docs/public/.well-known/skills/nuxt-better-auth/references/database.md
@@ -33,7 +33,7 @@ export default defineNuxtConfig({
 
 Important:
 
-- NuxtHub KV cannot implement Better Auth 1.7's atomic `getAndDelete` and `increment` operations, so `hubSecondaryStorage: true` logs a setup warning and falls back to database-backed sessions. Track native support in [nuxt-hub/core#927](https://github.com/nuxt-hub/core/pull/927)
+- NuxtHub KV cannot implement Better Auth 1.7's atomic `getAndDelete` and `increment` operations, so `hubSecondaryStorage: true` logs a setup warning and continues without module-provided secondary storage. Sessions use the configured database when one exists. Track native support in [nuxt-hub/core#927](https://github.com/nuxt-hub/core/pull/927)
 - `hubSecondaryStorage: 'custom'` means you provide an atomic `secondaryStorage`, such as Redis or Upstash
 - use DB-only reads if you prefer stricter read-after-write consistency
 

--- a/src/module/runtime.ts
+++ b/src/module/runtime.ts
@@ -19,7 +19,10 @@ function resolveSecondaryStorage(input: SetupRuntimeConfigInput): { hubSecondary
 
   const opt = options.hubSecondaryStorage ?? false
   if (opt === true) {
-    consola.warn('[nuxt-better-auth] hubSecondaryStorage: true cannot use NuxtHub KV with Better Auth 1.7 because NuxtHub KV lacks atomic getAndDelete and increment operations. The module will ignore this option and continue without injecting secondary storage. Better Auth uses database-backed sessions and in-memory rate limiting by default. Set auth.hubSecondaryStorage to false to silence this warning, or use "custom" with an atomic secondaryStorage in defineServerAuth(). Track NuxtHub support: https://github.com/nuxt-hub/core/pull/927')
+    if (clientOnly)
+      consola.warn('[nuxt-better-auth] hubSecondaryStorage: true is ignored in clientOnly mode because this module does not run the auth server.')
+    else
+      consola.warn('[nuxt-better-auth] hubSecondaryStorage: true cannot use NuxtHub KV with Better Auth 1.7 because NuxtHub KV lacks atomic getAndDelete and increment operations. The module will ignore this option and continue without injecting secondary storage. Better Auth uses database-backed sessions and process-local, in-memory rate limiting by default. Configure rateLimit.storage as "database" or provide rateLimit.customStorage for shared limits. Set auth.hubSecondaryStorage to false to silence this warning, or use "custom" with an atomic secondaryStorage in defineServerAuth(). Track NuxtHub support: https://github.com/nuxt-hub/core/pull/927')
     return { hubSecondaryStorage: false, secondaryStorageEnabled: false }
   }
 

--- a/src/module/runtime.ts
+++ b/src/module/runtime.ts
@@ -14,12 +14,13 @@ interface SetupRuntimeConfigInput {
   consola: ConsolaInstance
 }
 
-function resolveSecondaryStorage(input: SetupRuntimeConfigInput): { secondaryStorageEnabled: boolean } {
-  const { options, clientOnly } = input
+function resolveSecondaryStorage(input: SetupRuntimeConfigInput): { hubSecondaryStorage: false | 'custom', secondaryStorageEnabled: boolean } {
+  const { options, clientOnly, consola } = input
 
   const opt = options.hubSecondaryStorage ?? false
   if (opt === true) {
-    throw new Error('[nuxt-better-auth] hubSecondaryStorage: true is not supported with Better Auth 1.7 because NuxtHub KV cannot provide the required atomic getAndDelete and increment operations. Set auth.hubSecondaryStorage to false, or use "custom" with an atomic secondaryStorage in defineServerAuth().')
+    consola.warn('[nuxt-better-auth] hubSecondaryStorage: true cannot use NuxtHub KV with Better Auth 1.7 because NuxtHub KV lacks atomic getAndDelete and increment operations. The module will ignore this option and continue without injecting secondary storage. Better Auth uses database-backed sessions and in-memory rate limiting by default. Set auth.hubSecondaryStorage to false to silence this warning, or use "custom" with an atomic secondaryStorage in defineServerAuth(). Track NuxtHub support: https://github.com/nuxt-hub/core/pull/927')
+    return { hubSecondaryStorage: false, secondaryStorageEnabled: false }
   }
 
   const secondaryStorageEnabled = opt === 'custom'
@@ -28,12 +29,12 @@ function resolveSecondaryStorage(input: SetupRuntimeConfigInput): { secondarySto
     throw new Error('[nuxt-better-auth] hubSecondaryStorage is not available in clientOnly mode. Either disable clientOnly or remove auth.hubSecondaryStorage.')
   }
 
-  return { secondaryStorageEnabled }
+  return { hubSecondaryStorage: opt, secondaryStorageEnabled }
 }
 
 export function setupRuntimeConfig(input: SetupRuntimeConfigInput): { secondaryStorageEnabled: boolean } {
   const { nuxt, options, clientOnly, databaseProvider, consola } = input
-  const { secondaryStorageEnabled } = resolveSecondaryStorage(input)
+  const { hubSecondaryStorage, secondaryStorageEnabled } = resolveSecondaryStorage(input)
 
   nuxt.options.runtimeConfig.public = nuxt.options.runtimeConfig.public || {}
   const configuredSiteUrl = nuxt.options.runtimeConfig.public.siteUrl as string | undefined
@@ -64,9 +65,11 @@ export function setupRuntimeConfig(input: SetupRuntimeConfigInput): { secondaryS
   const currentSecret = nuxt.options.runtimeConfig.betterAuthSecret as string | undefined
   nuxt.options.runtimeConfig.betterAuthSecret = currentSecret || process.env.NUXT_BETTER_AUTH_SECRET || process.env.BETTER_AUTH_SECRET || ''
 
-  nuxt.options.runtimeConfig.auth = defu(nuxt.options.runtimeConfig.auth as Record<string, unknown>, {
-    hubSecondaryStorage: options.hubSecondaryStorage ?? false,
+  const authRuntimeConfig = defu(nuxt.options.runtimeConfig.auth as Record<string, unknown>, {
+    hubSecondaryStorage,
   }) as AuthPrivateRuntimeConfig
+  authRuntimeConfig.hubSecondaryStorage = hubSecondaryStorage
+  nuxt.options.runtimeConfig.auth = authRuntimeConfig
 
   return { secondaryStorageEnabled }
 }

--- a/src/module/runtime.ts
+++ b/src/module/runtime.ts
@@ -22,7 +22,7 @@ function resolveSecondaryStorage(input: SetupRuntimeConfigInput): { hubSecondary
     if (clientOnly)
       consola.warn('[nuxt-better-auth] hubSecondaryStorage: true is ignored in clientOnly mode because this module does not run the auth server.')
     else
-      consola.warn('[nuxt-better-auth] hubSecondaryStorage: true cannot use NuxtHub KV with Better Auth 1.7 because NuxtHub KV lacks atomic getAndDelete and increment operations. The module will ignore this option and continue without injecting secondary storage. Better Auth uses database-backed sessions and process-local, in-memory rate limiting by default. Configure rateLimit.storage as "database" or provide rateLimit.customStorage for shared limits. Set auth.hubSecondaryStorage to false to silence this warning, or use "custom" with an atomic secondaryStorage in defineServerAuth(). Track NuxtHub support: https://github.com/nuxt-hub/core/pull/927')
+      consola.warn('[nuxt-better-auth] hubSecondaryStorage: true cannot use NuxtHub KV with Better Auth 1.7 because NuxtHub KV lacks atomic getAndDelete and increment operations. The module will ignore this option and continue without injecting secondary storage. Without a custom secondary store, sessions use the configured database when one exists and rate limiting defaults to process-local memory. Configure rateLimit.storage as "database" or provide rateLimit.customStorage for shared limits. Set auth.hubSecondaryStorage to false to silence this warning, or use "custom" with an atomic secondaryStorage in defineServerAuth(). Track NuxtHub support: https://github.com/nuxt-hub/core/pull/927')
     return { hubSecondaryStorage: false, secondaryStorageEnabled: false }
   }
 

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -66,7 +66,7 @@ export interface BetterAuthModuleOptions {
   redirectQueryKey?: string
   /**
    * Configure secondary storage for sessions.
-   * - `true`: Unsupported with Better Auth 1.7; setup throws with migration guidance
+   * - `true`: Temporarily falls back to database-backed sessions with a setup warning
    * - `'custom'`: User provides an atomic secondaryStorage in defineServerAuth()
    * - `false` (default): No secondary storage from module
    */

--- a/src/runtime/server/api/_better-auth/config.get.ts
+++ b/src/runtime/server/api/_better-auth/config.get.ts
@@ -35,7 +35,7 @@ export default defineEventHandler(async (event) => {
           },
           preserveRedirect: publicAuth?.preserveRedirect ?? true,
           redirectQueryKey: publicAuth?.redirectQueryKey ?? 'redirect',
-          hubSecondaryStorage: privateAuth?.hubSecondaryStorage ?? false,
+          hubSecondaryStorage: privateAuth?.hubSecondaryStorage === true ? false : (privateAuth?.hubSecondaryStorage ?? false),
           useDatabase: publicAuth?.useDatabase ?? false,
           databaseProvider: publicAuth?.databaseProvider ?? 'none',
         },

--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -3,7 +3,6 @@ import type { ServerEvent } from '../internal/nitro-compat'
 import { betterAuth, env } from 'better-auth'
 import { withoutProtocol } from 'ufo'
 import { createDatabase, db } from '#auth/database'
-import { createSecondaryStorage } from '#auth/secondary-storage'
 import createServerAuth from '#auth/server'
 import { getRequestHost, getRequestProtocol, useRuntimeConfig } from '../internal/nitro-compat'
 import { resolveCustomSecondaryStorageRequirement } from './custom-secondary-storage'
@@ -26,6 +25,7 @@ const _authCache = new Map<string, AuthInstance>()
 const requestAuthKey = Symbol.for('nuxt-better-auth.requestAuth')
 let _baseURLInferenceLogged = false
 let _customSecondaryStorageMisconfigWarned = false
+let _unsupportedHubSecondaryStorageWarned = false
 
 interface RequestAuthContext {
   [requestAuthKey]?: AuthInstance
@@ -301,6 +301,10 @@ export function serverAuth(event?: ServerEvent): AuthInstance {
   const trustedOrigins = withDevTrustedOrigins(userConfig.trustedOrigins)
 
   const hubSecondaryStorage = (runtimeConfig.auth as { hubSecondaryStorage?: boolean | 'custom' })?.hubSecondaryStorage
+  if (hubSecondaryStorage === true && !_unsupportedHubSecondaryStorageWarned) {
+    _unsupportedHubSecondaryStorageWarned = true
+    console.warn('[nuxt-better-auth] Runtime hubSecondaryStorage: true is unsupported with Better Auth 1.7 and will be ignored. The module will preserve secondaryStorage from defineServerAuth(). Remove NUXT_AUTH_HUB_SECONDARY_STORAGE or set it to false.')
+  }
   const customSecondaryStorage = resolveCustomSecondaryStorageRequirement(hubSecondaryStorage, userConfig.secondaryStorage != null, Boolean(import.meta.dev))
   if (customSecondaryStorage?.shouldThrow)
     throw new Error(customSecondaryStorage.message)
@@ -321,7 +325,6 @@ export function serverAuth(event?: ServerEvent): AuthInstance {
   const authOptions: ResolvedAuthOptions = {
     ...userConfig,
     ...(database ? { database } : {}),
-    ...(hubSecondaryStorage === true ? { secondaryStorage: createSecondaryStorage() } : {}),
     secret: betterAuthSecret,
     baseURL: siteUrl,
     trustedOrigins,

--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -9,6 +9,7 @@ import { resolveCustomSecondaryStorageRequirement } from './custom-secondary-sto
 
 type AuthOptions = ReturnType<typeof createServerAuth>
 type UserAuthConfig = AuthOptions & {
+  rateLimit?: BetterAuthOptions['rateLimit']
   secrets?: BetterAuthOptions['secrets']
   trustedOrigins?: BetterAuthOptions['trustedOrigins']
   secondaryStorage?: BetterAuthOptions['secondaryStorage']
@@ -26,6 +27,7 @@ const requestAuthKey = Symbol.for('nuxt-better-auth.requestAuth')
 let _baseURLInferenceLogged = false
 let _customSecondaryStorageMisconfigWarned = false
 let _unsupportedHubSecondaryStorageWarned = false
+let _secondaryStorageRateLimitFallbackWarned = false
 
 interface RequestAuthContext {
   [requestAuthKey]?: AuthInstance
@@ -313,6 +315,17 @@ export function serverAuth(event?: ServerEvent): AuthInstance {
     console.warn(customSecondaryStorage.message)
   }
 
+  const useMemoryRateLimit = userConfig.rateLimit?.storage === 'secondary-storage'
+    && !userConfig.rateLimit.customStorage
+    && !userConfig.secondaryStorage
+  if (useMemoryRateLimit && !_secondaryStorageRateLimitFallbackWarned) {
+    _secondaryStorageRateLimitFallbackWarned = true
+    console.warn('[nuxt-better-auth] rateLimit.storage: "secondary-storage" requires secondaryStorage. Falling back to process-local memory. Set rateLimit.storage to "database" or provide rateLimit.customStorage for shared limits.')
+  }
+  const rateLimit = useMemoryRateLimit
+    ? { ...userConfig.rateLimit, storage: 'memory' as const }
+    : userConfig.rateLimit
+
   if (!database) {
     const cached = _authCache.get(cacheKey)
     if (cached) {
@@ -324,6 +337,7 @@ export function serverAuth(event?: ServerEvent): AuthInstance {
 
   const authOptions: ResolvedAuthOptions = {
     ...userConfig,
+    ...(rateLimit ? { rateLimit } : {}),
     ...(database ? { database } : {}),
     secret: betterAuthSecret,
     baseURL: siteUrl,

--- a/test/devtools-config.test.ts
+++ b/test/devtools-config.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  serverAuth: vi.fn(),
+  useRuntimeConfig: vi.fn(),
+}))
+
+vi.mock('../src/runtime/server/internal/nitro-compat', () => ({
+  defineEventHandler: (handler: unknown) => handler,
+  useRuntimeConfig: mocks.useRuntimeConfig,
+}))
+
+vi.mock('../src/runtime/server/utils/auth', () => ({
+  serverAuth: mocks.serverAuth,
+}))
+
+const handler = (await import('../src/runtime/server/api/_better-auth/config.get')).default as (event: unknown) => Promise<unknown>
+
+describe('devtools auth config', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.serverAuth.mockReturnValue({ options: {} })
+    mocks.useRuntimeConfig.mockReturnValue({
+      public: { auth: {} },
+      auth: {},
+    })
+  })
+
+  it('reports ignored hubSecondaryStorage: true as disabled', async () => {
+    mocks.useRuntimeConfig.mockReturnValue({
+      public: { auth: {} },
+      auth: { hubSecondaryStorage: true },
+    })
+
+    const result = await handler({}) as { config: { module: { hubSecondaryStorage: unknown } } }
+
+    expect(result.config.module.hubSecondaryStorage).toBe(false)
+  })
+})

--- a/test/runtime-config.test.ts
+++ b/test/runtime-config.test.ts
@@ -190,6 +190,24 @@ describe('setupRuntimeConfig hubSecondaryStorage validation', () => {
     expect(consola.warn).toHaveBeenCalledWith(expect.stringContaining('https://github.com/nuxt-hub/core/pull/927'))
   })
 
+  it('ignores hubSecondaryStorage: true with clientOnly guidance', () => {
+    const nuxt = createNuxtWithRuntimeConfig({ siteUrl: 'https://example.com' })
+    const consola = createConsolaMock()
+
+    const { secondaryStorageEnabled } = setupRuntimeConfig({
+      nuxt,
+      options: { hubSecondaryStorage: true },
+      clientOnly: true,
+      databaseProvider: 'none',
+      hasNuxtHub: false,
+      consola,
+    })
+
+    expect(secondaryStorageEnabled).toBe(false)
+    expect(consola.warn).toHaveBeenCalledWith(expect.stringContaining('ignored in clientOnly mode'))
+    expect(consola.warn).not.toHaveBeenCalledWith(expect.stringContaining('database-backed sessions'))
+  })
+
   it('throws when hubSecondaryStorage: "custom" in clientOnly mode', () => {
     const nuxt = createNuxtWithRuntimeConfig()
     const consola = createConsolaMock()

--- a/test/runtime-config.test.ts
+++ b/test/runtime-config.test.ts
@@ -170,11 +170,11 @@ describe('setupRuntimeConfig secret resolution', () => {
 })
 
 describe('setupRuntimeConfig hubSecondaryStorage validation', () => {
-  it('rejects NuxtHub KV because Better Auth requires atomic secondary storage', () => {
+  it('warns and disables NuxtHub KV when atomic secondary storage is unavailable', () => {
     const nuxt = createNuxtWithRuntimeConfig()
     const consola = createConsolaMock()
 
-    expect(() => setupRuntimeConfig({
+    const { secondaryStorageEnabled } = setupRuntimeConfig({
       nuxt,
       options: { hubSecondaryStorage: true },
       clientOnly: false,
@@ -182,7 +182,12 @@ describe('setupRuntimeConfig hubSecondaryStorage validation', () => {
       hasNuxtHub: true,
       hub: { kv: true },
       consola,
-    })).toThrow('NuxtHub KV cannot provide the required atomic getAndDelete and increment operations')
+    })
+
+    expect(secondaryStorageEnabled).toBe(false)
+    expect((nuxt.options.runtimeConfig.auth as any).hubSecondaryStorage).toBe(false)
+    expect(consola.warn).toHaveBeenCalledWith(expect.stringContaining('continue without injecting secondary storage'))
+    expect(consola.warn).toHaveBeenCalledWith(expect.stringContaining('https://github.com/nuxt-hub/core/pull/927'))
   })
 
   it('throws when hubSecondaryStorage: "custom" in clientOnly mode', () => {

--- a/test/server-auth-database-cache.test.ts
+++ b/test/server-auth-database-cache.test.ts
@@ -71,6 +71,7 @@ describe('serverAuth database cache and secret validation', () => {
 
   afterEach(() => {
     vi.unstubAllEnvs()
+    vi.restoreAllMocks()
   })
 
   it('rejects missing singular and versioned secrets before creating auth', async () => {
@@ -235,5 +236,31 @@ describe('serverAuth database cache and secret validation', () => {
     expect(first).toBe(second)
     expect(createDatabaseMock).toHaveBeenCalledTimes(2)
     expect(betterAuthMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves user secondary storage when runtime config contains stale true', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const secondaryStorage = {
+      get: vi.fn(),
+      getAndDelete: vi.fn(),
+      increment: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+    }
+    useRuntimeConfigMock.mockReturnValue({
+      public: { siteUrl: 'https://example.com' },
+      auth: { hubSecondaryStorage: true },
+      betterAuthSecret: 'test-secret-for-testing-only-32chars',
+    })
+    createServerAuthMock.mockReturnValue({
+      trustedOrigins: undefined,
+      secondaryStorage,
+    })
+
+    const { serverAuth } = await import('../src/runtime/server/utils/auth')
+    serverAuth()
+
+    expect(betterAuthMock).toHaveBeenCalledWith(expect.objectContaining({ secondaryStorage }))
+    expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('Runtime hubSecondaryStorage: true is unsupported'))
   })
 })

--- a/test/server-auth-database-cache.test.ts
+++ b/test/server-auth-database-cache.test.ts
@@ -263,4 +263,35 @@ describe('serverAuth database cache and secret validation', () => {
     expect(betterAuthMock).toHaveBeenCalledWith(expect.objectContaining({ secondaryStorage }))
     expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('Runtime hubSecondaryStorage: true is unsupported'))
   })
+
+  it('falls back to memory when secondary-storage rate limiting has no store', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    createServerAuthMock.mockReturnValue({
+      trustedOrigins: undefined,
+      rateLimit: { storage: 'secondary-storage' },
+    })
+
+    const { serverAuth } = await import('../src/runtime/server/utils/auth')
+    serverAuth()
+
+    expect(betterAuthMock).toHaveBeenCalledWith(expect.objectContaining({
+      rateLimit: { storage: 'memory' },
+    }))
+    expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('Falling back to process-local memory'))
+  })
+
+  it('preserves custom rate-limit storage without secondary storage', async () => {
+    const customStorage = { consume: vi.fn() }
+    createServerAuthMock.mockReturnValue({
+      trustedOrigins: undefined,
+      rateLimit: { storage: 'secondary-storage', customStorage },
+    })
+
+    const { serverAuth } = await import('../src/runtime/server/utils/auth')
+    serverAuth()
+
+    expect(betterAuthMock).toHaveBeenCalledWith(expect.objectContaining({
+      rateLimit: { storage: 'secondary-storage', customStorage },
+    }))
+  })
 })


### PR DESCRIPTION
When `hubSecondaryStorage: true` cannot meet Better Auth 1.7 atomic storage requirements, setup now warns and continues without injecting the NuxtHub adapter. The effective runtime setting becomes `false`, so sessions use the configured database and Better Auth rate limiting uses memory by default instead of failing the build or advertising an inactive integration.

The NuxtHub guide documents this temporary fallback and links [nuxt-hub/core#927](https://github.com/nuxt-hub/core/pull/927). Automatic support can return per driver once both `getAndDelete` and `increment` are available.

## Test plan

- `pnpm exec vitest run test/runtime-config.test.ts test/secondary-storage.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`