### PR TITLE
docs: add branded technology badges

### DIFF
--- a/docs/app/components/content/BrandBadge.vue
+++ b/docs/app/components/content/BrandBadge.vue
@@ -4,30 +4,30 @@ type BrandName = keyof typeof brands
 const props = defineProps<{
   name: BrandName
   to?: string
+  unlinked?: boolean
 }>()
 
 const brands = {
-  'cloudflare': { label: 'Cloudflare', icon: 'i-simple-icons-cloudflare', iconClass: 'text-orange-500' },
-  'cloudflare-d1': { label: 'Cloudflare D1', icon: 'i-simple-icons-cloudflare', iconClass: 'text-orange-500' },
-  'cloudflare-pages': { label: 'Cloudflare Pages', icon: 'i-simple-icons-cloudflarepages', iconClass: 'text-orange-500' },
-  'cloudflare-workers': { label: 'Cloudflare Workers', icon: 'i-simple-icons-cloudflareworkers', iconClass: 'text-orange-500' },
-  'convex': { label: 'Convex', icon: 'i-simple-icons-convex', iconClass: 'text-orange-500' },
-  'drizzle': { label: 'Drizzle', icon: 'i-simple-icons-drizzle', iconClass: 'text-lime-600 dark:text-lime-400' },
-  'kysely': { label: 'Kysely', icon: 'i-lucide-database', iconClass: 'text-blue-500' },
-  'mysql': { label: 'MySQL', icon: 'i-simple-icons-mysql', iconClass: 'text-blue-500' },
-  'netlify': { label: 'Netlify', icon: 'i-simple-icons-netlify', iconClass: 'text-teal-500' },
-  'nuxthub': { label: 'NuxtHub', icon: 'i-simple-icons-nuxt', iconClass: 'text-emerald-500' },
-  'postgresql': { label: 'PostgreSQL', icon: 'i-simple-icons-postgresql', iconClass: 'text-blue-500' },
-  'prisma': { label: 'Prisma', icon: 'i-simple-icons-prisma', iconClass: 'text-indigo-500 dark:text-indigo-300' },
-  'redis': { label: 'Redis', icon: 'i-simple-icons-redis', iconClass: 'text-red-500' },
-  'sqlite': { label: 'SQLite', icon: 'i-simple-icons-sqlite', iconClass: 'text-sky-500' },
-  'upstash': { label: 'Upstash', icon: 'i-simple-icons-upstash', iconClass: 'text-emerald-500' },
-  'vercel': { label: 'Vercel', icon: 'i-simple-icons-vercel', iconClass: 'text-stone-900 dark:text-stone-100' },
+  'cloudflare': { label: 'Cloudflare', icon: 'i-simple-icons-cloudflare', iconClass: 'text-orange-500', to: 'https://www.cloudflare.com/developer-platform/' },
+  'cloudflare-d1': { label: 'Cloudflare D1', icon: 'i-simple-icons-cloudflare', iconClass: 'text-orange-500', to: 'https://developers.cloudflare.com/d1/' },
+  'convex': { label: 'Convex', icon: 'i-simple-icons-convex', iconClass: 'text-orange-500', to: 'https://www.convex.dev/' },
+  'drizzle': { label: 'Drizzle', icon: 'i-simple-icons-drizzle', iconClass: 'text-lime-600 dark:text-lime-400', to: 'https://orm.drizzle.team/' },
+  'kysely': { label: 'Kysely', icon: 'i-lucide-database', iconClass: 'text-blue-500', to: 'https://kysely.dev/' },
+  'mysql': { label: 'MySQL', icon: 'i-simple-icons-mysql', iconClass: 'text-blue-500', to: 'https://www.mysql.com/' },
+  'netlify': { label: 'Netlify', icon: 'i-simple-icons-netlify', iconClass: 'text-teal-500', to: 'https://www.netlify.com/' },
+  'nuxthub': { label: 'NuxtHub', icon: 'i-simple-icons-nuxt', iconClass: 'text-emerald-500', to: 'https://hub.nuxt.com/' },
+  'postgresql': { label: 'PostgreSQL', icon: 'i-simple-icons-postgresql', iconClass: 'text-blue-500', to: 'https://www.postgresql.org/' },
+  'prisma': { label: 'Prisma', icon: 'i-simple-icons-prisma', iconClass: 'text-indigo-500 dark:text-indigo-300', to: 'https://www.prisma.io/' },
+  'redis': { label: 'Redis', icon: 'i-simple-icons-redis', iconClass: 'text-red-500', to: 'https://redis.io/' },
+  'sqlite': { label: 'SQLite', icon: 'i-simple-icons-sqlite', iconClass: 'text-sky-500', to: 'https://sqlite.org/' },
+  'upstash': { label: 'Upstash', icon: 'i-simple-icons-upstash', iconClass: 'text-emerald-500', to: 'https://upstash.com/' },
+  'vercel': { label: 'Vercel', icon: 'i-simple-icons-vercel', iconClass: 'text-stone-900 dark:text-stone-100', to: 'https://vercel.com/' },
 } as const
 
 const brand = computed(() => brands[props.name])
-const tag = computed(() => props.to ? resolveComponent('NuxtLink') : 'span')
-const external = computed(() => props.to?.startsWith('http'))
+const to = computed(() => props.unlinked ? undefined : props.to ?? brand.value.to)
+const tag = computed(() => to.value ? resolveComponent('NuxtLink') : 'span')
+const external = computed(() => to.value?.startsWith('http'))
 </script>
 
 <template>
