### PR TITLE
fix!: limit auto-imports to public helpers

### DIFF
--- a/docs/content/5.api/1.composables.md
+++ b/docs/content/5.api/1.composables.md
@@ -9,6 +9,10 @@ Use this page when you need exact behavior for the client-side composables expos
 These composables are auto-imported in Vue files. No import statement is needed in pages, components, plugins, middleware, or stores inside your Nuxt app.
 ::
 
+Only the public composables exported by `@nuxtjs/better-auth/composables` are registered as auto-imports. The deprecated `useUserSessionState` alias remains available.
+
+Internal helpers `getAuthRuntimeFlags`, `useRawAuthClient`, `useAuthActionNamespaces`, and `matchesUser` are no longer auto-imported. Use `useAuthClient` for the configured client and `useSignIn` or `useSignUp` for authentication actions. Applications that used `matchesUser` should keep their matching logic in application code.
+
 ## Quick Start
 
 Use `useUserSession()` in pages and components to access the current session and session lifecycle actions.

--- a/docs/content/5.api/2.server-utils.md
+++ b/docs/content/5.api/2.server-utils.md
@@ -5,6 +5,8 @@ description: API reference for server-side helpers available in Nitro event hand
 
 Use this page when you need exact behavior for the auto-imported server helpers registered by the module.
 
+Only the helpers documented here and `defineServerAuth` are registered. The internal `resolveCustomSecondaryStorageRequirement` helper and `HubSecondaryStorageMode` type are no longer auto-imported. Configure custom storage through `defineServerAuth` and `auth.hubSecondaryStorage`.
+
 ::warning
 These utilities are only available in **full mode**. In [clientOnly mode](/guides/external-auth-backend), there is no local auth server, so these utilities are not registered.
 ::

--- a/src/module/hooks.ts
+++ b/src/module/hooks.ts
@@ -1,7 +1,7 @@
 import type { Nuxt, NuxtPage } from '@nuxt/schema'
 import type { AuthRouteRules } from '../runtime/types'
 import { existsSync, statSync } from 'node:fs'
-import { addComponentsDir, addImportsDir, addPlugin, addServerHandler, addServerImports, addServerImportsDir, addServerScanDir, extendPages, updateTemplates } from '@nuxt/kit'
+import { addComponentsDir, addImports, addPlugin, addServerHandler, addServerImports, addServerScanDir, extendPages, updateTemplates } from '@nuxt/kit'
 import { defu } from 'defu'
 import { isAbsolute, join } from 'pathe'
 import { createRouter, toRouteMatcher } from 'radix3'
