### PR TITLE
fix!: type user updates with writable fields

### DIFF
--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -198,6 +198,8 @@ await fetchSession({
 
 Updates the user on the server and optimistically patches local state. Local state reverts if the server call fails.
 
+`updateUser` accepts `AuthUserUpdateInput`: `name`, `image`, and input-enabled fields from your Better Auth configuration and client plugins. It no longer accepts user IDs, email verification status, admin roles, or custom fields declared with `input: false`. Use Better Auth's dedicated email-change or admin actions for those operations. Import `AuthUserUpdateInput` from `#nuxt-better-auth` when annotating an update.
+
 ```ts
 await updateUser({ name: 'New Name' })
 ```

--- a/src/module/type-templates.ts
+++ b/src/module/type-templates.ts
@@ -99,7 +99,7 @@ declare module '@nuxtjs/better-auth/config' {
     filename: 'types/nuxt-better-auth-infer.d.ts',
     getContents: () => `
 import type { BetterAuthOptions, BetterAuthPlugin, InferPluginTypes, UnionToIntersection } from 'better-auth'
-import type { InferFieldsOutput } from 'better-auth/db'
+import type { InferFieldsInputClient, InferFieldsOutput } from 'better-auth/db'
 import type createServerAuth from '${serverConfigPath}'
 
 type _RawConfig = ReturnType<typeof createServerAuth>
@@ -123,11 +123,24 @@ type _InferModelFieldsFromOptions<C, M extends 'user' | 'session'> = C extends {
   ? InferFieldsOutput<F>
   : {}
 
+type _UserFields = NonNullable<NonNullable<BetterAuthOptions['user']>['additionalFields']>
+
+type _InferUserInputFromPlugins<P> = P extends readonly (infer Plugin)[]
+  ? UnionToIntersection<Plugin extends { schema: { user: { fields: infer F extends _UserFields } } } ? InferFieldsInputClient<F> : {}>
+  : {}
+
+type _UserInputFallback = Partial<_InferUserInputFromPlugins<_RawPlugins> & (
+  _RawConfig extends { user: { additionalFields: infer F extends _UserFields } }
+    ? InferFieldsInputClient<F>
+    : {}
+)>
+
 type _UserFallback = _InferModelFieldsFromPlugins<_RawPlugins, 'user'> & _InferModelFieldsFromOptions<_RawConfig, 'user'>
 type _SessionFallback = _InferModelFieldsFromPlugins<_RawPlugins, 'session'> & _InferModelFieldsFromOptions<_RawConfig, 'session'>
 
 declare module '#nuxt-better-auth' {
   interface AuthUser extends _UserFallback {}
+  interface AuthUserUpdateInput extends _UserInputFallback {}
   interface AuthSession extends _SessionFallback {}
   type PluginTypes = InferPluginTypes<_Config>
 }
@@ -379,6 +392,11 @@ declare module '#nuxt-better-auth' {
   export interface AuthSocialProviderRegistry {}
   export type AuthSocialProviderId = AuthSocialProviderRegistry extends { ids: infer T } ? Extract<T, string> : never
 
+  export interface AuthUserUpdateInput {
+    name?: string
+    image?: string | null
+  }
+
   export interface UserSessionComposable {
     user: Ref<AuthUser | null>
     session: Ref<AuthSession | null>
@@ -387,7 +405,7 @@ declare module '#nuxt-better-auth' {
     fetchSession: (options?: { headers?: HeadersInit, force?: boolean }) => Promise<void>
     waitForSession: () => Promise<void>
     signOut: (options?: { onSuccess?: () => void | Promise<void> }) => Promise<void>
-    updateUser: (updates: Partial<AuthUser>) => Promise<void>
+    updateUser: (updates: AuthUserUpdateInput) => Promise<void>
   }
 
   export type UserMatch<T> = { [K in keyof T]?: T[K] | T[K][] }
@@ -423,8 +441,10 @@ export {}
     filename: 'types/nuxt-better-auth-client.d.ts',
     getContents: () => `
 import type createAppAuthClient from '${input.clientConfigPath}'
+type _ClientUserUpdateInput = Omit<NonNullable<Parameters<ReturnType<typeof createAppAuthClient>['updateUser']>[0]>, 'fetchOptions'>
 declare module '#nuxt-better-auth' {
   export type AppAuthClient = ReturnType<typeof createAppAuthClient>
+  interface AuthUserUpdateInput extends _ClientUserUpdateInput {}
 }
 `,
   })

--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -1,5 +1,5 @@
 import type { ComputedRef, Ref } from 'vue'
-import type { AppAuthClient, AuthSession, AuthUser } from '#nuxt-better-auth'
+import type { AppAuthClient, AuthSession, AuthUser, AuthUserUpdateInput } from '#nuxt-better-auth'
 import { computed, navigateTo, nextTick, useNuxtApp, useRequestURL, useRuntimeConfig, useState, watch } from '#imports'
 import { normalizeAuthActionError } from '../internal/auth-action-error'
 import { resolvePostAuthSuccessRedirect, withFallbackSocialCallbackURL } from '../internal/redirect-helpers'
@@ -22,7 +22,7 @@ export interface UseUserSessionReturn {
   signOut: (options?: SignOutOptions) => Promise<void>
   waitForSession: () => Promise<void>
   fetchSession: (options?: { headers?: HeadersInit, force?: boolean }) => Promise<void>
-  updateUser: (updates: Partial<AuthUser>) => Promise<void>
+  updateUser: (updates: AuthUserUpdateInput) => Promise<void>
 }
 
 interface UpdateUserResponse { error?: unknown }
@@ -91,7 +91,7 @@ export function useUserSession(): UseUserSessionReturn {
       return fetchSessionClient(rawClient, session, user, authReady, options)
   }
 
-  async function updateUser(updates: Partial<AuthUser>) {
+  async function updateUser(updates: AuthUserUpdateInput) {
     if (!user.value)
       return
 
@@ -102,7 +102,7 @@ export function useUserSession(): UseUserSessionReturn {
       return
 
     try {
-      const clientWithUpdateUser = rawClient as AppAuthClient & { updateUser: (updates: Partial<AuthUser>) => Promise<UpdateUserResponse> }
+      const clientWithUpdateUser = rawClient as AppAuthClient & { updateUser: (updates: AuthUserUpdateInput) => Promise<UpdateUserResponse> }
       const result = await clientWithUpdateUser.updateUser(updates)
       if (result?.error) {
         if (result.error instanceof Error)

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,7 +1,7 @@
 import type { AuthSocialProviderRegistry, AuthUser, UserMatch } from '#nuxt-better-auth'
 
 // Re-export augmentable types
-export type { AppSession, AuthSession, AuthSocialProviderRegistry, AuthUser, RequireSessionOptions, ServerAuthContext, UserMatch, UserSessionComposable } from './types/augment'
+export type { AppSession, AuthSession, AuthSocialProviderRegistry, AuthUser, AuthUserUpdateInput, RequireSessionOptions, ServerAuthContext, UserMatch, UserSessionComposable } from './types/augment'
 
 export type AuthSocialProviderId = AuthSocialProviderRegistry extends { ids: infer T } ? Extract<T, string> : never
 

--- a/src/runtime/types/augment.ts
+++ b/src/runtime/types/augment.ts
@@ -36,6 +36,12 @@ export interface ServerAuthContext {
 // Extended by generated types from configured socialProviders keys.
 export interface AuthSocialProviderRegistry {}
 
+// Writable fields; generated types add input-enabled configured fields.
+export interface AuthUserUpdateInput {
+  name?: string
+  image?: string | null
+}
+
 // Composable return type
 export interface UserSessionComposable {
   user: Ref<AuthUser | null>
@@ -45,7 +51,7 @@ export interface UserSessionComposable {
   fetchSession: (options?: { headers?: HeadersInit, force?: boolean }) => Promise<void>
   waitForSession: () => Promise<void>
   signOut: (options?: { onSuccess?: () => void | Promise<void> }) => Promise<void>
-  updateUser: (updates: Partial<AuthUser>) => Promise<void>
+  updateUser: (updates: AuthUserUpdateInput) => Promise<void>
 }
 
 export type UserMatch<T> = { [K in keyof T]?: T[K] | T[K][] }

--- a/test/cases/plugins-type-inference/app/update-user-contract.ts
+++ b/test/cases/plugins-type-inference/app/update-user-contract.ts
@@ -1,0 +1,16 @@
+import { useUserSession } from '../../../../src/runtime/app/composables/useUserSession'
+
+const { updateUser } = useUserSession()
+void updateUser({ name: 'Updated', image: null, internalCode: 'writable', username: 'new-name' })
+// @ts-expect-error Identity fields are not writable through updateUser.
+void updateUser({ id: 'someone-else' })
+// @ts-expect-error Email changes have a dedicated Better Auth action.
+void updateUser({ email: 'other@example.com' })
+// @ts-expect-error Verification is controlled by the server.
+void updateUser({ emailVerified: true })
+// @ts-expect-error Admin plugin role is output-only for user updates.
+void updateUser({ role: 'admin' })
+// @ts-expect-error Custom input:false fields cannot be written.
+void updateUser({ readOnlyCode: 'overwrite' })
+// @ts-expect-error Transport options are not optimistic user fields.
+void updateUser({ fetchOptions: {} })

--- a/test/cases/plugins-type-inference/server/auth.config.ts
+++ b/test/cases/plugins-type-inference/server/auth.config.ts
@@ -12,6 +12,7 @@ export default defineServerAuth(() => ({
   },
   user: {
     additionalFields: {
+      readOnlyCode: { type: 'string', required: false, input: false },
       internalCode: {
         type: 'string',
         required: false,

--- a/test/infer-plugins-types.test.ts
+++ b/test/infer-plugins-types.test.ts
@@ -32,6 +32,14 @@ describe('type inference regressions #107, #192, and #382', () => {
     expect(output).not.toContain(`Property 'signInUsername' does not exist on type`)
     expect(output).not.toContain(`'signInUsername' does not exist on type`)
 
+    const appTypecheck = spawnSync('npx', ['vue-tsc', '--noEmit', '--pretty', 'false', '-p', '.nuxt/tsconfig.app.json'], {
+      cwd: fixtureDir,
+      env,
+      encoding: 'utf8',
+      timeout: 60_000,
+    })
+    expect(appTypecheck.status, `app vue-tsc failed:\n${appTypecheck.stdout}\n${appTypecheck.stderr}`).toBe(0)
+
     const sharedTypecheck = spawnSync('npx', ['vue-tsc', '--noEmit', '--pretty', 'false', '-p', '.nuxt/tsconfig.shared.json'], {
       cwd: fixtureDir,
       env,


### PR DESCRIPTION
`updateUser(Partial<AuthUser>)` accepts output fields that Better Auth does not let users write, such as IDs and verification status. Replace it with `AuthUserUpdateInput`, inferred from writable server fields and the configured client's update input, including plugin fields and excluding transport options.

Migration: use dedicated email-change or admin actions for those operations, and annotate update objects with `AuthUserUpdateInput` from `#nuxt-better-auth`. Optimistic updates and the existing SSR local-patch behavior remain unchanged.

**Before:** [immutable fields compile as user updates](https://github.com/onmax/repros/tree/repro/better-auth-update-user-input/better-auth-update-user-input). **After:** [immutable fields are rejected while name/image remain valid](https://github.com/onmax/repros/tree/repro/better-auth-update-user-input/better-auth-update-user-input-fix). These are runnable Node fixtures with clean-install commands.