@@ -38,7 +38,7 @@ const external = computed(() => props.to?.startsWith('http'))
     :rel="external ? 'noopener noreferrer' : undefined"
     class="brand-badge"
   >
-    <UIcon :name="brand.icon" class="size-3.5 shrink-0" :class="brand.iconClass" aria-hidden="true" />
+    <UIcon :name="brand.icon" class="brand-badge__icon size-3.5 shrink-0" :class="brand.iconClass" aria-hidden="true" />
     <span>{{ brand.label }}</span>
   </component>
 </template>
@@ -46,26 +46,38 @@ const external = computed(() => props.to?.startsWith('http'))
 <style scoped>
 .brand-badge {
   display: inline-flex;
-  align-items: center;
+  align-items: baseline;
   gap: 0.25rem;
-  padding: 0.2rem 0.4rem;
-  border-radius: var(--ui-radius);
-  background: color-mix(in srgb, var(--ui-text) 8%, transparent);
-  color: var(--ui-text-muted);
+  padding: 0.125rem 0.375rem;
+  border: 1px solid var(--ui-border);
+  border-radius: calc(var(--ui-radius) + 0.125rem);
+  background: color-mix(in srgb, var(--ui-bg-elevated) 72%, var(--ui-bg));
+  box-shadow: 0 1px 1px color-mix(in srgb, var(--ui-text) 5%, transparent);
+  color: var(--ui-text-toned);
   font-size: 0.875em;
   font-weight: 500;
-  line-height: 1;
+  line-height: 1.25;
   text-decoration: none;
-  vertical-align: 0.08em;
+  vertical-align: baseline;
   white-space: nowrap;
 }
 
+.brand-badge__icon {
+  transform: translateY(0.1em);
+}
+
 a.brand-badge {
-  transition: color 150ms ease, background-color 150ms ease;
+  transition: color 150ms ease, background-color 150ms ease, border-color 150ms ease;
 }
 
 a.brand-badge:hover {
-  background: color-mix(in srgb, var(--ui-text) 14%, transparent);
+  border-color: color-mix(in srgb, var(--ui-text) 24%, var(--ui-border));
+  background: var(--ui-bg-elevated);
   color: var(--ui-text);
+}
+
+a.brand-badge:focus-visible {
+  outline: 2px solid var(--ui-primary);
+  outline-offset: 2px;
 }
 </style>

--- a/docs/app/components/content/BrandBadge.vue
+++ b/docs/app/components/content/BrandBadge.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+type BrandName = keyof typeof brands
+
+const props = defineProps<{
+  name: BrandName
+  to?: string
+}>()
+
+const brands = {
+  'cloudflare': { label: 'Cloudflare', icon: 'i-simple-icons-cloudflare', iconClass: 'text-orange-500' },
+  'cloudflare-d1': { label: 'Cloudflare D1', icon: 'i-simple-icons-cloudflare', iconClass: 'text-orange-500' },
+  'cloudflare-pages': { label: 'Cloudflare Pages', icon: 'i-simple-icons-cloudflarepages', iconClass: 'text-orange-500' },
+  'cloudflare-workers': { label: 'Cloudflare Workers', icon: 'i-simple-icons-cloudflareworkers', iconClass: 'text-orange-500' },
+  'convex': { label: 'Convex', icon: 'i-simple-icons-convex', iconClass: 'text-orange-500' },
+  'drizzle': { label: 'Drizzle', icon: 'i-simple-icons-drizzle', iconClass: 'text-lime-600 dark:text-lime-400' },
+  'kysely': { label: 'Kysely', icon: 'i-lucide-database', iconClass: 'text-blue-500' },
+  'mysql': { label: 'MySQL', icon: 'i-simple-icons-mysql', iconClass: 'text-blue-500' },
+  'netlify': { label: 'Netlify', icon: 'i-simple-icons-netlify', iconClass: 'text-teal-500' },
+  'nuxthub': { label: 'NuxtHub', icon: 'i-simple-icons-nuxt', iconClass: 'text-emerald-500' },
+  'postgresql': { label: 'PostgreSQL', icon: 'i-simple-icons-postgresql', iconClass: 'text-blue-500' },
+  'prisma': { label: 'Prisma', icon: 'i-simple-icons-prisma', iconClass: 'text-indigo-500 dark:text-indigo-300' },
+  'redis': { label: 'Redis', icon: 'i-simple-icons-redis', iconClass: 'text-red-500' },
+  'sqlite': { label: 'SQLite', icon: 'i-simple-icons-sqlite', iconClass: 'text-sky-500' },
+  'upstash': { label: 'Upstash', icon: 'i-simple-icons-upstash', iconClass: 'text-emerald-500' },
+  'vercel': { label: 'Vercel', icon: 'i-simple-icons-vercel', iconClass: 'text-stone-900 dark:text-stone-100' },
+} as const
+
+const brand = computed(() => brands[props.name])
+const tag = computed(() => props.to ? resolveComponent('NuxtLink') : 'span')
+const external = computed(() => props.to?.startsWith('http'))
+</script>
+
+<template>
+  <component
+    :is="tag"
+    :to="to"
+    :target="external ? '_blank' : undefined"
+    :rel="external ? 'noopener noreferrer' : undefined"
+    class="brand-badge"
+  >
+    <UIcon :name="brand.icon" class="size-3.5 shrink-0" :class="brand.iconClass" aria-hidden="true" />
+    <span>{{ brand.label }}</span>
+  </component>
+</template>
+
+<style scoped>
+.brand-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.4rem;
+  border-radius: var(--ui-radius);
+  background: color-mix(in srgb, var(--ui-text) 8%, transparent);
+  color: var(--ui-text-muted);
+  font-size: 0.875em;
+  font-weight: 500;
+  line-height: 1;
+  text-decoration: none;
+  vertical-align: 0.08em;
+  white-space: nowrap;
+}
+
+a.brand-badge {
+  transition: color 150ms ease, background-color 150ms ease;
+}
+
+a.brand-badge:hover {
+  background: color-mix(in srgb, var(--ui-text) 14%, transparent);
+  color: var(--ui-text);
+}
+</style>

