### PR TITLE
test: isolate Nuxt fixtures and bound subprocess execution

### DIFF
--- a/test/auth-schema-export.test.ts
+++ b/test/auth-schema-export.test.ts
@@ -12,6 +12,7 @@ describe('#auth/schema export', async () => {
   const prepare = spawnSync('npx', ['nuxi', 'prepare'], {
     cwd: rootDir,
     encoding: 'utf8',
+    timeout: 120_000,
   })
   if (prepare.status !== 0)
     throw new Error(`clean nuxi prepare failed:\n${prepare.stdout}\n${prepare.stderr}`)

--- a/test/composables-subpath-exports.test.ts
+++ b/test/composables-subpath-exports.test.ts
@@ -16,6 +16,7 @@ describe('public composables subpath export', () => {
         cwd: fileURLToPath(new URL('..', import.meta.url)),
         env,
         encoding: 'utf8',
+        timeout: 120_000,
       })
       expect(build.status, `nuxt-module-build failed:\n${build.stdout}\n${build.stderr}`).toBe(0)
     }
@@ -24,6 +25,7 @@ describe('public composables subpath export', () => {
       cwd: fixtureDir,
       env,
       encoding: 'utf8',
+      timeout: 120_000,
     })
     expect(prepare.status, `nuxi prepare failed:\n${prepare.stdout}\n${prepare.stderr}`).toBe(0)
 
@@ -31,6 +33,7 @@ describe('public composables subpath export', () => {
       cwd: fixtureDir,
       env,
       encoding: 'utf8',
+      timeout: 120_000,
     })
     expect(typecheck.status, `tsc failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)
   }, 180_000)

--- a/test/composables-subpath-exports.test.ts
+++ b/test/composables-subpath-exports.test.ts
@@ -36,5 +36,5 @@ describe('public composables subpath export', () => {
       timeout: 120_000,
     })
     expect(typecheck.status, `tsc failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)
-  }, 180_000)
+  }, 360_000)
 })

--- a/test/config-extend-hook.test.ts
+++ b/test/config-extend-hook.test.ts
@@ -16,7 +16,7 @@ it('accepts only schema plugin contributions', () => {
   expect(runtimeConfig.appName).toBe('runtime option')
 })
 
