### PR TITLE
docs: correct auth testing examples and session waits

### DIFF
--- a/docs/content/3.guides/8.testing.md
+++ b/docs/content/3.guides/8.testing.md
@@ -1,39 +1,87 @@
 ---
 title: Testing
-description: Mock authentication in tests.
+description: Mock authentication in component tests and verify protected API routes.
 ---
 
-Use this guide when you want to test pages, composables, or Nitro routes without relying on a live auth backend.
+Use Nuxt's runtime test environment for components and composables. Use its end-to-end test environment for HTTP requests to a running application. See [Nuxt's testing setup](https://nuxt.com/docs/getting-started/testing) for the Vitest configuration for each environment.
 
 ## Mocking useUserSession
 
-```ts [tests/utils.ts]
-import type { AuthUser } from '#nuxt-better-auth'
-import { mockNuxtImport } from '@nuxt/test-utils/runtime'
-import { computed, ref } from 'vue'
-import { vi } from 'vitest'
+`mockNuxtImport` is hoisted. Register it once at the top level of the test file and create the mock with `vi.hoisted`. Set its return value in `beforeEach` so each test receives fresh state.
 
-export function mockAuth(user: Partial<AuthUser> | null = null) {
-  mockNuxtImport('useUserSession', () => () => ({
-    user: ref(user),
-    session: ref(user ? { id: 'test-session' } : null),
-    loggedIn: computed(() => !!user),
-    ready: ref(true),
-    signIn: { email: vi.fn(), social: vi.fn() },
-    signOut: vi.fn(),
-  }))
-}
+For example, this component reads the signed-in state:
+
+```vue [app/components/AuthStatus.vue]
+<script setup lang="ts">
+const { loggedIn } = useUserSession()
+</script>
+
+<template>
+  <p>{{ loggedIn ? 'Signed in' : 'Signed out' }}</p>
+</template>
 ```
 
-## Testing Protected API Routes
+Test it in the Nuxt runtime environment:
 
-```ts [server/api/protected.test.ts]
-import { describe, it, expect } from 'vitest'
+```ts [tests/nuxt/auth-status.nuxt.spec.ts]
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import AuthStatus from '~/components/AuthStatus.vue'
 
-describe('GET /api/protected', () => {
-  it('returns 401 without session', async () => {
-    const res = await $fetch('/api/protected', { ignoreResponseError: true })
-    expect(res.statusCode).toBe(401)
+const { useUserSessionMock } = vi.hoisted(() => ({
+  useUserSessionMock: vi.fn(),
+}))
+
+mockNuxtImport('useUserSession', () => useUserSessionMock)
+
+beforeEach(() => {
+  useUserSessionMock.mockReset()
+  useUserSessionMock.mockReturnValue({ loggedIn: ref(false) })
+})
+
+describe('AuthStatus', () => {
+  it('shows the signed-out state', async () => {
+    const component = await mountSuspended(AuthStatus)
+    expect(component.text()).toBe('Signed out')
+  })
+
+  it('shows the signed-in state', async () => {
+    useUserSessionMock.mockReturnValue({ loggedIn: ref(true) })
+    const component = await mountSuspended(AuthStatus)
+    expect(component.text()).toBe('Signed in')
+  })
+})
+```
+
+This mock supplies the field the component reads. Add `user`, `session`, `ready`, or methods when the component uses them. `useUserSession` does not return `signIn` or `signUp`; mock `useSignIn` or `useSignUp` separately when testing an authentication action.
+
+## Testing protected API routes
+
+Run HTTP tests against a prepared Nuxt fixture. For example, create a minimal application in `tests/fixtures/auth` with the module configured and this route:
+
+```ts [tests/fixtures/auth/server/api/protected.get.ts]
+export default defineEventHandler(async (event) => {
+  const { user } = await requireUserSession(event)
+  return { id: user.id }
+})
+```
+
+The end-to-end setup builds and starts that fixture. Use the response's HTTP status to verify access is denied:
+
+```ts [tests/e2e/protected.test.ts]
+import { fileURLToPath } from 'node:url'
+import { setup, url } from '@nuxt/test-utils/e2e'
+import { describe, expect, it } from 'vitest'
+
+describe('GET /api/protected', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('../fixtures/auth', import.meta.url)),
+  })
+
+  it('returns 401 without a session', async () => {
+    const response = await fetch(url('/api/protected'))
+    expect(response.status).toBe(401)
   })
 })
 ```

--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -166,15 +166,15 @@ await signOut({
 
 ### `waitForSession()`
 
-Waits for session state to be ready. Resolves when user is logged in or after 5 second timeout.
+Waits until `loggedIn` becomes true or five seconds pass. A signed-out session can already be ready, so this helper does not wait for `ready`.
 
 ```ts
 await waitForSession()
-// Session is now ready (or timed out)
+// The user is logged in, or the five-second wait ended.
 ```
 
 ::tip
-Use this when you need to ensure session state before proceeding. The function always resolves - it doesn't throw or return a value.
+The function always resolves and returns no value. Check `loggedIn.value` after awaiting it if the next action requires authentication. To perform a session lookup and wait for it to finish, use `await fetchSession()`.
 ::
 
 #### `fetchSession`


### PR DESCRIPTION
The testing guide puts a hoisted mock inside a function, mocks a removed session API, and omits the HTTP test setup. Replace it with a component example using `vi.hoisted` and `mockNuxtImport`, and a protected-route example that starts a Nuxt fixture and checks the HTTP status.

Clarify that `waitForSession()` waits for login or its timeout; callers must still check authentication afterward.