@@ -38,14 +38,33 @@ export function registerServerRuntime(input: RegisterServerRuntimeInput): void {
   const { clientOnly, resolve } = input
 
   if (!clientOnly) {
-    addServerImportsDir(resolve('./runtime/server/utils'))
-    addServerImports([{ name: 'defineServerAuth', from: resolve('./runtime/config') }])
+    addServerImports([
+      { name: 'defineServerAuth', from: resolve('./runtime/config') },
+      { name: 'serverAuth', from: resolve('./runtime/server/utils/auth') },
+      ...['getRequestSession', 'getUserSession', 'setRequestSession', 'refreshSessionCookieCache', 'setSessionCookie', 'createSession', 'requireUserSession']
+        .map(name => ({ name, from: resolve('./runtime/server/utils/session') })),
+    ])
     addServerScanDir(resolve('./runtime/server/middleware'))
     addServerHandler({ route: '/api/auth/**', handler: resolve('./runtime/server/api/auth/[...all]') })
   }
 
-  addImportsDir(resolve('./runtime/app/composables'))
-  addImportsDir(resolve('./runtime/utils'))
+  addImports([
+    'runWithSessionRefresh',
+    'useAction',
+    'useAuthAsyncData',
+    'useAuthClient',
+    'useAuthClientAction',
+    'useAuthRequestFetch',
+    'useSignIn',
+    'useSignUp',
+    'useUserSession',
+    'useUserSessionState',
+  ].map(name => ({ name, from: resolve('./runtime/composables') })))
+  addImports([
+    ...['SignOutOptions', 'UseUserSessionReturn', 'UseUserSessionStateReturn']
+      .map(name => ({ name, type: true, from: resolve('./runtime/composables') })),
+    { name: 'UseAuthAsyncDataOptions', type: true, from: resolve('./runtime/app/composables/useAuthAsyncData') },
+  ])
   if (!clientOnly)
     addPlugin({ src: resolve('./runtime/app/plugins/session.server'), mode: 'server' })
   addPlugin({ src: resolve('./runtime/app/plugins/session.client'), mode: 'client' })

--- a/test/cases/public-auto-imports/nuxt.config.ts
+++ b/test/cases/public-auto-imports/nuxt.config.ts
@@ -1,0 +1,7 @@
+export default defineNuxtConfig({
+  extends: ['../_base-module'],
+  auth: { clientOnly: process.env.TEST_CLIENT_ONLY === 'true' },
+  runtimeConfig: {
+    public: { siteUrl: 'http://localhost:3000' },
+  },
+})

--- a/test/devtools.test.ts
+++ b/test/devtools.test.ts
@@ -10,11 +10,10 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@nuxt/kit', () => ({
   addComponentsDir: vi.fn(),
-  addImportsDir: vi.fn(),
+  addImports: vi.fn(),
   addPlugin: vi.fn(),
   addServerHandler: mocks.addServerHandler,
   addServerImports: vi.fn(),
-  addServerImportsDir: vi.fn(),
   addServerScanDir: vi.fn(),
   extendPages: mocks.extendPages,
   hasNuxtModule: mocks.hasNuxtModule,

--- a/test/public-auto-imports.test.ts
+++ b/test/public-auto-imports.test.ts
@@ -1,0 +1,29 @@
+import { spawnSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const fixtureDir = fileURLToPath(new URL('./cases/public-auto-imports', import.meta.url))
+
+describe('public auto-imports', () => {
+  it.each([false, true])('generates only public helpers with clientOnly=%s', (clientOnly) => {
+    const prepare = spawnSync('npx', ['nuxi', 'prepare'], {
+      cwd: fixtureDir,
+      encoding: 'utf8',
+      env: { ...process.env, TEST_CLIENT_ONLY: String(clientOnly) },
+      timeout: 120_000,
+    })
+    expect(prepare.status, `${prepare.error || ''}\n${prepare.stdout}\n${prepare.stderr}`).toBe(0)
+
+    const appImports = readFileSync(`${fixtureDir}/.nuxt/imports.d.ts`, 'utf8')
+    const serverImports = readFileSync(`${fixtureDir}/.nuxt/types/nitro-imports.d.ts`, 'utf8')
+    for (const name of ['runWithSessionRefresh', 'useAction', 'useAuthAsyncData', 'useAuthClient', 'useAuthClientAction', 'useAuthRequestFetch', 'useSignIn', 'useSignUp', 'useUserSession', 'useUserSessionState', 'SignOutOptions', 'UseUserSessionReturn', 'UseUserSessionStateReturn', 'UseAuthAsyncDataOptions'])
+      expect(appImports).toMatch(new RegExp(`export (?:type )?\\{[^}]*\\b${name}\\b[^}]*\\}`))
+    for (const name of ['serverAuth', 'defineServerAuth', 'getRequestSession', 'getUserSession', 'setRequestSession', 'refreshSessionCookieCache', 'setSessionCookie', 'createSession', 'requireUserSession'])
+      expect(new RegExp(`export (?:type )?\\{[^}]*\\b${name}\\b[^}]*\\}`).test(serverImports)).toBe(!clientOnly)
+    for (const name of ['getAuthRuntimeFlags', 'useRawAuthClient', 'useAuthActionNamespaces', 'matchesUser', 'resolveCustomSecondaryStorageRequirement', 'HubSecondaryStorageMode']) {
+      expect(appImports).not.toMatch(new RegExp(`\\b${name}\\b`))
+      expect(serverImports).not.toMatch(new RegExp(`\\b${name}\\b`))
+    }
+  }, 150_000)
+})


### PR DESCRIPTION
Directory scanning registers implementation helpers as application APIs whenever a runtime file exports them. Register the public client composables, their types, and the documented server helpers explicitly.

This removes the accidental auto-imports `getAuthRuntimeFlags`, `useRawAuthClient`, `useAuthActionNamespaces`, `matchesUser`, and `resolveCustomSecondaryStorageRequirement`. The internal `HubSecondaryStorageMode` type is also removed from auto-imports. The API docs describe replacements. The deprecated `useUserSessionState` alias remains available.
