### PR TITLE
fix!: require a trusted production auth origin

### DIFF
--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -14,7 +14,7 @@ Configure @nuxtjs/better-auth module options and server auth.
 - In `server/auth.config.ts`, use `defineServerAuth` (object or function syntax) to configure plugins and providers
 - The function syntax receives `ctx` with `runtimeConfig` and `db` (NuxtHub)
 - The module auto-injects `secret` and `baseURL` — do not set them in defineServerAuth
-- Base URL priority: runtimeConfig > request URL > platform env vars > localhost
+- Production base URL: runtimeConfig > platform env vars. Request URL inference is development-only.
 - Set `NUXT_PUBLIC_SITE_URL` for custom domains or deterministic OAuth callbacks
 ```
 
@@ -208,20 +208,20 @@ export default defineServerAuth((ctx) => ({
 
 - `ctx.runtimeConfig`: Nuxt runtime config.
 - `ctx.db`: :brand-badge{name="nuxthub"} database connection when :brand-badge{name="nuxthub"} DB is enabled. Do not set `database` when using module-managed adapters.
-- `ctx.requestOrigin`: Current request origin when auth is created with `serverAuth(event)`.
+- `ctx.requestOrigin`: Current request origin when auth is created with `serverAuth(event)`. This is request-controlled context, not a validated canonical URL.
 
-Use `requestOrigin` when Better Auth config needs the current request host, such as trusted origins:
+Configure additional trusted origins explicitly. Do not copy `requestOrigin` into `trustedOrigins` without validating it against application-owned origins:
 
 ```ts [server/auth.config.ts]
 import { defineServerAuth } from '@nuxtjs/better-auth/config'
 
-export default defineServerAuth(({ requestOrigin }) => ({
-  trustedOrigins: requestOrigin ? [requestOrigin] : [],
-}))
+export default defineServerAuth({
+  trustedOrigins: ['https://app.example.com'],
+})
 ```
 
 ::note
-For configured canonical URLs, read `runtimeConfig.public.siteUrl`. `requestOrigin` is optional and only available when auth is created from a request event. If allowed origins vary while using an explicit `siteUrl`, configure those origins explicitly or use Better Auth's `trustedOrigins` function form, because the auth instance can be cached.
+For configured canonical URLs, read `runtimeConfig.public.siteUrl`. `requestOrigin` is optional and only available when auth is created from a request event. The auth instance can be cached for its canonical URL, so `requestOrigin` describes the request that created it. If allowed origins vary per request, use Better Auth's `trustedOrigins` function form with your own origin validation.
 ::
 
 ### Session Enrichment
@@ -237,11 +237,13 @@ The module resolves `siteUrl` using this priority:
 | Priority | Source | When Used |
 |----------|--------|-----------|
 | 1 | `runtimeConfig.public.siteUrl` | Explicit config (always wins) |
-| 2 | Request URL | Auto-detected from the current Nitro request (`event`) |
+| 2 | Request URL, then Nitro development environment | Development only |
 | 3 | `VERCEL_URL`, `CF_PAGES_URL`, `URL` | Platform env vars (:brand-badge{name="vercel"}, :brand-badge{name="cloudflare"}, :brand-badge{name="netlify"}) |
 | 4 | `http://localhost:3000` | Development only |
 
-In server handlers, pass `event` to `serverAuth(event)` so request URL detection can run. In non-request contexts (seed scripts, tasks, startup plugins), the module uses environment/platform fallbacks.
+In production, request headers and listener settings such as `HOST` and `NITRO_HOST` never select the auth base URL. Set a public URL explicitly or use a platform environment variable. Without either, auth initialization fails with a configuration error.
+
+Continue passing `event` to `serverAuth(event)` for request-scoped database access and the optional `ctx.requestOrigin` context.
 
 Set an explicit site URL in `nuxt.config.ts` for deterministic OAuth callbacks and origin checks:
 
@@ -249,7 +251,7 @@ Set an explicit site URL in `nuxt.config.ts` for deterministic OAuth callbacks a
 export default defineNuxtConfig({
   runtimeConfig: {
     public: {
-      siteUrl: process.env.NUXT_PUBLIC_SITE_URL || 'http://localhost:3000',
+      siteUrl: '', // Set NUXT_PUBLIC_SITE_URL at runtime.
     },
   },
 })
@@ -264,7 +266,7 @@ NUXT_PUBLIC_SITE_URL="https://your-domain.com"
 ```
 
 ::note
-The module can auto-detect the request URL on most deployments. You should still set `runtimeConfig.public.siteUrl` (or `NUXT_PUBLIC_SITE_URL`) when callback consistency matters, such as local OAuth debugging, custom domains, or non-request contexts like seed scripts.
+Migration: deployments that previously inferred the URL from `Host` or forwarded headers must set `NUXT_PUBLIC_SITE_URL`, unless a platform URL is available. This prevents a supplied host from changing password-reset links or OAuth callbacks. Development still infers the request URL. Custom domains need an explicit URL because platform variables name the platform domain.
 ::
 
 ## Runtime Config

--- a/docs/content/2.core-concepts/1.server-auth.md
+++ b/docs/content/2.core-concepts/1.server-auth.md
@@ -8,7 +8,7 @@ description: When to reach for the full Better Auth server instance.
 ```txt [Prompt]
 Use server-side auth utilities in @nuxtjs/better-auth.
 
