### PR TITLE
fix!: expose token-free client session types

### DIFF
--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -73,6 +73,10 @@ For SSR-safe auth access:
 
 Return `useUserSession()` directly when you want auth state in a Pinia setup store or another shared state container.
 
+### Client session type
+
+`useUserSession().session` uses `ClientAuthSession`, which omits `token` from `AuthSession`. The module already removes the token from client state. Update explicit client-side `AuthSession` annotations to `ClientAuthSession` imported from `#nuxt-better-auth`. Server helpers continue to return the full `AuthSession`, including its token.
+
 It returns:
 - `user`
 - `session`
@@ -452,7 +456,3 @@ await execute(
 - [Sessions](/core-concepts/sessions)
 - [Server utilities](/api/server-utils)
 - [Components](/api/components)
-
-### Client session type
-
-`useUserSession().session` uses `ClientAuthSession`, which omits `token` from `AuthSession`. The module already removes the token from client state. Update explicit client-side `AuthSession` annotations to `ClientAuthSession` imported from `#nuxt-better-auth`. Server helpers continue to return the full `AuthSession`, including its token.

--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -51,7 +51,7 @@ const { loggedIn, user, session, signOut } = useUserSession()
   ::field{name="user" type="Ref<AuthUser | null>"}
     The current user object, inferred from your config.
   ::
-  ::field{name="session" type="Ref<AuthSession | null>"}
+  ::field{name="session" type="Ref<ClientAuthSession | null>"}
     The current session object.
   ::
   ::field{name="ready" type="ComputedRef<boolean>"}
@@ -452,3 +452,7 @@ await execute(
 - [Sessions](/core-concepts/sessions)
 - [Server utilities](/api/server-utils)
 - [Components](/api/components)
+
+### Client session type
+
+`useUserSession().session` uses `ClientAuthSession`, which omits `token` from `AuthSession`. The module already removes the token from client state. Update explicit client-side `AuthSession` annotations to `ClientAuthSession` imported from `#nuxt-better-auth`. Server helpers continue to return the full `AuthSession`, including its token.

--- a/docs/content/5.api/4.types.md
+++ b/docs/content/5.api/4.types.md
@@ -14,6 +14,7 @@ import type {
   AuthRouteRules,
   AuthSocialProviderId,
   AuthSession,
+  ClientAuthSession,
   AuthUser,
   RequireSessionOptions,
   UserMatch,
@@ -46,7 +47,11 @@ Additional fields depend on your Better Auth plugins.
 
 ## AuthSession
 
-The session object returned by `useUserSession()`.
+The full session returned by server helpers, including its `token`.
+
+## ClientAuthSession
+
+The session object returned by `useUserSession()`. This is `Omit<AuthSession, 'token'>` and preserves additional session fields inferred from your configuration.
 
 ::field-group
   ::field{name="id" type="string"}

--- a/src/module/type-templates.ts
+++ b/src/module/type-templates.ts
@@ -370,6 +370,8 @@ declare module '#nuxt-better-auth' {
     userAgent?: string | null
   }
 
+  export type ClientAuthSession = Omit<AuthSession, 'token'>
+
   export interface ServerAuthContext {
     runtimeConfig: Record<string, unknown>
     db: unknown
@@ -381,7 +383,7 @@ declare module '#nuxt-better-auth' {
 
   export interface UserSessionComposable {
     user: Ref<AuthUser | null>
-    session: Ref<AuthSession | null>
+    session: Ref<ClientAuthSession | null>
     loggedIn: ComputedRef<boolean>
     ready: ComputedRef<boolean>
     fetchSession: (options?: { headers?: HeadersInit, force?: boolean }) => Promise<void>

--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -1,5 +1,5 @@
 import type { ComputedRef, Ref } from 'vue'
-import type { AppAuthClient, AuthSession, AuthUser } from '#nuxt-better-auth'
+import type { AppAuthClient, AuthSession, AuthUser, ClientAuthSession } from '#nuxt-better-auth'
 import { computed, navigateTo, nextTick, useNuxtApp, useRequestURL, useRuntimeConfig, useState, watch } from '#imports'
 import { normalizeAuthActionError } from '../internal/auth-action-error'
 import { resolvePostAuthSuccessRedirect, withFallbackSocialCallbackURL } from '../internal/redirect-helpers'
@@ -15,7 +15,7 @@ let _signOutPromise: Promise<void> | null = null
 const _sessionSyncApps = new WeakSet<object>()
 
 export interface UseUserSessionReturn {
-  session: Ref<AuthSession | null>
+  session: Ref<ClientAuthSession | null>
   user: Ref<AuthUser | null>
   loggedIn: ComputedRef<boolean>
   ready: ComputedRef<boolean>
@@ -50,7 +50,7 @@ export function useUserSession(): UseUserSessionReturn {
   const rawClient = useRawAuthClient()
 
   // Shared state via useState for SSR hydration
-  const session = useState<AuthSession | null>('auth:session', () => null)
+  const session = useState<ClientAuthSession | null>('auth:session', () => null)
   const user = useState<AuthUser | null>('auth:user', () => null)
   const authReady = useState('auth:ready', () => false)
   const prerenderReadyResetQueued = useState('auth:prerender-ready-reset-queued', () => false)

--- a/src/runtime/app/internal/session-fetch.ts
+++ b/src/runtime/app/internal/session-fetch.ts
@@ -1,13 +1,13 @@
 import type { Ref } from 'vue'
-import type { AppAuthClient, AuthSession, AuthUser } from '#nuxt-better-auth'
+import type { AppAuthClient, AuthSession, AuthUser, ClientAuthSession } from '#nuxt-better-auth'
 import { useRequestFetch, useRequestHeaders } from '#imports'
 import { normalizeAuthActionError } from './auth-action-error'
 
 interface SessionResponse { session: AuthSession & { token?: string }, user: AuthUser }
 
-export function stripToken(session: AuthSession & { token?: string }): AuthSession {
+export function stripToken(session: AuthSession & { token?: string }): ClientAuthSession {
   const { token: _, ...safe } = session
-  return safe as AuthSession
+  return safe
 }
 
 function isExpectedSignedOutSessionError(error: unknown): boolean {
@@ -18,7 +18,7 @@ function isExpectedSignedOutSessionError(error: unknown): boolean {
 }
 
 export async function fetchSessionServer(
-  session: Ref<AuthSession | null>,
+  session: Ref<ClientAuthSession | null>,
   user: Ref<AuthUser | null>,
   authReady: Ref<boolean>,
   options: { headers?: HeadersInit } = {},
@@ -49,7 +49,7 @@ export async function fetchSessionServer(
 
 export async function fetchSessionClient(
   client: AppAuthClient,
-  session: Ref<AuthSession | null>,
+  session: Ref<ClientAuthSession | null>,
   user: Ref<AuthUser | null>,
   authReady: Ref<boolean>,
   options: { headers?: HeadersInit, force?: boolean } = {},

--- a/src/runtime/app/plugins/session.server.ts
+++ b/src/runtime/app/plugins/session.server.ts
@@ -1,11 +1,11 @@
-import type { AuthSession, AuthUser } from '#nuxt-better-auth'
+import type { AuthSession, AuthUser, ClientAuthSession } from '#nuxt-better-auth'
 import { defineNuxtPlugin, useRequestEvent, useRequestHeaders, useState } from '#imports'
 
 export default defineNuxtPlugin({
   name: 'auth:session-init',
   enforce: 'pre',
   async setup() {
-    const session = useState<AuthSession | null>('auth:session', () => null)
+    const session = useState<ClientAuthSession | null>('auth:session', () => null)
     const user = useState<AuthUser | null>('auth:user', () => null)
     const authReady = useState('auth:ready', () => false)
 
@@ -18,7 +18,7 @@ export default defineNuxtPlugin({
         if (data?.session && data?.user) {
           // Filter out sensitive token field from client state
           const { token: _, ...safeSession } = data.session
-          session.value = safeSession as AuthSession
+          session.value = safeSession
           user.value = data.user
         }
       }

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,7 +1,7 @@
 import type { AuthSocialProviderRegistry, AuthUser, UserMatch } from '#nuxt-better-auth'
 
 // Re-export augmentable types
-export type { AppSession, AuthSession, AuthSocialProviderRegistry, AuthUser, RequireSessionOptions, ServerAuthContext, UserMatch, UserSessionComposable } from './types/augment'
+export type { AppSession, AuthSession, AuthSocialProviderRegistry, AuthUser, ClientAuthSession, RequireSessionOptions, ServerAuthContext, UserMatch, UserSessionComposable } from './types/augment'
 
 export type AuthSocialProviderId = AuthSocialProviderRegistry extends { ids: infer T } ? Extract<T, string> : never
 

--- a/src/runtime/types/augment.ts
+++ b/src/runtime/types/augment.ts
@@ -26,6 +26,8 @@ export interface AuthSession {
   userAgent?: string | null
 }
 
+export type ClientAuthSession = Omit<AuthSession, 'token'>
+
 // Server auth context - extended by generated types with hub:db types
 export interface ServerAuthContext {
   runtimeConfig: Record<string, unknown>
@@ -39,7 +41,7 @@ export interface AuthSocialProviderRegistry {}
 // Composable return type
 export interface UserSessionComposable {
   user: Ref<AuthUser | null>
-  session: Ref<AuthSession | null>
+  session: Ref<ClientAuthSession | null>
   loggedIn: ComputedRef<boolean>
   ready: ComputedRef<boolean>
   fetchSession: (options?: { headers?: HeadersInit, force?: boolean }) => Promise<void>

--- a/test/cases/plugins-type-inference/typecheck-target.ts
+++ b/test/cases/plugins-type-inference/typecheck-target.ts
@@ -1,5 +1,5 @@
 import type { NitroRouteRules } from 'nitropack/types'
-import type { AuthSession, AuthUser } from '#nuxt-better-auth'
+import type { AuthSession, AuthUser, ClientAuthSession, UserSessionComposable } from '#nuxt-better-auth'
 import type { AuthSocialProviderId } from '../../../src/runtime/types'
 
 declare const serverAuth: typeof import('../../../src/runtime/server/utils/auth').serverAuth
@@ -7,6 +7,10 @@ declare const serverAuth: typeof import('../../../src/runtime/server/utils/auth'
 declare module '#nuxt-better-auth' {
   interface AuthUser {
     foo: string
+  }
+
+  interface AuthSession {
+    deviceLabel?: string
   }
 }
 
@@ -51,3 +55,22 @@ void auth
 void signInUsername
 void session
 void provider
+
+// Server helpers retain the token, while client state omits it after sanitization.
+const serverToken: string = session.token
+const clientSession: ClientAuthSession = {
+  id: 'session-1',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  userId: '1',
+  expiresAt: new Date(),
+  deviceLabel: 'Laptop',
+}
+declare const composable: UserSessionComposable
+composable.session.value = clientSession
+// @ts-expect-error Tokens are removed from state before it reaches the client.
+void composable.session.value?.token
+// @ts-expect-error A client session cannot satisfy the full server session contract.
+const fullSession: AuthSession = clientSession
+void serverToken
+void fullSession


### PR DESCRIPTION
Client session state removes the token at runtime, but its type still promises a string token. Use `ClientAuthSession = Omit<AuthSession, 'token'>` for the composable, SSR state and generated declarations; server helpers retain the full session type.

Migration: replace explicit client-side `AuthSession` annotations with `ClientAuthSession`. Additional session fields remain inferred.

**Before:** [client token access compiles despite being absent at runtime](https://github.com/onmax/repros/tree/repro/better-auth-client-session-type/better-auth-client-session-type). **After:** [client token access is rejected; server token access remains valid](https://github.com/onmax/repros/tree/repro/better-auth-client-session-type/better-auth-client-session-type-fix). These are runnable Node fixtures with clean-install commands.
