### PR TITLE
fix: preserve auth schema in NuxtHub migrations

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -11,7 +11,7 @@ import { version } from '../package.json'
 import { resolveAuthConfigDescriptors } from './module/config-paths'
 import { resolveNitroCompatibilityImports } from './module/compatibility'
 import { registerAuthMiddlewareHook, registerDevtools, registerNuxtHubDatabaseExternalHook, registerPrepareTypesHook, registerRouteRulesMetaHook, registerServerRuntime, registerTemplateHmrHook } from './module/hooks'
-import { setupBetterAuthSchema } from './module/schema'
+import { registerNuxtHubSchemaHook, setupBetterAuthSchema } from './module/schema'
 import { promptForSecret } from './module/secret'
 import { collectAuthRouteRules, resolveAuthModuleSetup } from './module/setup'
 import { buildAuthRouteRulesCode, buildExtendedClientAuthCode, buildExtendedServerAuthCode, buildSchemaExportCode, buildSecondaryStorageCode } from './module/templates'
@@ -116,7 +116,7 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
     await createDefaultAuthConfigFiles(nuxt)
   },
   setup(options, nuxt) {
-    nuxt.hook('modules:done', async () => {
+    const finishSetup = async () => {
       const resolver = createResolver(import.meta.url)
       const nitroImports = resolveNitroCompatibilityImports(nuxt._version)
       nuxt.options.alias['#better-auth/nitro-compat'] = resolver.resolve(`./runtime/server/internal/${nitroImports.runtime}`)
@@ -248,6 +248,19 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
 
       await registerDevtools({ nuxt, clientOnly: setup.clientOnly, hasHubDb: setup.database.hasHubDb, resolve: resolver.resolve })
       registerRouteRulesMetaHook(nuxt)
+
+      return Boolean(setup.schemaGeneration)
+    }
+
+    let setupPromise: Promise<boolean> | undefined
+    const finishSetupOnce = () => {
+      setupPromise ||= finishSetup()
+      return setupPromise
+    }
+
+    registerNuxtHubSchemaHook(nuxt, finishSetupOnce)
+    nuxt.hook('modules:done', async () => {
+      await finishSetupOnce()
     })
   },
 })

--- a/src/module/schema.ts
+++ b/src/module/schema.ts
@@ -66,6 +66,22 @@ export function resolveHubSchemaPath(
   return null
 }
 
