### PR TITLE
docs: clarify D1 migration deployment

### DIFF
--- a/docs/content/3.guides/9.production-deployment.md
+++ b/docs/content/3.guides/9.production-deployment.md
@@ -85,10 +85,6 @@ Without the preview origin, browser auth flows can fail because Better Auth reje
 When deploying with NuxtHub:
 
 1. Database migrations run automatically during build
-
-   ::callout{to="https://hub.nuxt.com/docs/guides/ci-cd#d1-migrations-in-cicd" external}
-   NuxtHub skips build-time migrations for Cloudflare D1. Run them before deployment with `wrangler d1 migrations apply` or a credentialed `npx nuxt db migrate` step.
-   ::
 2. Set environment variables in your deployment platform
 3. Ensure `@nuxthub/core` is listed before `@nuxtjs/better-auth` in modules
 
@@ -100,6 +96,10 @@ export default defineNuxtConfig({
   ],
 })
 ```
+
+::callout{to="https://hub.nuxt.com/docs/guides/ci-cd#d1-migrations-in-cicd" external}
+NuxtHub skips build-time migrations for Cloudflare D1. Run them before deployment with `wrangler d1 migrations apply` or a credentialed `npx nuxt db migrate` step.
+::
 
 ## Common Issues
 

--- a/docs/content/3.guides/9.production-deployment.md
+++ b/docs/content/3.guides/9.production-deployment.md
@@ -84,7 +84,7 @@ Without the preview origin, browser auth flows can fail because Better Auth reje
 
 When deploying with NuxtHub:
 
-1. Database migrations run automatically during build
+1. Database migrations run automatically during build, except for Cloudflare D1. NuxtHub disables build-time D1 migrations, so run `wrangler d1 migrations apply` or a credentialed `npx nuxt db migrate` step before deployment.
 2. Set environment variables in your deployment platform
 3. Ensure `@nuxthub/core` is listed before `@nuxtjs/better-auth` in modules
 

--- a/docs/content/3.guides/9.production-deployment.md
+++ b/docs/content/3.guides/9.production-deployment.md
@@ -84,7 +84,11 @@ Without the preview origin, browser auth flows can fail because Better Auth reje
 
 When deploying with NuxtHub:
 
-1. Database migrations run automatically during build, except for Cloudflare D1. NuxtHub disables build-time D1 migrations, so run `wrangler d1 migrations apply` or a credentialed `npx nuxt db migrate` step before deployment.
+1. Database migrations run automatically during build
+
+   ::callout{to="https://hub.nuxt.com/docs/guides/ci-cd#d1-migrations-in-cicd" external}
+   NuxtHub skips build-time migrations for Cloudflare D1. Run them before deployment with `wrangler d1 migrations apply` or a credentialed `npx nuxt db migrate` step.
+   ::
 2. Set environment variables in your deployment platform
 3. Ensure `@nuxthub/core` is listed before `@nuxtjs/better-auth` in modules
 


### PR DESCRIPTION
Qualifies the production guide’s automatic NuxtHub migration claim with the Cloudflare D1 exception. NuxtHub [disables build-time migrations for the D1 driver](https://github.com/nuxt-hub/core/blob/69b029660488b5bd2fabf8dee53fed246db041f1/src/db/setup.ts#L139-L142) and documents [Wrangler and credentialed Nuxt CLI migration steps](https://github.com/nuxt-hub/core/blob/69b029660488b5bd2fabf8dee53fed246db041f1/docs/content/docs/6.guides/3.ci-cd.md#L217-L245) that must run before deployment.

## Test plan

- `pnpm build:docs`
- `git diff --check`