### PR TITLE
fix: preserve session when logout fails

### DIFF
--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -216,7 +216,9 @@ export function useUserSession(): UseUserSessionReturn {
     }
 
     _signOutPromise = (async () => {
-      await rawClient.signOut()
+      const result = await rawClient.signOut()
+      if (isRecord(result) && result.error)
+        throw new Error(normalizeAuthActionError(result.error).message)
       clearSession()
 
       if (options?.onSuccess) {

--- a/test/use-user-session.test.ts
+++ b/test/use-user-session.test.ts
@@ -1,3 +1,4 @@
+import { createAuthClient } from 'better-auth/vue'
 import { createPinia, defineStore, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { isReactive, isRef, ref, watch } from 'vue'
@@ -899,6 +900,41 @@ describe('useUserSession hydration bootstrap', () => {
     await flushPromises()
 
     expect(auth.session.value).toBe(bridgedSession)
+  })
+
+  it.each([401, 500])('preserves session state when Better Auth returns HTTP %i during logout', async (status) => {
+    const client = createAuthClient({
+      baseURL: 'https://auth.example.test',
+      fetchOptions: {
+        customFetchImpl: async () => Response.json({ message: 'Logout unavailable' }, { status }),
+      },
+    })
+    mockClient.signOut.mockImplementationOnce(() => client.signOut())
+    runtimeConfig.public.auth.redirects = { logout: '/logged-out' }
+    seedHydratedState()
+    const auth = (await loadUseUserSession())()
+    const onSuccess = vi.fn()
+
+    await expect(auth.signOut({ onSuccess })).rejects.toThrow('Logout unavailable')
+
+    expect(auth.loggedIn.value).toBe(true)
+    expect(onSuccess).not.toHaveBeenCalled()
+    expect(navigateTo).not.toHaveBeenCalled()
+
+    await auth.signOut({ onSuccess })
+    expect(auth.loggedIn.value).toBe(false)
+    expect(onSuccess).toHaveBeenCalledOnce()
+  })
+
+  it('preserves session state when logout rejects', async () => {
+    mockClient.signOut.mockRejectedValueOnce(new Error('Network unavailable'))
+    seedHydratedState()
+    const auth = (await loadUseUserSession())()
+    const onSuccess = vi.fn()
+
+    await expect(auth.signOut({ onSuccess })).rejects.toThrow('Network unavailable')
+    expect(auth.loggedIn.value).toBe(true)
+    expect(onSuccess).not.toHaveBeenCalled()
   })
 
   it('signOut navigates to redirects.logout when configured (and no onSuccess)', async () => {


### PR DESCRIPTION
Better Auth resolves failed logout requests with an error result. Reject that result before clearing session state, running success callbacks, or navigating.

[Before](https://github.com/onmax/repros/tree/repro/better-auth-logout-error/better-auth-logout-error) · [After](https://github.com/onmax/repros/tree/repro/better-auth-logout-error/better-auth-logout-error-fix)
