### PR TITLE
fix: bypass cookie cache for forced SSR session refresh

### DIFF
--- a/src/runtime/app/internal/session-fetch.ts
+++ b/src/runtime/app/internal/session-fetch.ts
@@ -21,12 +21,15 @@ export async function fetchSessionServer(
   session: Ref<AuthSession | null>,
   user: Ref<AuthUser | null>,
   authReady: Ref<boolean>,
-  options: { headers?: HeadersInit } = {},
+  options: { headers?: HeadersInit, force?: boolean } = {},
 ): Promise<void> {
   try {
     const headers = options.headers || useRequestHeaders(['cookie'])
     const requestFetch = useRequestFetch()
-    const data = await requestFetch<SessionResponse | null>('/api/auth/get-session', { headers })
+    const data = await requestFetch<SessionResponse | null>('/api/auth/get-session', {
+      headers,
+      ...(options.force ? { query: { disableCookieCache: true } } : {}),
+    })
 
     if (data?.session && data?.user) {
       session.value = stripToken(data.session)

--- a/test/use-user-session.test.ts
+++ b/test/use-user-session.test.ts
@@ -433,6 +433,19 @@ describe('useUserSession hydration bootstrap', () => {
     expect(auth.ready.value).toBe(true)
   })
 
+  it('bypasses the cookie cache when forcing an SSR session refresh', async () => {
+    setRuntimeFlags({ client: false, server: true })
+    $fetch.mockImplementationOnce(async (_path: string, options: { query?: { disableCookieCache?: boolean } }) => ({
+      session: { id: 'session-server' },
+      user: { id: options.query?.disableCookieCache ? 'fresh-user' : 'cached-user' },
+    }))
+
+    const auth = (await loadUseUserSession())()
+    await auth.fetchSession({ force: true })
+
+    expect(auth.user.value?.id).toBe('fresh-user')
+  })
+
   it('fetchSession clears SSR state on server when no session is returned', async () => {
     setRuntimeFlags({ client: false, server: true })
     seedHydratedState()


### PR DESCRIPTION
`fetchSession({ force: true })` currently ignores `force` during SSR. Forward `disableCookieCache` to the session endpoint so forced server refreshes use current session data.

[Before](https://github.com/onmax/repros/tree/repro/better-auth-ssr-force/better-auth-ssr-force) · [After](https://github.com/onmax/repros/tree/repro/better-auth-ssr-force/better-auth-ssr-force-fix)
