### PR TITLE
fix: install client session bridge once

### DIFF
--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -12,6 +12,7 @@ import { getAuthRuntimeFlags, useRawAuthClient } from './useAuthClient'
 export interface SignOutOptions { onSuccess?: () => void | Promise<void> }
 
 let _signOutPromise: Promise<void> | null = null
+const _sessionSyncApps = new WeakSet<object>()
 
 export interface UseUserSessionReturn {
   session: Ref<AuthSession | null>
@@ -132,7 +133,7 @@ export function useUserSession(): UseUserSessionReturn {
   }
 
   // On client, subscribe to better-auth's reactive session store
-  if (runtimeFlags.client && rawClient) {
+  if (runtimeFlags.client && rawClient && !_sessionSyncApps.has(nuxtApp)) {
     const clientSession = rawClient.useSession()
     const initialClientSession = clientSession.value
 
@@ -182,6 +183,8 @@ export function useUserSession(): UseUserSessionReturn {
           authReady.value = true
       },
     )
+
+    _sessionSyncApps.add(nuxtApp)
   }
 
   function waitForSession(): Promise<void> {

--- a/test/use-user-session.test.ts
+++ b/test/use-user-session.test.ts
@@ -204,6 +204,15 @@ describe('useUserSession hydration bootstrap', () => {
     expect(mockClient.useSession).toHaveBeenCalledOnce()
   })
 
+  it('installs the client session bridge once per Nuxt app', async () => {
+    const useUserSession = await loadUseUserSession()
+
+    for (let index = 0; index < 100; index++)
+      useUserSession()
+
+    expect(mockClient.useSession).toHaveBeenCalledOnce()
+  })
+
   it('bootstraps client session for prerendered/cached payloads', async () => {
     payload.serverRendered = true
     payload.prerenderedAt = Date.now()


### PR DESCRIPTION
## Summary

- install the client session bridge once per Nuxt app
- add a regression test that calls `useUserSession()` 100 times and requires one Better Auth subscription

## Why

Every composable consumer previously called `rawClient.useSession()` and installed another watcher. In a large Nuxt app, those retained subscriptions amplified focus-driven session refreshes until the renderer became unresponsive.

## Verification

- regression test on `main`: failed with 100 subscriptions instead of 1
- regression test after the fix: passed with 1 subscription
- `pnpm test`: 58 files, 339 tests passed
- `pnpm lint`
- `pnpm typecheck`
- `pnpm prepack`