### PR TITLE
build: remove undeclared unbuild helper import

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -1,5 +1,3 @@
-import { defineBuildConfig } from 'unbuild'
-
-export default defineBuildConfig({
+export default {
   externals: ['consola', 'auth', 'auth/api'],
-})
+}


### PR DESCRIPTION
The build config imports `defineBuildConfig` from undeclared `unbuild`. Export the config object directly so invoking module-builder through Node works without pnpm's transitive dependency paths.

[Before](https://github.com/onmax/repros/tree/repro/better-auth-package-build/better-auth-package-build) · [After](https://github.com/onmax/repros/tree/repro/better-auth-package-build/better-auth-package-build-fix)