+export function registerNuxtHubSchemaHook(
+  nuxt: Nuxt,
+  finishSetup: () => Promise<boolean>,
+): void {
+  const nuxtWithHubHooks = nuxt as Nuxt & { hook: (name: string, cb: (arg: { paths: string[], dialect: string }) => Promise<void>) => void }
+  nuxtWithHubHooks.hook('hub:db:schema:extend', async ({ paths, dialect }) => {
+    const hasHubSchema = await finishSetup()
+    if (!hasHubSchema)
+      return
+
+    const schemaPath = resolveHubSchemaPath(nuxt.options.buildDir, nuxt.options.rootDir, dialect)
+    if (schemaPath && !paths.includes(schemaPath))
+      paths.unshift(schemaPath)
+  })
+}
+
 async function loadAuthOptions(context: SchemaContext) {
   const isProduction = !context.nuxt.options.dev
   const configFile = CONFIG_EXTENSION_RE.test(context.serverConfigPath) ? context.serverConfigPath : `${context.serverConfigPath}.ts`
@@ -100,16 +116,6 @@ export async function setupBetterAuthSchema(
   }
 
   const context: SchemaContext = { nuxt, serverConfigPath }
-
-  // Registered before generation so NuxtHub still resolves the schema file already
-  // on disk when generation below is skipped. resolveHubSchemaPath is a plain
-  // filesystem lookup, so it does not care whether this run produced the file.
-  const nuxtWithHubHooks = nuxt as Nuxt & { hook: (name: string, cb: (arg: { paths: string[], dialect: string }) => void) => void }
-  nuxtWithHubHooks.hook('hub:db:schema:extend', ({ paths, dialect: hookDialect }) => {
-    const schemaPath = resolveHubSchemaPath(nuxt.options.buildDir, nuxt.options.rootDir, hookDialect)
-    if (schemaPath)
-      paths.unshift(schemaPath)
-  })
 
   try {
     const authConfig = await loadAuthOptions(context)

--- a/test/auth-schema-export.test.ts
+++ b/test/auth-schema-export.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process'
-import { rmSync } from 'node:fs'
+import { readFileSync, rmSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { join } from 'pathe'
 import { $fetch, setup } from '@nuxt/test-utils/e2e'
@@ -15,6 +15,9 @@ describe('#auth/schema export', async () => {
   })
   if (prepare.status !== 0)
     throw new Error(`clean nuxi prepare failed:\n${prepare.stdout}\n${prepare.stderr}`)
+
+  const hubSchemaEntry = readFileSync(join(rootDir, '.nuxt/hub/db/schema.entry.ts'), 'utf8')
+  const betterAuthSchema = join(rootDir, '.nuxt/better-auth/schema.sqlite.ts')
 
   await setup({
     rootDir,
@@ -44,5 +47,9 @@ describe('#auth/schema export', async () => {
     expect(res.hasNamedAccount).toBe(true)
     expect(res.hasAccounts).toBe(true)
     expect(res.hasVerification).toBe(true)
+  })
+
+  it('contributes the generated schema to NuxtHub on a clean prepare', () => {
+    expect(hubSchemaEntry).toContain(`export * from '${betterAuthSchema}'`)
   })
 })

--- a/test/schema-generator.test.ts
+++ b/test/schema-generator.test.ts
@@ -7,7 +7,7 @@ import { join } from 'node:path'
 import { runWithNuxtContext } from '@nuxt/kit'
 import { getAuthTables } from 'better-auth/db'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
-import { setupBetterAuthSchema } from '../src/module/schema'
+import { registerNuxtHubSchemaHook, setupBetterAuthSchema } from '../src/module/schema'
 import { buildSchemaExportCode } from '../src/module/templates'
 import { defineClientAuth, defineServerAuth } from '../src/runtime/config'
 import { generateDrizzleSchema, loadUserAuthConfig } from '../src/schema-generator'
@@ -59,7 +59,7 @@ function createSchemaProject(options: { dev: boolean, config: string }) {
   const serverConfigPath = join(serverDir, 'auth.config')
   writeFileSync(`${serverConfigPath}.ts`, options.config)
 
-  const hooks = new Map<string, (payload: { paths: string[], dialect: string }) => void>()
+  const hooks = new Map<string, (payload: { paths: string[], dialect: string }) => void | Promise<void>>()
 
   const nuxt = {
     options: {
@@ -72,20 +72,28 @@ function createSchemaProject(options: { dev: boolean, config: string }) {
       hub: { db: 'sqlite' },
     },
     callHook: async () => {},
-    hook: (name: string, cb: (payload: { paths: string[], dialect: string }) => void) => {
+    hook: (name: string, cb: (payload: { paths: string[], dialect: string }) => void | Promise<void>) => {
       hooks.set(name, cb)
     },
   } as unknown as Nuxt
 
   const schemaPath = join(buildDir, 'better-auth', 'schema.sqlite.ts')
 
-  const run = () => runWithNuxtContext(nuxt, () => setupBetterAuthSchema(
-    nuxt,
-    serverConfigPath,
-    {} as BetterAuthModuleOptions,
-    silentConsola,
-    undefined,
-  ))
+  let setupPromise: Promise<boolean> | undefined
+  const finishSetup = () => {
+    setupPromise ||= runWithNuxtContext(nuxt, () => setupBetterAuthSchema(
+      nuxt,
+      serverConfigPath,
+      {} as BetterAuthModuleOptions,
+      silentConsola,
+      undefined,
+    )).then(() => true)
+    return setupPromise
+  }
+  const run = async () => {
+    await finishSetup()
+  }
+  registerNuxtHubSchemaHook(nuxt, finishSetup)
 
   const writeExistingSchema = (contents: string) => {
     mkdirSync(join(buildDir, 'better-auth'), { recursive: true })
@@ -93,9 +101,9 @@ function createSchemaProject(options: { dev: boolean, config: string }) {
   }
 
   /** Fires NuxtHub's `hub:db:schema:extend` hook and returns the paths it collected. */
-  const collectHubSchemaPaths = () => {
+  const collectHubSchemaPaths = async () => {
     const paths: string[] = []
-    hooks.get('hub:db:schema:extend')?.({ paths, dialect: 'sqlite' })
+    await hooks.get('hub:db:schema:extend')?.({ paths, dialect: 'sqlite' })
     return paths
   }
 
@@ -317,7 +325,7 @@ describe.each([
 
     await project.run()
 
-    expect(project.collectHubSchemaPaths()).toEqual([project.schemaPath])
+    await expect(project.collectHubSchemaPaths()).resolves.toEqual([project.schemaPath])
   })
 })
 


### PR DESCRIPTION
NuxtHub now waits for Better Auth’s memoized module setup before collecting the generated schema path. Cold upgrades from 0.2.2 to 0.2.3 therefore keep the auth tables instead of producing a migration that drops them, while late plugin sources and custom database providers still resolve before schema generation.

Fixes #429

Reproduction: https://github.com/jd-solanki/reproductions/tree/nuxtjs-better-auth-hub-db-schema-extend-registered-too-late--2026-08-31

## Test plan

- `pnpm lint`
- `pnpm typecheck`
- `pnpm prepack`
- `pnpm test` (58 files, 338 tests)
- Clean pnpm reproduction: unpatched 0.2.3 drops all four auth tables; the pnpm-patched package contributes the schema and generates no migration.