--- a/docs/content/1.getting-started/0.index.md
+++ b/docs/content/1.getting-started/0.index.md
@@ -12,7 +12,7 @@ This quickstart assumes:
 - you are using `pnpm`
 - you want a local login flow working before you customize providers or plugins
 
-If you already know you need a different architecture, jump to [NuxtHub](/integrations/nuxthub), [custom database](/guides/custom-database), or [external auth backend](/guides/external-auth-backend).
+If you already know you need a different architecture, jump to :brand-badge{name="nuxthub" to="/integrations/nuxthub"}, [custom database](/guides/custom-database), or [external auth backend](/guides/external-auth-backend).
 
 ## What you will end up with
 

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -75,7 +75,7 @@ BETTER_AUTH_SECRETS=2:current-secret-must-be-at-least-32-characters,1:previous-s
 
 2. **Base URL** (Optional)
 
-The module auto-detects the URL on :brand-badge{name="vercel"}, :brand-badge{name="cloudflare-pages"}, and :brand-badge{name="netlify"}. Set manually for other platforms.
+The module auto-detects the URL on :brand-badge{name="vercel"}, :brand-badge{name="cloudflare"}, and :brand-badge{name="netlify"}. Set manually for other platforms.
 
 ```txt [.env]
 NUXT_PUBLIC_SITE_URL=https://your-domain.com
@@ -126,9 +126,9 @@ Confirm all of the following:
 - If you need durable persistence, pick either :brand-badge{name="nuxthub" to="/integrations/nuxthub"} integration or [custom database](/guides/custom-database).
 
 ::callout{icon="i-lucide-database" to="/integrations/nuxthub"}
-**Need database persistence?** See :brand-badge{name="nuxthub"} Integration for auto-generated schemas and full database support.
+**Need database persistence?** See :brand-badge{name="nuxthub" unlinked} Integration for auto-generated schemas and full database support.
 ::
 
 ::callout{icon="i-lucide-hard-drive" to="/guides/custom-database"}
-**Bring your own database?** Use :brand-badge{name="drizzle"}, :brand-badge{name="prisma"}, or :brand-badge{name="kysely"} adapters with any database.
+**Bring your own database?** Use :brand-badge{name="drizzle" unlinked}, :brand-badge{name="prisma" unlinked}, or :brand-badge{name="kysely" unlinked} adapters with any database.
 ::

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -75,7 +75,7 @@ BETTER_AUTH_SECRETS=2:current-secret-must-be-at-least-32-characters,1:previous-s
 
 2. **Base URL** (Optional)
 
-The module auto-detects the URL on Vercel, Cloudflare Pages, and Netlify. Set manually for other platforms.
+The module auto-detects the URL on :brand-badge{name="vercel"}, :brand-badge{name="cloudflare-pages"}, and :brand-badge{name="netlify"}. Set manually for other platforms.
 
 ```txt [.env]
 NUXT_PUBLIC_SITE_URL=https://your-domain.com
@@ -123,12 +123,12 @@ Confirm all of the following:
 
 - Continue with [configuration](/getting-started/configuration) to set module options and route protection.
 - Continue with [client setup](/getting-started/client-setup) to wire sign-in and sign-out flows.
-- If you need durable persistence, pick either [NuxtHub integration](/integrations/nuxthub) or [custom database](/guides/custom-database).
+- If you need durable persistence, pick either :brand-badge{name="nuxthub" to="/integrations/nuxthub"} integration or [custom database](/guides/custom-database).
 
 ::callout{icon="i-lucide-database" to="/integrations/nuxthub"}
-**Need database persistence?** See [NuxtHub Integration](/integrations/nuxthub) for auto-generated schemas and full database support.
+**Need database persistence?** See :brand-badge{name="nuxthub"} Integration for auto-generated schemas and full database support.
 ::
 
 ::callout{icon="i-lucide-hard-drive" to="/guides/custom-database"}
-**Bring your own database?** Use Drizzle, Prisma, or Kysely adapters with any database.
+**Bring your own database?** Use :brand-badge{name="drizzle"}, :brand-badge{name="prisma"}, or :brand-badge{name="kysely"} adapters with any database.
 ::

--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -105,8 +105,8 @@ You can define auth route rules in either `routeRules` or `nitro.routeRules`. Th
 
     Configure secondary storage for sessions.
 
-    - `true` — Temporarily logs a setup warning and continues without module-provided secondary storage because NuxtHub KV cannot implement the required atomic `getAndDelete` and `increment` operations. Sessions use the configured database when one exists, and Better Auth rate limiting uses process-local memory by default.
-    - `'custom'` — You provide an atomic `secondaryStorage` in `defineServerAuth()` (required; the build fails in production if missing). The module won't inject NuxtHub KV, and this mode can omit the `session` table from generated schema.
+    - `true` — Temporarily logs a setup warning and continues without module-provided secondary storage because :brand-badge{name="nuxthub"} KV cannot implement the required atomic `getAndDelete` and `increment` operations. Sessions use the configured database when one exists, and Better Auth rate limiting uses process-local memory by default.
+    - `'custom'` — You provide an atomic `secondaryStorage` in `defineServerAuth()` (required; the build fails in production if missing). The module won't inject :brand-badge{name="nuxthub"} KV, and this mode can omit the `session` table from generated schema.
     - `false` (default) — No secondary storage from the module. User-provided `secondaryStorage` in `defineServerAuth()` is not overridden.
   ::
 
