### PR TITLE
fix: load sessions with throwing client fetch options

### DIFF
--- a/src/runtime/app/internal/session-fetch.ts
+++ b/src/runtime/app/internal/session-fetch.ts
@@ -56,7 +56,7 @@ export async function fetchSessionClient(
 ): Promise<void> {
   try {
     const headers = options.headers || useRequestHeaders(['cookie'])
-    const fetchOptions = headers ? { headers } : undefined
+    const fetchOptions = { ...(headers ? { headers } : {}), throw: false as const }
     const query = options.force ? { disableCookieCache: true } : undefined
     const result = await client.getSession({ query }, fetchOptions)
     const data = result.data as SessionResponse | null

--- a/test/session-fetch-contract.test.ts
+++ b/test/session-fetch-contract.test.ts
@@ -1,0 +1,43 @@
+import { createAuthClient } from 'better-auth/vue'
+import { expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+vi.mock('#imports', () => ({ useRequestHeaders: () => undefined }))
+
+it.each([false, true])('loads a session with global fetchOptions.throw=%s', async (throwErrors) => {
+  const { fetchSessionClient } = await import('../src/runtime/app/internal/session-fetch')
+  const client = createAuthClient({
+    baseURL: 'https://auth.example.test',
+    fetchOptions: {
+      throw: throwErrors,
+      customFetchImpl: async () => Response.json({ session: { id: 's', token: 'private' }, user: { id: 'u' } }),
+    },
+  })
+  const session = ref(null)
+  const user = ref(null)
+  const ready = ref(false)
+
+  await fetchSessionClient(client, session, user, ready)
+
+  expect(session.value).toEqual({ id: 's' })
+  expect(user.value).toEqual({ id: 'u' })
+  expect(ready.value).toBe(true)
+})
+
+it('keeps the configured error behavior for other client calls', async () => {
+  const { fetchSessionClient } = await import('../src/runtime/app/internal/session-fetch')
+  const client = createAuthClient({
+    baseURL: 'https://auth.example.test',
+    fetchOptions: {
+      throw: true,
+      customFetchImpl: async () => Response.json({ message: 'Unauthorized' }, { status: 401 }),
+    },
+  })
+  const session = ref(null)
+  const user = ref(null)
+  const ready = ref(false)
+
+  await expect(fetchSessionClient(client, session, user, ready)).resolves.toBeUndefined()
+  expect(ready.value).toBe(true)
+  await expect(client.getSession()).rejects.toMatchObject({ status: 401 })
+})


### PR DESCRIPTION
A client configured with `fetchOptions.throw: true` returns successful session data directly, leaving the module signed out. Set `throw: false` on module-owned session requests so they retain the expected response shape while other client calls keep their configured behavior.

[Before](https://github.com/onmax/repros/tree/repro/better-auth-session-throw/better-auth-session-throw) · [After](https://github.com/onmax/repros/tree/repro/better-auth-session-throw/better-auth-session-throw-fix)