-it('rejects runtime options during typechecking', { timeout: 30_000 }, () => {
+it('rejects runtime options during typechecking', { timeout: 180_000 }, () => {
   const typecheck = spawnSync('pnpm', [
     'exec',
     'tsc',

--- a/test/config-extend-hook.test.ts
+++ b/test/config-extend-hook.test.ts
@@ -35,6 +35,7 @@ it('rejects runtime options during typechecking', { timeout: 30_000 }, () => {
   ], {
     cwd: import.meta.dirname,
     encoding: 'utf8',
+    timeout: 120_000,
   })
 
   expect(typecheck.status, `tsc failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)

--- a/test/define-server-auth-literal-inference.test.ts
+++ b/test/define-server-auth-literal-inference.test.ts
@@ -9,6 +9,7 @@ describe('defineServerAuth literal inference regression #134', () => {
     const typecheck = spawnSync('pnpm', ['exec', 'tsc', '--noEmit', '--pretty', 'false', '-p', 'tsconfig.json'], {
       cwd: fixtureDir,
       encoding: 'utf8',
+      timeout: 120_000,
     })
 
     expect(typecheck.status, `tsc failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)

--- a/test/define-server-auth-literal-inference.test.ts
+++ b/test/define-server-auth-literal-inference.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest'
 const fixtureDir = fileURLToPath(new URL('./cases/define-server-auth-literal-inference', import.meta.url))
 
 describe('defineServerAuth literal inference regression #134', () => {
-  it('typechecks nested literals without as const and rejects invalid literals', { timeout: 30_000 }, () => {
+  it('typechecks nested literals without as const and rejects invalid literals', { timeout: 180_000 }, () => {
     const typecheck = spawnSync('pnpm', ['exec', 'tsc', '--noEmit', '--pretty', 'false', '-p', 'tsconfig.json'], {
       cwd: fixtureDir,
       encoding: 'utf8',

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -18,6 +18,7 @@ describe('exports-snapshot', async () => {
     if (!existsSync('dist/module.mjs') || !existsSync('dist/runtime/config.js') || !existsSync('dist/runtime/composables.js')) {
       const build = spawnSync('pnpm', ['exec', 'nuxt-module-build', 'build'], {
         encoding: 'utf8',
+        timeout: 120_000,
         env: process.env,
       })
       expect(build.status, `nuxt-module-build failed:\n${build.stdout}\n${build.stderr}`).toBe(0)
@@ -51,12 +52,13 @@ describe('exports-snapshot', async () => {
     }
 
     await expect(yaml.stringify(manifest)).toMatchFileSnapshot('./exports/module.yaml')
-  }, 60_000)
+  }, 360_000)
 
   it('does not import module-owned composables from #imports in built runtime', () => {
     if (!existsSync('dist/runtime/composables.js')) {
       const build = spawnSync('pnpm', ['exec', 'nuxt-module-build', 'build'], {
         encoding: 'utf8',
+        timeout: 120_000,
         env: process.env,
       })
       expect(build.status, `nuxt-module-build failed:\n${build.stdout}\n${build.stderr}`).toBe(0)
@@ -69,5 +71,5 @@ describe('exports-snapshot', async () => {
     })
 
     expect(coupledFiles).toEqual([])
-  }, 60_000)
+  }, 360_000)
 })

--- a/test/infer-nitro-endpoints-types.test.ts
+++ b/test/infer-nitro-endpoints-types.test.ts
@@ -14,6 +14,7 @@ describe('nitro route inference', () => {
       cwd: fixtureDir,
       env,
       encoding: 'utf8',
+      timeout: 120_000,
     })
     expect(prepare.status, `nuxi prepare failed:\n${prepare.stdout}\n${prepare.stderr}`).toBe(0)
 
@@ -21,7 +22,8 @@ describe('nitro route inference', () => {
       cwd: fixtureDir,
       env,
       encoding: 'utf8',
+      timeout: 120_000,
     })
     expect(typecheck.status, `tsc failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)
-  }, 60_000)
+  }, 360_000)
 })

--- a/test/infer-plugins-types.test.ts
+++ b/test/infer-plugins-types.test.ts
@@ -15,6 +15,7 @@ describe('type inference regressions #107, #192, and #382', () => {
       cwd: fixtureDir,
       env,
       encoding: 'utf8',
+      timeout: 120_000,
     })
     expect(prepare.status, `nuxi prepare failed:\n${prepare.stdout}\n${prepare.stderr}`).toBe(0)
 
@@ -22,6 +23,7 @@ describe('type inference regressions #107, #192, and #382', () => {
       cwd: fixtureDir,
       env,
       encoding: 'utf8',
+      timeout: 120_000,
     })
     expect(typecheck.status, `vue-tsc failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)
     const output = `${typecheck.stdout}\n${typecheck.stderr}`
@@ -36,15 +38,17 @@ describe('type inference regressions #107, #192, and #382', () => {
       cwd: fixtureDir,
       env,
       encoding: 'utf8',
+      timeout: 120_000,
     })
     expect(sharedTypecheck.status, `shared vue-tsc failed:\n${sharedTypecheck.stdout}\n${sharedTypecheck.stderr}`).toBe(0)
-  }, 60_000)
+  }, 360_000)
 
   it('keeps admin plugin fields in app and shared projects when auth config comes from a layer', () => {
     const prepare = spawnSync('npx', ['nuxi', 'prepare'], {
       cwd: layerFixtureDir,
       env,
       encoding: 'utf8',
+      timeout: 120_000,
     })
     expect(prepare.status, `layer nuxi prepare failed:\n${prepare.stdout}\n${prepare.stderr}`).toBe(0)
 
@@ -53,8 +57,9 @@ describe('type inference regressions #107, #192, and #382', () => {
         cwd: layerFixtureDir,
         env,
         encoding: 'utf8',
+        timeout: 120_000,
       })
       expect(typecheck.status, `${project} vue-tsc failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)
     }
-  }, 60_000)
+  }, 360_000)
 })

--- a/test/infer-use-fetch-endpoints-types.test.ts
+++ b/test/infer-use-fetch-endpoints-types.test.ts
@@ -14,6 +14,7 @@ describe('typed useFetch auth endpoint inference', () => {
       cwd: fixtureDir,
       env,
       encoding: 'utf8',
+      timeout: 120_000,
     })
     expect(prepare.status, `nuxi prepare failed:\n${prepare.stdout}\n${prepare.stderr}`).toBe(0)
 
@@ -21,7 +22,8 @@ describe('typed useFetch auth endpoint inference', () => {
       cwd: fixtureDir,
       env,
       encoding: 'utf8',
+      timeout: 120_000,
     })
     expect(typecheck.status, `tsc failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)
-  }, 60_000)
+  }, 360_000)
 })

--- a/test/layer-plugin-contributions.test.ts
+++ b/test/layer-plugin-contributions.test.ts
@@ -28,6 +28,7 @@ describe('layer plugin contributions', async () => {
       cwd: fixtureDir,
       env,
       encoding: 'utf8',
+      timeout: 120_000,
     })
     expect(prepare.status, `nuxi prepare failed:\n${prepare.stdout}\n${prepare.stderr}`).toBe(0)
 
@@ -35,11 +36,12 @@ describe('layer plugin contributions', async () => {
       cwd: fixtureDir,
       env,
       encoding: 'utf8',
+      timeout: 120_000,
     })
     expect(typecheck.status, `app vue-tsc failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)
 
     const sharedTypes = readFileSync(`${fixtureDir}/.nuxt/nuxt.shared.d.ts`, 'utf8')
     expect(sharedTypes).not.toContain('types/nuxt-better-auth-infer.d.ts')
     expect(sharedTypes).not.toContain('types/nuxt-better-auth-social-providers.d.ts')
-  }, 60_000)
+  }, 360_000)
 })

--- a/test/nuxthub-prerender-db-import.test.ts
+++ b/test/nuxthub-prerender-db-import.test.ts
@@ -59,6 +59,7 @@ describe('nuxthub prerender @nuxthub/db imports', () => {
       cwd: fixtureDir,
       env,
       encoding: 'utf8',
+      timeout: 120_000,
     })
 
     expect(build.status, `nuxi build failed:\n${build.stdout}\n${build.stderr}`).toBe(0)
@@ -84,5 +85,5 @@ describe('nuxthub prerender @nuxthub/db imports', () => {
     expect(authSchema).toContain('const authSchema = pgSchema("auth")')
     expect(authSchema).toContain('export const user = authSchema.table("user"')
     expect(authSchema).not.toContain('pgTable')
-  }, 120_000)
+  }, 360_000)
 })

--- a/test/require-user-session-typing.test.ts
+++ b/test/require-user-session-typing.test.ts
@@ -137,6 +137,7 @@ export async function check(event: H3Event) {
       const typecheck = spawnSync('corepack', ['pnpm', 'exec', 'tsc', '--noEmit', '--pretty', 'false', '-p', tsconfigPath], {
         cwd: import.meta.dirname,
         encoding: 'utf8',
+        timeout: 120_000,
       })
 
       expect(typecheck.status, `tsc failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)
@@ -144,5 +145,5 @@ export async function check(event: H3Event) {
     finally {
       await rm(testDir, { recursive: true, force: true })
     }
-  }, 30_000)
+  }, 360_000)
 })

