### PR TITLE
test: verify exports from a fresh package build

### DIFF
--- a/test/composables-subpath-exports.test.ts
+++ b/test/composables-subpath-exports.test.ts
@@ -1,5 +1,4 @@
 import { spawnSync } from 'node:child_process'
-import { existsSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
@@ -11,15 +10,6 @@ const env = {
 
 describe('public composables subpath export', () => {
   it('typechecks consumer imports from @nuxtjs/better-auth/composables', () => {
-    if (!existsSync(fileURLToPath(new URL('../dist/runtime/composables.js', import.meta.url)))) {
-      const build = spawnSync('pnpm', ['exec', 'nuxt-module-build', 'build'], {
-        cwd: fileURLToPath(new URL('..', import.meta.url)),
-        env,
-        encoding: 'utf8',
-      })
-      expect(build.status, `nuxt-module-build failed:\n${build.stdout}\n${build.stderr}`).toBe(0)
-    }
-
     const prepare = spawnSync('npx', ['nuxi', 'prepare'], {
       cwd: fixtureDir,
       env,

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,8 +1,12 @@
-import { spawnSync } from 'node:child_process'
-import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import yaml from 'yaml'
+
+// Nuxt provides these modules in a consumer app. Keep the package's own
+// composables real so a missing or changed export fails this snapshot.
+vi.mock('#imports', () => ({}))
+vi.mock('#auth/client', () => ({ default: () => ({}) }))
 
 function listRuntimeFiles(dir: string): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
@@ -15,53 +19,23 @@ function listRuntimeFiles(dir: string): string[] {
 
 describe('exports-snapshot', async () => {
   it('module exports', async () => {
-    if (!existsSync('dist/module.mjs') || !existsSync('dist/runtime/config.js') || !existsSync('dist/runtime/composables.js')) {
-      const build = spawnSync('pnpm', ['exec', 'nuxt-module-build', 'build'], {
-        encoding: 'utf8',
-        env: process.env,
-      })
-      expect(build.status, `nuxt-module-build failed:\n${build.stdout}\n${build.stderr}`).toBe(0)
-    }
-
     const moduleExports = await import('../dist/module.mjs')
     const configExports = await import('../dist/runtime/config.js')
 
+    const composableExports = await import('../dist/runtime/composables.js')
+    const exportTypes = (exports: Record<string, unknown>) => Object.fromEntries(
+      Object.entries(exports).sort(([a], [b]) => a.localeCompare(b)).map(([name, value]) => [name, typeof value]),
+    )
     const manifest = {
-      '.': {
-        default: typeof moduleExports.default,
-        defineClientAuth: typeof moduleExports.defineClientAuth,
-        defineServerAuth: typeof moduleExports.defineServerAuth,
-      },
-      './composables': {
-        runWithSessionRefresh: 'function',
-        useAction: 'function',
-        useAuthAsyncData: 'function',
-        useAuthClient: 'function',
-        useAuthClientAction: 'function',
-        useAuthRequestFetch: 'function',
-        useSignIn: 'function',
-        useSignUp: 'function',
-        useUserSession: 'function',
-        useUserSessionState: 'function',
-      },
-      './config': {
-        defineClientAuth: typeof configExports.defineClientAuth,
-        defineServerAuth: typeof configExports.defineServerAuth,
-      },
+      '.': exportTypes(moduleExports),
+      './composables': exportTypes(composableExports),
+      './config': exportTypes(configExports),
     }
 
     await expect(yaml.stringify(manifest)).toMatchFileSnapshot('./exports/module.yaml')
   }, 60_000)
 
   it('does not import module-owned composables from #imports in built runtime', () => {
-    if (!existsSync('dist/runtime/composables.js')) {
-      const build = spawnSync('pnpm', ['exec', 'nuxt-module-build', 'build'], {
-        encoding: 'utf8',
-        env: process.env,
-      })
-      expect(build.status, `nuxt-module-build failed:\n${build.stdout}\n${build.stderr}`).toBe(0)
-    }
-
     const runtimeFiles = listRuntimeFiles('dist/runtime/app')
     const coupledFiles = runtimeFiles.filter((file) => {
       const contents = readFileSync(file, 'utf8')

--- a/test/exports/module.yaml
+++ b/test/exports/module.yaml
@@ -16,3 +16,5 @@
 ./config:
   defineClientAuth: function
   defineServerAuth: function
+  extendClientAuth: function
+  extendServerAuth: function

--- a/test/setup/build-package.ts
+++ b/test/setup/build-package.ts
@@ -1,0 +1,15 @@
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+// Build once before any worker can import package exports or prepare a consumer.
+// An existing dist may come from another version or a development stub build.
+export default function setup() {
+  const build = spawnSync('pnpm', ['exec', 'nuxt-module-build', 'build'], {
+    cwd: fileURLToPath(new URL('../..', import.meta.url)),
+    env: process.env,
+    encoding: 'utf8',
+    timeout: 120_000,
+  })
+  if (build.status !== 0)
+    throw new Error(`nuxt-module-build failed: ${build.error || ''}\n${build.stdout}\n${build.stderr}`)
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,7 @@ const nitroCompatibilityAlias = {
 
 export default defineConfig({
   test: {
+    globalSetup: ['./test/setup/build-package.ts'],
     projects: [
       {
         resolve: {


### PR DESCRIPTION
The export snapshot hardcodes composables as functions, and package consumers can reuse output from an older build. Build the package once before workers start, then derive the snapshot from the actual module, config, and composable exports.

Only Nuxt's virtual modules are mocked when loading composables. The module's own exports remain real, so removed exports and changed value types change the snapshot.