-- `serverAuth(event?)` — returns the Better Auth instance. Pass `event` in Nitro handlers for request-aware base URLs
+- `serverAuth(event?)` — returns the Better Auth instance. Pass `event` in Nitro handlers for request-scoped database access and configuration context
 - `getUserSession(event)` — get current session (auto-imported in `server/`)
 - `requireUserSession(event, options?)` — throws 401 if not authenticated, supports role matching
 - `getRequestSession(event)` — request-cached session, preferred over repeated `getUserSession` in same request
@@ -21,7 +21,7 @@ Use server-side auth utilities in @nuxtjs/better-auth.
 
 Use this page when you need authentication state or Better Auth APIs inside Nitro handlers, middleware, plugins, or other server-side code.
 
-`serverAuth(event?)` returns the Better Auth instance (module-level singleton). In Nitro handlers, you should pass `event` so the module can resolve request-aware base URLs on initialization. Outside request contexts (seed scripts, tasks, plugins), you can call `serverAuth()` without an event.
+`serverAuth(event?)` returns the Better Auth instance. Pass `event` in Nitro handlers for request-scoped database access and `ctx.requestOrigin`. In production, the canonical auth URL comes from `runtimeConfig.public.siteUrl` or platform environment variables. Development can infer it from the request. Outside request contexts, such as seed scripts and tasks, call `serverAuth()` without an event.
 
 ## When to Use What
 