--- a/test/runtime-only-secret-build.test.ts
+++ b/test/runtime-only-secret-build.test.ts
@@ -19,9 +19,10 @@ describe('runtime-only auth secret', () => {
       cwd: fixtureDir,
       env,
       encoding: 'utf8',
+      timeout: 120_000,
     })
 
     expect(build.status, `nuxi build failed:\n${build.stdout}\n${build.stderr}`).toBe(0)
     expect(existsSync(join(fixtureDir, '.output/server/wrangler.json'))).toBe(true)
-  }, 120_000)
+  }, 360_000)
 })

--- a/test/server-auth-project-references-typecheck.test.ts
+++ b/test/server-auth-project-references-typecheck.test.ts
@@ -19,6 +19,7 @@ beforeAll(() => {
     cwd: rootDir,
     env,
     encoding: 'utf8',
+    timeout: 120_000,
   })
   expect(build.status, `nuxt-module-build failed:\n${build.stdout}\n${build.stderr}`).toBe(0)
 }, 180_000)
@@ -28,6 +29,7 @@ function runProjectReferenceTypecheck(fixtureDir: string) {
     cwd: fixtureDir,
     env,
     encoding: 'utf8',
+    timeout: 120_000,
   })
   expect(prepare.status, `nuxi prepare failed:\n${prepare.stdout}\n${prepare.stderr}`).toBe(0)
 
