### PR TITLE
test: check social providers against the real sign-in composable

### DIFF
--- a/test/cases/signin-provider-alias-type-inference/tsconfig.type-check.json
+++ b/test/cases/signin-provider-alias-type-inference/tsconfig.type-check.json
@@ -13,12 +13,12 @@
     "noEmit": true,
     "skipLibCheck": true
   },
-  "include": [],
   "files": [
     "./.nuxt/types/nuxt-better-auth.d.ts",
     "./.nuxt/types/nuxt-better-auth-client.d.ts",
     "./.nuxt/types/nuxt-better-auth-endpoints.d.ts",
     "./.nuxt/types/nuxt-better-auth-social-providers.d.ts",
     "./typecheck-target.ts"
-  ]
+  ],
+  "include": []
 }

--- a/test/cases/signin-provider-alias-type-inference/tsconfig.type-check.json
+++ b/test/cases/signin-provider-alias-type-inference/tsconfig.type-check.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./.nuxt/tsconfig.app.json",
   "compilerOptions": {
     "target": "ESNext",
     "lib": [
@@ -12,8 +13,11 @@
     "noEmit": true,
     "skipLibCheck": true
   },
+  "include": [],
   "files": [
     "./.nuxt/types/nuxt-better-auth.d.ts",
+    "./.nuxt/types/nuxt-better-auth-client.d.ts",
+    "./.nuxt/types/nuxt-better-auth-endpoints.d.ts",
     "./.nuxt/types/nuxt-better-auth-social-providers.d.ts",
     "./typecheck-target.ts"
   ]

--- a/test/cases/signin-provider-alias-type-inference/typecheck-target.ts
+++ b/test/cases/signin-provider-alias-type-inference/typecheck-target.ts
@@ -1,14 +1,8 @@
+import { useSignIn } from '../../../src/runtime/app/composables/useSignIn'
 import type { AuthSocialProviderId } from '#nuxt-better-auth'
 import type { socialProviders } from './server/auth.config'
 
 type RawSocialProviderIds = Extract<keyof typeof socialProviders, string>
-
-interface ActionHandle<Payload> {
-  execute: (payload: Payload) => Promise<void>
-}
-
-declare function useSignIn(method: 'email'): ActionHandle<{ email: string, password: string }>
-declare function useSignIn(method: 'social'): ActionHandle<{ provider: RawSocialProviderIds, callbackURL?: string }>
 
 useSignIn('email')
 useSignIn('social')


### PR DESCRIPTION
The social-provider fixture declares its own `useSignIn` overloads, so it can pass after the shipped composable's types regress. Import the actual composable and load its generated client and endpoint declarations to check configured providers against the public implementation.