@@ -123,7 +123,7 @@ You can define auth route rules in either `routeRules` or `nitro.routeRules`. Th
   ::
 
   ::field{name="schema.schemaName" type="string"}
-    PostgreSQL schema namespace for generated auth tables.
+    :brand-badge{name="postgresql"} schema namespace for generated auth tables.
   ::
 ::
 
@@ -189,7 +189,7 @@ export default defineServerAuth((ctx) => ({
 The module automatically injects the singular `secret` and `baseURL`. Use Better Auth's `secrets` option only when you need versioned rotation.
 - **Secret**: Priority: `nuxt.config.ts` runtimeConfig > `NUXT_BETTER_AUTH_SECRET` > `BETTER_AUTH_SECRET`
 - **Versioned secrets**: Set `secrets` in `defineServerAuth` or use `BETTER_AUTH_SECRETS`. When present, the singular secret is a legacy decryption fallback.
-- **Base URL**: The module auto-detects the base URL on Vercel/Cloudflare/Netlify. For other platforms, set `NUXT_PUBLIC_SITE_URL`
+- **Base URL**: The module auto-detects the base URL on :brand-badge{name="vercel"}, :brand-badge{name="cloudflare"}, and :brand-badge{name="netlify"}. For other platforms, set `NUXT_PUBLIC_SITE_URL`
 ::
 
 ### Context Options
@@ -207,7 +207,7 @@ export default defineServerAuth((ctx) => ({
 ```
 
 - `ctx.runtimeConfig`: Nuxt runtime config.
-- `ctx.db`: NuxtHub database connection when NuxtHub DB is enabled. Do not set `database` when using module-managed adapters.
+- `ctx.db`: :brand-badge{name="nuxthub"} database connection when :brand-badge{name="nuxthub"} DB is enabled. Do not set `database` when using module-managed adapters.
 - `ctx.requestOrigin`: Current request origin when auth is created with `serverAuth(event)`.
 
 Use `requestOrigin` when Better Auth config needs the current request host, such as trusted origins:
@@ -238,7 +238,7 @@ The module resolves `siteUrl` using this priority:
 |----------|--------|-----------|
 | 1 | `runtimeConfig.public.siteUrl` | Explicit config (always wins) |
 | 2 | Request URL | Auto-detected from the current Nitro request (`event`) |
-| 3 | `VERCEL_URL`, `CF_PAGES_URL`, `URL` | Platform env vars (Vercel, Cloudflare, Netlify) |
+| 3 | `VERCEL_URL`, `CF_PAGES_URL`, `URL` | Platform env vars (:brand-badge{name="vercel"}, :brand-badge{name="cloudflare"}, :brand-badge{name="netlify"}) |
 | 4 | `http://localhost:3000` | Development only |
 
 In server handlers, pass `event` to `serverAuth(event)` so request URL detection can run. In non-request contexts (seed scripts, tasks, startup plugins), the module uses environment/platform fallbacks.

--- a/docs/content/1.getting-started/5.schema-generation.md
+++ b/docs/content/1.getting-started/5.schema-generation.md
@@ -88,7 +88,7 @@ Do not rely on this flow if:
 In those cases, use [custom database setup](/guides/custom-database).
 
    ::callout{to="https://hub.nuxt.com/docs/getting-started/deploy" external}
-   See :brand-badge{name="nuxthub"} deployment documentation.
+   See :brand-badge{name="nuxthub" unlinked} deployment documentation.
    ::
 
 ::warning

--- a/docs/content/1.getting-started/5.schema-generation.md
+++ b/docs/content/1.getting-started/5.schema-generation.md
@@ -20,29 +20,29 @@ Set up auto schema generation for @nuxtjs/better-auth with NuxtHub.
 
 ::
 
-Use this page when you are using NuxtHub and want the module to generate auth tables from your Better Auth configuration.
+Use this page when you are using :brand-badge{name="nuxthub"} and want the module to generate auth tables from your Better Auth configuration.
 
 ::note
-This feature requires **NuxtHub**. See [NuxtHub Integration](/integrations/nuxthub) for setup.
+This feature requires :brand-badge{name="nuxthub"}. See :brand-badge{name="nuxthub" to="/integrations/nuxthub"} for setup.
 ::
 
-Better Auth requires tables for users, sessions, accounts. This module creates them automatically with NuxtHub and Drizzle ORM.
+Better Auth requires tables for users, sessions, accounts. This module creates them automatically with :brand-badge{name="nuxthub"} and :brand-badge{name="drizzle"} ORM.
 
 ## How it works
 
 The module analyzes your `server/auth.config.ts` at build time to determine which tables are required by your core configuration and enabled plugins (e.g., `twoFactor`, `passkey`).
 
 1. **Analysis**: Reads `plugins` from your config.
-2. **Generation**: Generates a Drizzle schema file corresponding to your database dialect (SQLite, PostgreSQL, MySQL).
-3. **Integration**: Automatically injects this schema into NuxtHub's database configuration.
+2. **Generation**: Generates a :brand-badge{name="drizzle"} schema file corresponding to your database dialect (:brand-badge{name="sqlite"}, :brand-badge{name="postgresql"}, :brand-badge{name="mysql"}).
+3. **Integration**: Automatically injects this schema into :brand-badge{name="nuxthub"}'s database configuration.
 
 ::tip
-You do not need to manually write Drizzle schemas for authentication tables.
+You do not need to manually write :brand-badge{name="drizzle"} schemas for authentication tables.
 ::
 
 ## Supported Dialects
 
-The module supports all dialects compatible with NuxtHub:
+The module supports all dialects compatible with :brand-badge{name="nuxthub"}:
 
 - `sqlite` (Default)
 - `postgresql`
@@ -67,12 +67,12 @@ When you add a new plugin that requires database tables (e.g., adding `twoFactor
 1. Update `server/auth.config.ts`.
 2. Restart your development server.
 3. The module regenerates the schema.
-4. If using NuxtHub local development, the tables are ready.
+4. If using :brand-badge{name="nuxthub"} local development, the tables are ready.
 5. **Deploy with migrations:**
 
    For local development, migrations run automatically when you start the dev server.
 
-   For production (Cloudflare D1):
+   For production (:brand-badge{name="cloudflare-d1"}):
    ```bash
    npx nuxt db migrate
    ```
@@ -81,14 +81,14 @@ When you add a new plugin that requires database tables (e.g., adding `twoFactor
 
 Do not rely on this flow if:
 
-- you are not using NuxtHub
+- you are not using :brand-badge{name="nuxthub"}
 - you are in `clientOnly` mode
 - you manage Better Auth tables with a separate adapter and migration pipeline
 
 In those cases, use [custom database setup](/guides/custom-database).
 
    ::callout{to="https://hub.nuxt.com/docs/getting-started/deploy" external}
-   See NuxtHub deployment documentation.
+   See :brand-badge{name="nuxthub"} deployment documentation.
    ::
 
 ::warning

--- a/docs/content/1.getting-started/6.how-it-works.md
+++ b/docs/content/1.getting-started/6.how-it-works.md
@@ -10,7 +10,7 @@ Use this page after installation. It explains how the module connects Nuxt runti
 
 ::steps
 ### Initialization
-During build, the module reads `server/auth.config.ts` and generates the auth handler. If using NuxtHub, it also generates the database schema automatically.
+During build, the module reads `server/auth.config.ts` and generates the auth handler. If using :brand-badge{name="nuxthub"}, it also generates the database schema automatically.
 
 ### Server Runtime
 The module injects a catch-all API handler at `/api/auth/**`. This handler processes all authentication requests (login, logout, session fetching) using the configuration provided in `server/auth.config.ts`.
@@ -44,4 +44,4 @@ On the client side, `useUserSession` initializes the Better Auth client. It esta
 - client pages use `useUserSession()` and related composables
 - protected API routes should still call `requireUserSession(event)`
 - route rules improve navigation UX, but server-side checks remain the real security boundary
-- NuxtHub integration and schema generation are build-time concerns, not request-time concerns
+- :brand-badge{name="nuxthub"} integration and schema generation are build-time concerns, not request-time concerns

--- a/docs/content/3.guides/3.custom-database.md
+++ b/docs/content/3.guides/3.custom-database.md
@@ -3,15 +3,15 @@ title: Custom Database
 description: Use your own database with Drizzle, Prisma, or Kysely adapters.
 ---
 
-Use this guide when you want Better Auth to run against your existing database stack instead of NuxtHub.
+Use this guide when you want Better Auth to run against your existing database stack instead of :brand-badge{name="nuxthub"}.
 
-Better Auth supports any database through adapters. Use this guide when you need full control over your database setup or can't use NuxtHub.
+Better Auth supports any database through adapters. Use this guide when you need full control over your database setup or can't use :brand-badge{name="nuxthub"}.
 
 ## When to Use This
 
 | Scenario | Recommended |
 |----------|-------------|
-| Quick start, managed infra | [NuxtHub](/integrations/nuxthub) |
+| Quick start, managed infra | :brand-badge{name="nuxthub" to="/integrations/nuxthub"} |
 | OAuth-only, no persistence | [Database-less Mode](/guides/database-less-mode) |
 | Existing database, custom setup | **This guide** |
 
@@ -24,6 +24,8 @@ pnpm add better-auth
 ```
 
 `better-auth` is a peer dependency of `@nuxtjs/better-auth`. Keep the major versions aligned to avoid mismatches.
+
+Choose the adapter that matches your stack: :brand-badge{name="drizzle"}, :brand-badge{name="prisma"}, or :brand-badge{name="kysely"}.
 
 ## Drizzle Adapter
 
@@ -100,7 +102,7 @@ export const auth = betterAuth({
 })
 ```
 
-If you use Prisma or Kysely, swap the adapter section to match your setup.
+If you use :brand-badge{name="prisma"} or :brand-badge{name="kysely"}, swap the adapter section to match your setup.
 
 Use `--config` if you place the file elsewhere:
 

--- a/docs/content/3.guides/6.migrate-from-nuxt-auth-utils.md
+++ b/docs/content/3.guides/6.migrate-from-nuxt-auth-utils.md
@@ -310,7 +310,7 @@ See **Schema Generation** to set up database tables.
 Ensure a singular or versioned auth secret is configured and the database is available.
 
 ### OAuth redirect errors
-Auto-detected on Vercel/Cloudflare/Netlify. For other platforms, set `NUXT_PUBLIC_SITE_URL`.
+Auto-detected on :brand-badge{name="vercel"}, :brand-badge{name="cloudflare"}, and :brand-badge{name="netlify"}. For other platforms, set `NUXT_PUBLIC_SITE_URL`.
 
 ### Type errors on user fields
 Run type augmentation - see [Type Augmentation](/getting-started/type-augmentation).

--- a/docs/content/3.guides/7.two-factor-auth.md
+++ b/docs/content/3.guides/7.two-factor-auth.md
@@ -5,7 +5,7 @@ description: Enable two-factor auth using the Better Auth two-factor plugin.
 
 Use this guide when you already have a database-backed auth setup and want to add TOTP with backup codes.
 
-Better Auth ships a `twoFactor` plugin with TOTP, OTP, and backup codes. It requires a database-backed setup (e.g., NuxtHub).
+Better Auth ships a `twoFactor` plugin with TOTP, OTP, and backup codes. It requires a database-backed setup (e.g., :brand-badge{name="nuxthub"}).
 
 ::steps
 

--- a/docs/content/3.guides/9.production-deployment.md
+++ b/docs/content/3.guides/9.production-deployment.md
@@ -61,7 +61,7 @@ Better Auth stores rate-limit data in memory by default. For serverless or multi
 
 ### Separate Build and Runtime Environments
 
-Some platforms, including :brand-badge{name="cloudflare-workers"} Builds, expose build-time and runtime environment variables separately. Your singular or versioned auth secret must be available to the deployed runtime, but it does not need to be present in the build container.
+Some platforms, including :brand-badge{name="cloudflare"} Workers Builds, expose build-time and runtime environment variables separately. Your singular or versioned auth secret must be available to the deployed runtime, but it does not need to be present in the build container.
 
 ### Trusted Origins for Preview Environments
 
@@ -98,7 +98,7 @@ export default defineNuxtConfig({
 ```
 
 ::callout{to="https://hub.nuxt.com/docs/guides/ci-cd#d1-migrations-in-cicd" external}
-:brand-badge{name="nuxthub"} skips build-time migrations for :brand-badge{name="cloudflare-d1"}. Run them before deployment with `wrangler d1 migrations apply` or a credentialed `npx nuxt db migrate` step.
+:brand-badge{name="nuxthub" unlinked} skips build-time migrations for :brand-badge{name="cloudflare-d1" unlinked}. Run them before deployment with `wrangler d1 migrations apply` or a credentialed `npx nuxt db migrate` step.
 ::
 
 ## Common Issues
@@ -113,7 +113,7 @@ The deployed server runtime could not resolve an auth secret. Set `NUXT_BETTER_A
 
 ### "siteUrl required in production"
 
-The module auto-detects URLs on :brand-badge{name="vercel"}, :brand-badge{name="cloudflare-pages"}, and :brand-badge{name="netlify"}. For other platforms, set `NUXT_PUBLIC_SITE_URL` to your production domain.
+The module auto-detects URLs on :brand-badge{name="vercel"}, :brand-badge{name="cloudflare"}, and :brand-badge{name="netlify"}. For other platforms, set `NUXT_PUBLIC_SITE_URL` to your production domain.
 
 ### OAuth Redirects Fail
 

--- a/docs/content/3.guides/9.production-deployment.md
+++ b/docs/content/3.guides/9.production-deployment.md
@@ -37,7 +37,7 @@ Singular secrets must be at least 32 characters. Shorter `NUXT_BETTER_AUTH_SECRE
 ### Before Deploying
 
 - [ ] `NUXT_BETTER_AUTH_SECRET`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_SECRETS`, or `defineServerAuth({ secrets })` is configured
-- [ ] `NUXT_PUBLIC_SITE_URL` set (or using Vercel/Cloudflare/Netlify auto-detection)
+- [ ] `NUXT_PUBLIC_SITE_URL` set (or using :brand-badge{name="vercel"}, :brand-badge{name="cloudflare"}, or :brand-badge{name="netlify"} auto-detection)
 - [ ] `trustedOrigins` includes every active frontend origin (primary domain and preview domain, if used)
 - [ ] OAuth redirect URIs configured for production domain
 - [ ] `NODE_ENV=production` is set (disables devtools)
@@ -61,7 +61,7 @@ Better Auth stores rate-limit data in memory by default. For serverless or multi
 
 ### Separate Build and Runtime Environments
 
-Some platforms, including Cloudflare Workers Builds, expose build-time and runtime environment variables separately. Your singular or versioned auth secret must be available to the deployed runtime, but it does not need to be present in the build container.
+Some platforms, including :brand-badge{name="cloudflare-workers"} Builds, expose build-time and runtime environment variables separately. Your singular or versioned auth secret must be available to the deployed runtime, but it does not need to be present in the build container.
 
 ### Trusted Origins for Preview Environments
 
@@ -82,7 +82,7 @@ Without the preview origin, browser auth flows can fail because Better Auth reje
 
 ## NuxtHub Deployment
 
-When deploying with NuxtHub:
+When deploying with :brand-badge{name="nuxthub"}:
 
 1. Database migrations run automatically during build
 2. Set environment variables in your deployment platform
@@ -98,7 +98,7 @@ export default defineNuxtConfig({
 ```
 
 ::callout{to="https://hub.nuxt.com/docs/guides/ci-cd#d1-migrations-in-cicd" external}
-NuxtHub skips build-time migrations for Cloudflare D1. Run them before deployment with `wrangler d1 migrations apply` or a credentialed `npx nuxt db migrate` step.
+:brand-badge{name="nuxthub"} skips build-time migrations for :brand-badge{name="cloudflare-d1"}. Run them before deployment with `wrangler d1 migrations apply` or a credentialed `npx nuxt db migrate` step.
 ::
 
 ## Common Issues
@@ -113,7 +113,7 @@ The deployed server runtime could not resolve an auth secret. Set `NUXT_BETTER_A
 
 ### "siteUrl required in production"
 
-The module auto-detects URLs on Vercel, Cloudflare Pages, and Netlify. For other platforms, set `NUXT_PUBLIC_SITE_URL` to your production domain.
+The module auto-detects URLs on :brand-badge{name="vercel"}, :brand-badge{name="cloudflare-pages"}, and :brand-badge{name="netlify"}. For other platforms, set `NUXT_PUBLIC_SITE_URL` to your production domain.
 
 ### OAuth Redirects Fail
 

--- a/docs/content/4.integrations/1.nuxthub.md
+++ b/docs/content/4.integrations/1.nuxthub.md
@@ -141,7 +141,7 @@ Add to your GitHub Actions workflow:
 ```
 
 ::callout{icon="i-lucide-book" to="https://hub.nuxt.com/docs/features/database"}
-See :brand-badge{name="nuxthub"} Database docs for more details.
+See :brand-badge{name="nuxthub" unlinked} Database docs for more details.
 ::
 
 ## Schema Generation Details
@@ -208,7 +208,7 @@ Match your auth table ID types in foreign keys:
 - **:brand-badge{name="postgresql"} with UUID**: Use `uuid()` when `advanced.database.generateId = 'uuid'`
 
 ::callout{icon="i-lucide-book" to="https://orm.drizzle.team/docs/schemas"}
-See :brand-badge{name="drizzle"} schemas for the full schema definition guide.
+See :brand-badge{name="drizzle" unlinked} schemas for the full schema definition guide.
 ::
 
 ### Migrations

--- a/docs/content/4.integrations/1.nuxthub.md
+++ b/docs/content/4.integrations/1.nuxthub.md
@@ -5,18 +5,18 @@ description: Automatic database setup with schema generation and Drizzle ORM int
 
 Use this guide when you want the shortest path to database-backed auth with schema generation handled by the module.
 
-NuxtHub provides the easiest way to add database persistence to your authentication. Enable NuxtHub and this module generates and manages your database schema.
+:brand-badge{name="nuxthub"} provides the easiest way to add database persistence to your authentication. Enable :brand-badge{name="nuxthub"} and this module generates and manages your database schema.
 
 ::note
-NuxtHub is vendor-agnostic. Deploy to Cloudflare, Vercel, or self-host. See [NuxtHub deployment docs](https://hub.nuxt.com/docs/getting-started/deploy).
+:brand-badge{name="nuxthub"} is vendor-agnostic. Deploy to :brand-badge{name="cloudflare"}, :brand-badge{name="vercel"}, or self-host. See :brand-badge{name="nuxthub" to="https://hub.nuxt.com/docs/getting-started/deploy"} deployment docs.
 ::
 
 ## Features
 
 - **Auto Schema Generation** - Tables for users, sessions, accounts created automatically
 - **Plugin-Aware** - Schema updates when you add plugins like `twoFactor`, `passkey`
-- **Multi-Dialect** - SQLite, PostgreSQL, or MySQL
-- **Multi-Cloud** - Deploy to Cloudflare, Vercel, or self-hosted infrastructure
+- **Multi-Dialect** - :brand-badge{name="sqlite"}, :brand-badge{name="postgresql"}, or :brand-badge{name="mysql"}
+- **Multi-Cloud** - Deploy to :brand-badge{name="cloudflare"}, :brand-badge{name="vercel"}, or self-hosted infrastructure
 - **Custom Secondary Storage** - Optional atomic storage for session caching
 - **Zero Config Migrations** - Use `npx nuxt db migrate` for production
 
@@ -71,9 +71,9 @@ export default defineNuxtConfig({
 
 ## Secondary Storage
 
-NuxtHub KV cannot be used as Better Auth 1.7 secondary storage. Better Auth requires atomic `getAndDelete` for one-time verification values and atomic `increment` for rate limiting. NuxtHub KV exposes neither operation.
+:brand-badge{name="nuxthub"} KV cannot be used as Better Auth 1.7 secondary storage. Better Auth requires atomic `getAndDelete` for one-time verification values and atomic `increment` for rate limiting. :brand-badge{name="nuxthub"} KV exposes neither operation.
 
-Use a custom backend such as Redis or Upstash that implements the complete atomic contract:
+Use a custom backend such as :brand-badge{name="redis"} or :brand-badge{name="upstash"} that implements the complete atomic contract:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
@@ -93,9 +93,9 @@ Then provide `secondaryStorage` in `defineServerAuth()` with `get`, `getAndDelet
 
 ### Temporary compatibility fallback
 
-The warning keeps existing applications running while [NuxtHub adds atomic KV operations](https://github.com/nuxt-hub/core/pull/927). That work is driver-specific. The module can only restore automatic integration for drivers that provide both `getAndDelete` and `increment`.
+The warning keeps existing applications running while :brand-badge{name="nuxthub" to="https://github.com/nuxt-hub/core/pull/927"} adds atomic KV operations. That work is driver-specific. The module can only restore automatic integration for drivers that provide both `getAndDelete` and `increment`.
 
-This fallback does not pretend NuxtHub KV is active. The module records `hubSecondaryStorage` as `false` at runtime and generates the database-backed session schema.
+This fallback does not pretend :brand-badge{name="nuxthub"} KV is active. The module records `hubSecondaryStorage` as `false` at runtime and generates the database-backed session schema.
 
 Sessions and verification values stored only in KV will no longer be found after deploying this fallback. Users may need to sign in again, and you may need to reissue pending verification links or codes.
 
@@ -115,7 +115,7 @@ If you previously generated migrations while `hubSecondaryStorage: true` omitted
 
 ## Production Migrations
 
-NuxtHub handles migrations automatically in most deployments. For manual control:
+:brand-badge{name="nuxthub"} handles migrations automatically in most deployments. For manual control:
 
 ### Manual Migration
 
@@ -141,7 +141,7 @@ Add to your GitHub Actions workflow:
 ```
 
 ::callout{icon="i-lucide-book" to="https://hub.nuxt.com/docs/features/database"}
-See [NuxtHub Database docs](https://hub.nuxt.com/docs/features/database) for more details.
+See :brand-badge{name="nuxthub"} Database docs for more details.
 ::
 
 ## Schema Generation Details
@@ -149,20 +149,20 @@ See [NuxtHub Database docs](https://hub.nuxt.com/docs/features/database) for mor
 The module analyzes your `server/auth.config.ts` at build time:
 
 1. **Reads plugins** from your config
-2. **Generates Drizzle schema** matching your dialect
-3. **Injects into NuxtHub** via `hub:db:schema:extend` hook
+2. **Generates :brand-badge{name="drizzle"} schema** matching your dialect
+3. **Injects into :brand-badge{name="nuxthub"}** via `hub:db:schema:extend` hook
 
 ::warning
 **Restart Required**: After adding/removing plugins that affect database structure, restart the dev server to regenerate the schema.
 ::
 
 ::note
-When Nuxt resolves `buildDir` to `node_modules/.cache/nuxt/.nuxt`, the module mirrors `schema.<dialect>.ts` to root `.nuxt/better-auth/` and uses that mirrored path for NuxtHub schema extension. This avoids Node type-stripping failures for `.ts` files under `node_modules`. In normal buildDir layouts, the hook prefers `schema.<dialect>.ts` and falls back to `schema.<dialect>.mjs`.
+When Nuxt resolves `buildDir` to `node_modules/.cache/nuxt/.nuxt`, the module mirrors `schema.<dialect>.ts` to root `.nuxt/better-auth/` and uses that mirrored path for :brand-badge{name="nuxthub"} schema extension. This avoids Node type-stripping failures for `.ts` files under `node_modules`. In normal buildDir layouts, the hook prefers `schema.<dialect>.ts` and falls back to `schema.<dialect>.mjs`.
 ::
 
 ## Accessing the Database
 
-With NuxtHub, you get access to the Drizzle database instance in your server config:
+With :brand-badge{name="nuxthub"}, you get access to the :brand-badge{name="drizzle"} database instance in your server config:
 
 ```ts [server/auth.config.ts]
 import { defineServerAuth } from '@nuxtjs/better-auth/config'
@@ -204,11 +204,11 @@ Reference these tables via the `schema` object:
 
 Match your auth table ID types in foreign keys:
 
-- **SQLite/MySQL**: Use `text()` or `varchar()`
-- **PostgreSQL with UUID**: Use `uuid()` when `advanced.database.generateId = 'uuid'`
+- **:brand-badge{name="sqlite"} / :brand-badge{name="mysql"}**: Use `text()` or `varchar()`
+- **:brand-badge{name="postgresql"} with UUID**: Use `uuid()` when `advanced.database.generateId = 'uuid'`
 
 ::callout{icon="i-lucide-book" to="https://orm.drizzle.team/docs/schemas"}
-See [Drizzle schemas](https://orm.drizzle.team/docs/schemas) for full schema definition guide.
+See :brand-badge{name="drizzle"} schemas for the full schema definition guide.
 ::
 
 ### Migrations
@@ -221,7 +221,7 @@ npx nuxt db migrate   # Apply (automatic in dev)
 ```
 
 ::warning
-Restart dev server after adding schemas in `server/db/` for NuxtHub to discover them.
+Restart dev server after adding schemas in `server/db/` for :brand-badge{name="nuxthub"} to discover them.
 ::
 
 ### Adding Columns to Auth Tables

--- a/docs/content/4.integrations/3.convex.md
+++ b/docs/content/4.integrations/3.convex.md
@@ -3,19 +3,19 @@ title: Convex
 description: Current status of Convex integration in this module.
 ---
 
-Use this page when you are evaluating whether this module has first-class Convex support.
+Use this page when you are evaluating whether this module has first-class :brand-badge{name="convex"} support.
 
-This module does not currently provide a built-in Convex adapter integration.
+This module does not currently provide a built-in :brand-badge{name="convex"} adapter integration.
 
 ## Status
 
-- Convex-specific module configuration (`auth.database.provider = 'convex'`) is not supported.
-- The maintained paths in this module are NuxtHub-backed storage and database-less/client-only usage.
+- :brand-badge{name="convex"}-specific module configuration (`auth.database.provider = 'convex'`) is not supported.
+- The maintained paths in this module are :brand-badge{name="nuxthub"}-backed storage and database-less/client-only usage.
 
 ## Recommended paths
 
 - For external Better Auth backends, use [External Auth Backend](/guides/external-auth-backend).
-- For Convex-specific auth/database setup, use the upstream Convex and Better Auth documentation.
+- For :brand-badge{name="convex"}-specific auth/database setup, use the upstream :brand-badge{name="convex"} and Better Auth documentation.
 
 :read-more{to="https://www.convex.dev/docs"}
 :read-more{to="https://www.better-auth.com/docs"}


### PR DESCRIPTION
## Summary

- add a reusable inline brand badge for linked and plain technology mentions
- show logos for deployment platforms, database adapters, dialects, and related services
- apply the badges across the relevant getting-started, guide, and integration pages

## Test plan

- [x] `pnpm lint`
- [x] `pnpm build:docs`

