### PR TITLE
refactor: remove unused secondary storage module

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -14,7 +14,7 @@ import { registerAuthMiddlewareHook, registerDevtools, registerNuxtHubDatabaseEx
 import { registerNuxtHubSchemaHook, setupBetterAuthSchema } from './module/schema'
 import { promptForSecret } from './module/secret'
 import { collectAuthRouteRules, resolveAuthModuleSetup } from './module/setup'
-import { buildAuthRouteRulesCode, buildExtendedClientAuthCode, buildExtendedServerAuthCode, buildSchemaExportCode, buildSecondaryStorageCode } from './module/templates'
+import { buildAuthRouteRulesCode, buildExtendedClientAuthCode, buildExtendedServerAuthCode, buildSchemaExportCode } from './module/templates'
 import { registerServerTypeTemplates, registerSharedTypeTemplates } from './module/type-templates'
 
 import './types/hooks'
@@ -162,13 +162,6 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
       nuxt.options.alias['#auth/client'] = clientConfigPath
 
       if (!setup.clientOnly) {
-        const secondaryStorageTemplate = addTemplate({
-          filename: 'better-auth/secondary-storage.mjs',
-          getContents: () => buildSecondaryStorageCode(),
-          write: true,
-        })
-        nuxt.options.alias['#auth/secondary-storage'] = secondaryStorageTemplate.dst
-
         const databaseTemplate = addTemplate({
           filename: 'better-auth/database.mjs',
           getContents: () => setup.database.providerDefinition!.buildDatabaseCode(setup.database.buildContext!),

--- a/src/module/hooks.ts
+++ b/src/module/hooks.ts
@@ -69,7 +69,6 @@ export function registerPrepareTypesHook(input: RegisterPrepareTypesHookInput): 
       join(nuxt.options.buildDir, 'types/nitro-imports.d.ts'),
       join(nuxt.options.buildDir, 'types/auth-database.d.ts'),
       join(nuxt.options.buildDir, 'types/auth-schema.d.ts'),
-      join(nuxt.options.buildDir, 'types/auth-secondary-storage.d.ts'),
     ]
 
     if (hasHubDb)
@@ -81,7 +80,6 @@ export function registerPrepareTypesHook(input: RegisterPrepareTypesHookInput): 
       '#auth/client': nuxt.options.alias['#auth/client'],
       '#auth/database': nuxt.options.alias['#auth/database'],
       '#auth/schema': nuxt.options.alias['#auth/schema'],
-      '#auth/secondary-storage': nuxt.options.alias['#auth/secondary-storage'],
       '#auth/route-rules': nuxt.options.alias['#auth/route-rules'],
     } as const
 

--- a/src/module/templates.ts
+++ b/src/module/templates.ts
@@ -27,10 +27,6 @@ export default extendClientAuth(createAppAuthClient, [${plugins.names}])
 `
 }
 
-export function buildSecondaryStorageCode(): string {
-  return 'export function createSecondaryStorage() { return undefined }'
-}
-
 interface BuildDatabaseCodeInput {
   provider: 'none' | 'nuxthub'
   hubDialect: DbDialect

--- a/src/module/type-templates.ts
+++ b/src/module/type-templates.ts
@@ -28,15 +28,6 @@ export function registerServerTypeTemplates(input: RegisterServerTypeTemplatesIn
     : { nuxt: true, nitro: true, node: true }
 
   addTypeTemplate({
-    filename: 'types/auth-secondary-storage.d.ts',
-    getContents: () => `
-declare module '#auth/secondary-storage' {
-  export function createSecondaryStorage(): undefined
-}
-`,
-  }, { nitro: true })
-
-  addTypeTemplate({
     filename: 'types/auth-database.d.ts',
     getContents: () => `
 declare module '#auth/database' {
@@ -72,7 +63,6 @@ declare module '#auth/schema' {
 /// <reference path="./nitro-imports.d.ts" />
 /// <reference path="./auth-database.d.ts" />
 /// <reference path="./auth-schema.d.ts" />
-/// <reference path="./auth-secondary-storage.d.ts" />
 ${hasHubDb ? '/// <reference path="../hub/db.d.ts" />' : ''}
 
 export {}

--- a/src/runtime/server/virtual-modules.d.ts
+++ b/src/runtime/server/virtual-modules.d.ts
@@ -8,10 +8,6 @@ declare module '#imports' {
   export function useRuntimeConfig(): any
 }
 
-declare module '#auth/secondary-storage' {
-  export function createSecondaryStorage(...args: any[]): any
-}
-
 declare module '#auth/schema' {
   export const schema: any
 }

--- a/test/cases/plugins-type-inference/virtual-modules.d.ts
+++ b/test/cases/plugins-type-inference/virtual-modules.d.ts
@@ -3,10 +3,6 @@ declare module '#auth/database' {
   export function createDatabase(...args: any[]): any
 }
 
-declare module '#auth/secondary-storage' {
-  export function createSecondaryStorage(...args: any[]): any
-}
-
 declare module '#better-auth/nitro-compat' {
   export type ServerEvent = import('h3').H3Event
   export function createAuthError(status: number, statusText: string): Error

--- a/test/secondary-storage.test.ts
+++ b/test/secondary-storage.test.ts
@@ -1,13 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { resolveSchemaSecondaryStorageInjection } from '../src/module/schema'
-import { buildSecondaryStorageCode } from '../src/module/templates'
 import { resolveCustomSecondaryStorageRequirement } from '../src/runtime/server/utils/custom-secondary-storage'
-
-describe('generated secondary storage', () => {
-  it('does not emit the incomplete NuxtHub KV adapter', () => {
-    expect(buildSecondaryStorageCode()).toBe('export function createSecondaryStorage() { return undefined }')
-  })
-})
 
 describe('custom secondary storage runtime requirement', () => {
   it('returns null when mode is not custom', () => {

--- a/test/server-auth-database-cache.test.ts
+++ b/test/server-auth-database-cache.test.ts
@@ -11,10 +11,6 @@ vi.mock('#auth/database', () => ({
   db: { query: {} },
 }))
 
-vi.mock('#auth/secondary-storage', () => ({
-  createSecondaryStorage: vi.fn(() => undefined),
-}))
-
 vi.mock('#auth/server', () => ({
   default: createServerAuthMock,
 }))

--- a/test/server-auth-project-references-typecheck.test.ts
+++ b/test/server-auth-project-references-typecheck.test.ts
@@ -59,7 +59,6 @@ function expectSharedTypeReferencesToStayClientSafe(fixtureDir: string) {
     'types/nitro-imports.d.ts',
     'types/auth-database.d.ts',
     'types/auth-schema.d.ts',
-    'types/auth-secondary-storage.d.ts',
     'hub/db.d.ts',
   ]
 


### PR DESCRIPTION
The module still generates a `#auth/secondary-storage` factory that always returns `undefined`, although the runtime no longer imports it. Remove that factory, its alias and type references, and the obsolete mock and generated-text assertion.

Custom `secondaryStorage` supplied through `defineServerAuth` continues to use the existing validation and schema behavior.
