### PR TITLE
fix: preserve session dates during SSR

### DIFF
--- a/src/runtime/app/internal/session-fetch.ts
+++ b/src/runtime/app/internal/session-fetch.ts
@@ -1,5 +1,6 @@
 import type { Ref } from 'vue'
 import type { AppAuthClient, AuthSession, AuthUser } from '#nuxt-better-auth'
+import { parseJSON } from 'better-auth/client'
 import { useRequestFetch, useRequestHeaders } from '#imports'
 import { normalizeAuthActionError } from './auth-action-error'
 
@@ -26,7 +27,7 @@ export async function fetchSessionServer(
   try {
     const headers = options.headers || useRequestHeaders(['cookie'])
     const requestFetch = useRequestFetch()
-    const data = await requestFetch<SessionResponse | null>('/api/auth/get-session', { headers })
+    const data = await requestFetch<SessionResponse | null>('/api/auth/get-session', { headers, parseResponse: parseJSON })
 
     if (data?.session && data?.user) {
       session.value = stripToken(data.session)

--- a/src/runtime/app/plugins/session.server.ts
+++ b/src/runtime/app/plugins/session.server.ts
@@ -1,4 +1,5 @@
 import type { AuthSession, AuthUser } from '#nuxt-better-auth'
+import { parseJSON } from 'better-auth/client'
 import { defineNuxtPlugin, useRequestEvent, useRequestHeaders, useState } from '#imports'
 
 export default defineNuxtPlugin({
@@ -14,7 +15,7 @@ export default defineNuxtPlugin({
     if (event) {
       try {
         const headers = useRequestHeaders(['cookie'])
-        const data = await $fetch<{ session: AuthSession & { token?: string }, user: AuthUser } | null>('/api/auth/get-session', { headers })
+        const data = await $fetch<{ session: AuthSession & { token?: string }, user: AuthUser } | null>('/api/auth/get-session', { headers, parseResponse: parseJSON })
         if (data?.session && data?.user) {
           // Filter out sensitive token field from client state
           const { token: _, ...safeSession } = data.session

--- a/test/cases/core-auth/app/pages/session-dates.vue
+++ b/test/cases/core-auth/app/pages/session-dates.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+const { user, session, fetchSession } = useUserSession()
+const initialDates = user.value?.createdAt instanceof Date && session.value?.expiresAt instanceof Date
+await fetchSession()
+const refreshedDates = user.value?.createdAt instanceof Date && session.value?.expiresAt instanceof Date
+</script>
+
+<template>
+  <p>Initial dates: {{ initialDates }}; refreshed dates: {{ refreshedDates }}</p>
+</template>

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -102,6 +102,12 @@ describe('nuxt-better-auth module', async () => {
       expect(data.email).toBe(testUser.email)
     })
 
+    it('preserves Date fields in the SSR plugin and explicit session refresh', async () => {
+      const response = await fetch(url('/session-dates'), { headers: { cookie: cookies } })
+      expect(response.status).toBe(200)
+      expect(await response.text()).toContain('Initial dates: true; refreshed dates: true')
+    })
+
     it('hydrates session on SSR', async () => {
       // Fetch home page with auth cookies - should show user name, not "Not logged in"
       const response = await fetch(url('/'), { headers: { cookie: cookies } })

--- a/test/use-user-session.test.ts
+++ b/test/use-user-session.test.ts
@@ -427,7 +427,7 @@ describe('useUserSession hydration bootstrap', () => {
     const auth = useUserSession()
     await auth.fetchSession()
 
-    expect($fetch).toHaveBeenCalledWith('/api/auth/get-session', { headers: { cookie: 'session=test' } })
+    expect($fetch).toHaveBeenCalledWith('/api/auth/get-session', { headers: { cookie: 'session=test' }, parseResponse: expect.any(Function) })
     expect(auth.session.value).toEqual({ id: 'session-server', ipAddress: '127.0.0.1' })
     expect(auth.user.value).toEqual({ id: 'user-server', email: 'server@example.com' })
     expect(auth.ready.value).toBe(true)


### PR DESCRIPTION
SSR session requests leave JSON date fields as strings despite the public Date types. Use Better Auth's response parser for both initial SSR state and explicit session refreshes.

[Before](https://github.com/onmax/repros/tree/repro/better-auth-ssr-dates/better-auth-ssr-dates) · [After](https://github.com/onmax/repros/tree/repro/better-auth-ssr-dates/better-auth-ssr-dates-fix)
