### PR TITLE
fix!: reject unsupported server auth paths

### DIFF
--- a/docs/content/2.core-concepts/1.server-auth.md
+++ b/docs/content/2.core-concepts/1.server-auth.md
@@ -38,3 +38,9 @@ Use this page when you need authentication state or Better Auth APIs inside Nitr
 `refreshSessionCookieCache(event)` refreshes the cached session cookie. It does not update the session or user record; perform that update first.
 
 :read-more{to="/api/server-utils"}
+
+## Server endpoint path
+
+The module registers Better Auth at `/api/auth`. `defineServerAuth` accepts only this `basePath` and rejects other values when resolving the config. Remove a custom server `basePath` or set it to `/api/auth`; update client URLs and OAuth callback URLs accordingly.
+
+External backends configured with `auth.clientOnly: true` can still use a custom `basePath` in `defineClientAuth`.

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -11,7 +11,9 @@ export interface ClientAuthContext {
   siteUrl: string
 }
 
-export type ServerAuthConfig = Omit<BetterAuthOptions, 'secret' | 'baseURL'> & {
+export type ServerAuthConfig = Omit<BetterAuthOptions, 'secret' | 'baseURL' | 'basePath'> & {
+  /** The module registers its server handler at /api/auth. */
+  basePath?: '/api/auth'
   plugins?: readonly BetterAuthPlugin[]
 }
 export type ClientAuthConfig = Omit<BetterAuthClientOptions, 'baseURL'> & { baseURL?: string }
@@ -98,9 +100,14 @@ export interface AuthPrivateRuntimeConfig {
 }
 
 export function defineServerAuth<const R>(config: (ctx: ServerAuthContext) => R & ServerAuthConfig): (ctx: ServerAuthContext) => R
-export function defineServerAuth<const R>(config: R & ServerAuthConfig): (ctx: ServerAuthContext) => R
+export function defineServerAuth<const R>(config: R & ServerAuthConfig & (R extends (...args: never[]) => unknown ? never : unknown)): (ctx: ServerAuthContext) => R
 export function defineServerAuth(config: ServerAuthConfig | ((ctx: ServerAuthContext) => ServerAuthConfig)): (ctx: ServerAuthContext) => ServerAuthConfig {
-  return typeof config === 'function' ? config : () => config
+  return (ctx) => {
+    const resolved = typeof config === 'function' ? config(ctx) : config
+    if (resolved.basePath !== undefined && resolved.basePath !== '/api/auth')
+      throw new Error('[nuxt-better-auth] Server basePath must be /api/auth. Remove basePath from defineServerAuth() or set it to /api/auth. External clientOnly backends may use a custom client basePath.')
+    return resolved
+  }
 }
 
 export function extendServerAuth<const R extends ServerAuthConfig, const P extends readonly BetterAuthPlugin[]>(

--- a/test/cases/define-server-auth-literal-inference/typecheck-target.ts
+++ b/test/cases/define-server-auth-literal-inference/typecheck-target.ts
@@ -34,3 +34,10 @@ defineServerAuth({
     },
   },
 })
+
+defineServerAuth({ basePath: '/api/auth' })
+defineServerAuth(() => ({ basePath: '/api/auth' }))
+// @ts-expect-error The module only registers /api/auth on the server.
+defineServerAuth({ basePath: '/custom/auth' })
+// @ts-expect-error Callback configs have the same routing restriction.
+defineServerAuth(() => ({ basePath: '/custom/auth' }))

--- a/test/server-auth-config.test.ts
+++ b/test/server-auth-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { defineServerAuth, extendServerAuth } from '../src/runtime/config'
+import { defineClientAuth, defineServerAuth, extendServerAuth } from '../src/runtime/config'
 
 describe('extendServerAuth', () => {
   it('appends contributed plugins after the app plugins', () => {
@@ -8,5 +8,23 @@ describe('extendServerAuth', () => {
     const factory = extendServerAuth(defineServerAuth({ plugins: [appPlugin] }), [layerPlugin])
 
     expect(factory({} as never).plugins).toEqual([appPlugin, layerPlugin])
+  })
+})
+
+describe('server basePath', () => {
+  it.each([undefined, '/api/auth'])('accepts the registered path %s', (basePath) => {
+    expect(defineServerAuth({ basePath })({} as never).basePath).toBe(basePath)
+  })
+
+  it.each(['/custom/auth', '/', ''])('rejects unsupported path %s in object and callback configs', (basePath) => {
+    // JavaScript consumers and runtime values still receive a useful error.
+    const config = { basePath } as never
+    expect(() => defineServerAuth(config)({} as never)).toThrow('Server basePath must be /api/auth')
+    expect(() => defineServerAuth(() => config)({} as never)).toThrow('Server basePath must be /api/auth')
+  })
+
+  it('preserves custom paths for external auth clients', () => {
+    const client = defineClientAuth({ basePath: '/custom/auth' })
+    expect(client.resolveOptions('https://auth.example.com').basePath).toBe('/custom/auth')
   })
 })


### PR DESCRIPTION
The module registers `/api/auth/**`, so accepting another server `basePath` leaves its handler returning 404. Reject unsupported paths in `defineServerAuth` at compile time and when resolving object or callback configs. External clients retain custom paths.

Migration: remove a custom server `basePath` or set it to `/api/auth`, then update client and OAuth callback URLs. `auth.clientOnly` backends can keep their custom client path.

**Before:** [custom server path accepted, registered endpoint returns 404](https://github.com/onmax/repros/tree/repro/better-auth-base-path/better-auth-base-path). **After:** [unsupported config rejected with migration guidance](https://github.com/onmax/repros/tree/repro/better-auth-base-path/better-auth-base-path-fix). These are runnable Node fixtures with clean-install commands.