@@ -35,6 +37,7 @@ function runProjectReferenceTypecheck(fixtureDir: string) {
     cwd: fixtureDir,
     env,
     encoding: 'utf8',
+    timeout: 120_000,
   })
   expect(typecheck.status, `vue-tsc -b failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)
 }
@@ -97,7 +100,7 @@ describe('server auth config project-reference typecheck regression #309', () =>
     expectServerContextToAvoidNuxthubAugmentation(fixtureDir)
     expectNuxtTypesToStayClientSafe(fixtureDir)
     expectSharedTypesToIncludeOnlySafeConfigContext(fixtureDir)
-  }, 60_000)
+  }, 360_000)
 
   it('typechecks auth config imports that use the #server alias', () => {
     const fixtureDir = fileURLToPath(new URL('./cases/server-auth-alias-typecheck', import.meta.url))
@@ -106,5 +109,5 @@ describe('server auth config project-reference typecheck regression #309', () =>
     expectServerContextToAvoidNuxthubAugmentation(fixtureDir)
     expectNuxtTypesToStayClientSafe(fixtureDir)
     expectSharedTypesToIncludeOnlySafeConfigContext(fixtureDir)
-  }, 60_000)
+  }, 360_000)
 })

--- a/test/use-signin-provider-alias-typing.test.ts
+++ b/test/use-signin-provider-alias-typing.test.ts
@@ -9,13 +9,15 @@ describe('useSignIn social provider typing', () => {
     const prepare = spawnSync('npx', ['nuxi', 'prepare'], {
       cwd: fixtureDir,
       encoding: 'utf8',
+      timeout: 120_000,
     })
     expect(prepare.status, `nuxi prepare failed:\n${prepare.stdout}\n${prepare.stderr}`).toBe(0)
 
     const typecheck = spawnSync('npx', ['tsc', '--noEmit', '--pretty', 'false', '-p', 'tsconfig.type-check.json'], {
       cwd: fixtureDir,
       encoding: 'utf8',
+      timeout: 120_000,
     })
     expect(typecheck.status, `tsc failed:\n${typecheck.stdout}\n${typecheck.stderr}`).toBe(0)
-  }, 60000)
+  }, 360_000)
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,6 +31,7 @@ const integrationTests = [
   'test/preserve-redirect-custom-key.test.ts',
   'test/preserve-redirect-custom-login.test.ts',
   'test/preserve-redirect-disabled.test.ts',
+  'test/public-auto-imports.test.ts',
   'test/redirects-option.test.ts',
   'test/runtime-only-secret-build.test.ts',
   'test/server-auth-base-url-cache.test.ts',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,12 +1,40 @@
 import { configDefaults, defineConfig } from 'vitest/config'
 import { fileURLToPath } from 'node:url'
 
+const typeTests = [
+  'test/config-extend-hook.test.ts',
+  'test/define-server-auth-literal-inference.test.ts',
+  'test/infer-nitro-endpoints-types.test.ts',
+  'test/infer-plugins-types.test.ts',
+  'test/infer-use-fetch-endpoints-types.test.ts',
+  'test/require-user-session-typing.test.ts',
+  'test/use-signin-provider-alias-typing.test.ts',
+]
+
 const integrationTests = [
+  'test/auth-schema-export.test.ts',
+  'test/composables-subpath-exports.test.ts',
+  'test/config-paths.test.ts',
+  'test/dev-trusted-origins.test.ts',
+  'test/exports.test.ts',
+  'test/layer-default-configs.test.ts',
+  'test/layer-explicit-configs.test.ts',
+  'test/layer-plugin-contributions.test.ts',
+  'test/module-setup.test.ts',
   'test/module.test.ts',
   'test/no-db.test.ts',
   'test/no-hub.test.ts',
-  'test/dev-trusted-origins.test.ts',
+  'test/non-tty-secret-prompt.test.ts',
+  'test/nuxthub-drizzle-schema-regression.test.ts',
+  'test/nuxthub-prerender-db-import.test.ts',
+  'test/pinia-setup-store.test.ts',
+  'test/preserve-redirect-custom-key.test.ts',
+  'test/preserve-redirect-custom-login.test.ts',
+  'test/preserve-redirect-disabled.test.ts',
+  'test/redirects-option.test.ts',
+  'test/runtime-only-secret-build.test.ts',
   'test/server-auth-base-url-cache.test.ts',
+  'test/server-auth-project-references-typecheck.test.ts',
 ]
 
 const nitroCompatibilityAlias = {
@@ -23,7 +51,21 @@ export default defineConfig({
         test: {
           name: 'unit',
           include: ['test/**/*.test.ts'],
-          exclude: [...configDefaults.exclude, ...integrationTests],
+          exclude: [...configDefaults.exclude, ...typeTests, ...integrationTests],
+        },
+      },
+      {
+        resolve: {
+          alias: nitroCompatibilityAlias,
+        },
+        test: {
+          name: 'types',
+          include: typeTests,
+          fileParallelism: false,
+          testTimeout: 360_000,
+          sequence: {
+            groupOrder: 1,
+          },
         },
       },
       {
@@ -32,11 +74,12 @@ export default defineConfig({
         },
         test: {
           name: 'integration',
+          testTimeout: 360_000,
           include: integrationTests,
           fileParallelism: false,
           hookTimeout: 180_000,
           sequence: {
-            groupOrder: 1,
+            groupOrder: 2,
           },
         },
       },


### PR DESCRIPTION
Nuxt builds and compiler fixtures currently run alongside unit tests, competing for resources and leaving blocking child processes without a deadline. Group pure tests, compiler fixtures, and Nuxt integrations separately, serialize the heavy groups, and bound previously unbounded child commands at two minutes.

Tests that run several child commands receive a six-minute budget. Existing shorter child deadlines remain in place.