--- a/src/runtime/server/utils/auth.ts
+++ b/src/runtime/server/utils/auth.ts
@@ -158,7 +158,7 @@ function getNitroOrigin(): string | undefined {
 }
 
 function resolveEnvironmentOrigin(): { origin: string, source: string } | undefined {
-  const nitroOrigin = getNitroOrigin()
+  const nitroOrigin = import.meta.dev ? getNitroOrigin() : undefined
   if (nitroOrigin)
     return { origin: validateURL(nitroOrigin), source: 'Nitro environment detection' }
 
@@ -166,7 +166,7 @@ function resolveEnvironmentOrigin(): { origin: string, source: string } | undefi
     return { origin: validateURL(`https://${process.env.VERCEL_URL}`), source: 'VERCEL_URL' }
 
   if (process.env.CF_PAGES_URL)
-    return { origin: validateURL(`https://${process.env.CF_PAGES_URL}`), source: 'CF_PAGES_URL' }
+    return { origin: validateURL(process.env.CF_PAGES_URL), source: 'CF_PAGES_URL' }
 
   if (process.env.URL)
     return { origin: validateURL(process.env.URL.startsWith('http') ? process.env.URL : `https://${process.env.URL}`), source: 'URL' }
@@ -187,7 +187,7 @@ function getBaseURL(event?: ServerEvent): string {
   if (configuredSiteUrl)
     return configuredSiteUrl
 
-  const eventOrigin = resolveEventOrigin(event)
+  const eventOrigin = import.meta.dev ? resolveEventOrigin(event) : undefined
   if (eventOrigin) {
     logInferredBaseURL(eventOrigin, 'request origin')
     return eventOrigin
@@ -205,7 +205,7 @@ function getBaseURL(event?: ServerEvent): string {
     return devFallback.origin
   }
 
-  throw new Error('siteUrl required. Set NUXT_PUBLIC_SITE_URL.')
+  throw new Error('siteUrl required in production. Set NUXT_PUBLIC_SITE_URL to the public application URL or provide VERCEL_URL, CF_PAGES_URL, or URL.')
 }
 
 function dedupeOrigins(origins: readonly string[]): string[] {

--- a/test/server-auth-base-url-cache.test.ts
+++ b/test/server-auth-base-url-cache.test.ts
@@ -28,10 +28,9 @@ describe('serverAuth production baseURL', async () => {
     expect(secondResponse.status).toBe(200)
     const secondBody = await secondResponse.json() as { appName: string | undefined, baseURL: string | undefined }
 
-    expect(firstBody.appName).toBe('https://first.example.com')
     expect(firstBody.baseURL).toBe('https://deployment.example.com')
     // A canonical production origin shares one cached instance.
-    expect(secondBody.appName).toBe('https://first.example.com')
+    expect(secondBody.appName).toBe(firstBody.appName)
     expect(secondBody.baseURL).toBe('https://deployment.example.com')
   })
 })

--- a/test/server-auth-base-url-cache.test.ts
+++ b/test/server-auth-base-url-cache.test.ts
@@ -1,13 +1,15 @@
 import { fileURLToPath } from 'node:url'
 import { setup, url } from '@nuxt/test-utils/e2e'
-import { describe, expect, it } from 'vitest'
+import { afterAll, describe, expect, it, vi } from 'vitest'
 
-describe('serverAuth baseURL inference', async () => {
+describe('serverAuth production baseURL', async () => {
+  vi.stubEnv('VERCEL_URL', 'deployment.example.com')
+  afterAll(() => vi.unstubAllEnvs())
   await setup({
     rootDir: fileURLToPath(new URL('./cases/base-url-inference', import.meta.url)),
   })
 
-  it('derives baseURL from each request host when siteUrl is unset', async () => {
+  it('uses the platform origin regardless of forwarded request headers', async () => {
     const firstResponse = await fetch(url('/api/test/base-url'), {
       headers: {
         'x-forwarded-host': 'first.example.com',
@@ -27,8 +29,9 @@ describe('serverAuth baseURL inference', async () => {
     const secondBody = await secondResponse.json() as { appName: string | undefined, baseURL: string | undefined }
 
     expect(firstBody.appName).toBe('https://first.example.com')
-    expect(firstBody.baseURL).toBe('https://first.example.com')
-    expect(secondBody.appName).toBe('https://second.example.com')
-    expect(secondBody.baseURL).toBe('https://second.example.com')
+    expect(firstBody.baseURL).toBe('https://deployment.example.com')
+    // A canonical production origin shares one cached instance.
+    expect(secondBody.appName).toBe('https://first.example.com')
+    expect(secondBody.baseURL).toBe('https://deployment.example.com')
   })
 })

--- a/test/server-auth-database-cache.test.ts
+++ b/test/server-auth-database-cache.test.ts
@@ -74,6 +74,45 @@ describe('serverAuth database cache and secret validation', () => {
     vi.restoreAllMocks()
   })
 
+  it('rejects request-derived origins and listener addresses in production', async () => {
+    useRuntimeConfigMock.mockReturnValue({
+      public: { siteUrl: '' },
+      auth: {},
+      betterAuthSecret: 'test-secret-for-testing-only-32chars',
+    })
+    for (const name of ['VERCEL_URL', 'CF_PAGES_URL', 'URL'])
+      vi.stubEnv(name, '')
+    vi.stubEnv('HOST', '0.0.0.0')
+    vi.stubEnv('NITRO_HOST', '127.0.0.1')
+
+    const { serverAuth } = await import('../src/runtime/server/utils/auth')
+
+    expect(() => serverAuth(createEvent())).toThrow('siteUrl required in production')
+    expect(betterAuthMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['VERCEL_URL', 'deployment.vercel.app', 'https://deployment.vercel.app'],
+    ['CF_PAGES_URL', 'https://deployment.pages.dev', 'https://deployment.pages.dev'],
+    ['URL', 'https://deployment.netlify.app', 'https://deployment.netlify.app'],
+  ])('uses %s without trusting the request origin', async (name, value, expected) => {
+    useRuntimeConfigMock.mockReturnValue({
+      public: { siteUrl: '' },
+      auth: {},
+      betterAuthSecret: 'test-secret-for-testing-only-32chars',
+    })
+    for (const variable of ['VERCEL_URL', 'CF_PAGES_URL', 'URL'])
+      vi.stubEnv(variable, '')
+    vi.stubEnv(name, value)
+    vi.stubEnv('NITRO_HOST', '127.0.0.1')
+
+    const { serverAuth } = await import('../src/runtime/server/utils/auth')
+    serverAuth(createEvent())
+
+    expect(betterAuthMock.mock.calls[0]?.[0].baseURL).toBe(expected)
+    expect(createServerAuthMock).toHaveBeenCalledWith(expect.objectContaining({ requestOrigin: 'https://example.com' }))
+  })
+
   it('rejects missing singular and versioned secrets before creating auth', async () => {
     useRuntimeConfigMock.mockReturnValue({
       public: { siteUrl: 'https://example.com' },


### PR DESCRIPTION
When `siteUrl` is unset, production auth currently trusts the request host before deployment configuration. A forwarded host can therefore change password-reset links. Use explicit or platform-owned URLs in production and retain request inference for development.

Deployments relying on `Host`, forwarded headers, `HOST`, or `NITRO_HOST` must set `NUXT_PUBLIC_SITE_URL` unless a supported platform URL is present. This also handles Cloudflare Pages' full `CF_PAGES_URL` correctly and documents that `ctx.requestOrigin` is untrusted context.

**Before:** [production reset link uses the supplied host](https://github.com/onmax/repros/tree/repro/better-auth-production-origin/better-auth-production-origin). **After:** [the same production app ignores the supplied host and retains its deployment URL](https://github.com/onmax/repros/tree/repro/better-auth-production-origin/better-auth-production-origin-fix). These are Node production fixtures; StackBlitz execution is unverified.
