### PR TITLE
fix(types): preserve Nuxt fetch option and result checking

### DIFF
--- a/src/module/type-templates.ts
+++ b/src/module/type-templates.ts
@@ -1,5 +1,22 @@
 import { addTypeTemplate } from '@nuxt/kit'
 
+// Preserve Nuxt's ordinary fetch contract without adding auth routes to global InternalApi.
+function buildNuxtFetchFallback(name: 'useFetch' | 'useLazyFetch'): string {
+  const options = 'import(\'nuxt/app\').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>'
+  return ['undefined', 'DataT'].map(defaultType => `
+  export function ${name}<
+    ResT = void,
+    ErrorT = FetchError,
+    ReqT extends NitroFetchRequest = NitroFetchRequest,
+    const Method extends _NuxtFetchMethod<ReqT> = ResT extends void ? 'get' extends _NuxtFetchMethod<ReqT> ? 'get' : _NuxtFetchMethod<ReqT> : _NuxtFetchMethod<ReqT>,
+    _ResT = ResT extends void ? import('nuxt/app').FetchResult<ReqT, Method> : ResT,
+    DataT = _ResT,
+    PickKeys extends _NuxtKeysOf<DataT> = _NuxtKeysOf<DataT>,
+    DefaultT = ${defaultType},
+  >(request: import('vue').Ref<ReqT> | ReqT | (() => ReqT), opts?: ${name === 'useLazyFetch' ? `Omit<${options}, 'lazy'>` : options}): import('nuxt/app').AsyncData<_NuxtPickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
+`).join('')
+}
+
 interface RegisterServerTypeTemplatesInput {
   serverConfigPath: string
   hasHubDb: boolean
@@ -157,7 +174,7 @@ declare module '#nuxt-better-auth' {
 import type createServerAuth from '${serverConfigPath}'
 import type { BetterAuthOptions } from 'better-auth'
 import type { getEndpoints } from 'better-auth/api'
-import type { Serialize, Simplify } from '${nitroTypesPath}'
+import type { AvailableRouterMethod, NitroFetchRequest, Serialize, Simplify } from '${nitroTypesPath}'
 import type { FetchError } from 'ofetch'
 
 type _RawConfig = ReturnType<typeof createServerAuth>
@@ -220,7 +237,11 @@ type _AuthPatternFromRequestPath<Path extends string> = {
 }[_AuthApiPatternPath]
 type _AuthEndpointMethod<Path extends _AuthApiRequestPath> = Extract<keyof _GeneratedAuthInternalApi[_AuthPatternFromRequestPath<Path>], string>
 
-type _AuthFetchMethod<Path extends _AuthApiRequestPath> = Extract<Exclude<import('${nitroTypesPath}').NitroFetchOptions<Path>['method'], undefined>, string>
+type _NuxtKeysOf<T> = Array<T extends T ? keyof T extends string ? keyof T : never : never>
+type _NuxtPickFrom<T, Keys extends string[]> = T extends unknown[] ? T : T extends Record<string, any> ? keyof T extends Keys[number] ? T : Keys[number] extends never ? T : Pick<T, Keys[number]> : T
+type _NuxtFetchMethod<ReqT extends NitroFetchRequest> = AvailableRouterMethod<ReqT> | Uppercase<AvailableRouterMethod<ReqT>>
+
+type _AuthFetchMethod = _NuxtFetchMethod<string>
 type _AuthFetchDefaultMethod<Path extends _AuthApiRequestPath> = 'get'
 type _AuthFetchResolvedMethod<Path extends _AuthApiRequestPath, Method extends string> = Lowercase<Method> extends _AuthEndpointMethod<Path>
   ? Lowercase<Method>
@@ -238,88 +259,50 @@ declare module '#nuxt-better-auth' {
   > = AuthApiInternalRoutes[_AuthPatternFromRequestPath<Path>][Method]
 }
 
-declare module 'nuxt/dist/app/composables/fetch' {
-  export function useFetch<
-    ErrorT = FetchError,
-    Path extends import('#nuxt-better-auth').AuthApiEndpointPath = import('#nuxt-better-auth').AuthApiEndpointPath,
-    Method extends _AuthFetchMethod<Path> = _AuthFetchDefaultMethod<Path>,
-    _ResT = _AuthFetchResult<Path, Method>,
-    DataT = _ResT,
-    PickKeys extends import('nuxt/dist/app/composables/asyncData').KeysOf<DataT> = import('nuxt/dist/app/composables/asyncData').KeysOf<DataT>,
-    DefaultT = undefined,
-  >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: import('nuxt/dist/app/composables/fetch').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>): import('nuxt/dist/app/composables/asyncData').AsyncData<import('nuxt/dist/app/composables/asyncData').PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
-  export function useFetch<
-    ErrorT = FetchError,
-    Path extends import('#nuxt-better-auth').AuthApiEndpointPath = import('#nuxt-better-auth').AuthApiEndpointPath,
-    Method extends _AuthFetchMethod<Path> = _AuthFetchDefaultMethod<Path>,
-    _ResT = _AuthFetchResult<Path, Method>,
-    DataT = _ResT,
-    PickKeys extends import('nuxt/dist/app/composables/asyncData').KeysOf<DataT> = import('nuxt/dist/app/composables/asyncData').KeysOf<DataT>,
-    DefaultT = DataT,
-  >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: import('nuxt/dist/app/composables/fetch').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>): import('nuxt/dist/app/composables/asyncData').AsyncData<import('nuxt/dist/app/composables/asyncData').PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
-  export function useFetch(request: string | import('vue').Ref<string> | (() => string), opts?: any): any
-
-  export function useLazyFetch<
-    ErrorT = FetchError,
-    Path extends import('#nuxt-better-auth').AuthApiEndpointPath = import('#nuxt-better-auth').AuthApiEndpointPath,
-    Method extends _AuthFetchMethod<Path> = _AuthFetchDefaultMethod<Path>,
-    _ResT = _AuthFetchResult<Path, Method>,
-    DataT = _ResT,
-    PickKeys extends import('nuxt/dist/app/composables/asyncData').KeysOf<DataT> = import('nuxt/dist/app/composables/asyncData').KeysOf<DataT>,
-    DefaultT = undefined,
-  >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: Omit<import('nuxt/dist/app/composables/fetch').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>, 'lazy'>): import('nuxt/dist/app/composables/asyncData').AsyncData<import('nuxt/dist/app/composables/asyncData').PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
-  export function useLazyFetch<
-    ErrorT = FetchError,
-    Path extends import('#nuxt-better-auth').AuthApiEndpointPath = import('#nuxt-better-auth').AuthApiEndpointPath,
-    Method extends _AuthFetchMethod<Path> = _AuthFetchDefaultMethod<Path>,
-    _ResT = _AuthFetchResult<Path, Method>,
-    DataT = _ResT,
-    PickKeys extends import('nuxt/dist/app/composables/asyncData').KeysOf<DataT> = import('nuxt/dist/app/composables/asyncData').KeysOf<DataT>,
-    DefaultT = DataT,
-  >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: Omit<import('nuxt/dist/app/composables/fetch').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>, 'lazy'>): import('nuxt/dist/app/composables/asyncData').AsyncData<import('nuxt/dist/app/composables/asyncData').PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
-  export function useLazyFetch(request: string | import('vue').Ref<string> | (() => string), opts?: any): any
-}
-
 declare module 'nuxt/app' {
   export function useFetch<
+    ResT = void,
     ErrorT = FetchError,
     Path extends import('#nuxt-better-auth').AuthApiEndpointPath = import('#nuxt-better-auth').AuthApiEndpointPath,
-    Method extends _AuthFetchMethod<Path> = _AuthFetchDefaultMethod<Path>,
-    _ResT = _AuthFetchResult<Path, Method>,
+    const Method extends _AuthFetchMethod = _AuthFetchDefaultMethod<Path>,
+    _ResT = ResT extends void ? _AuthFetchResult<Path, Method> : ResT,
     DataT = _ResT,
-    PickKeys extends import('nuxt/dist/app/composables/asyncData').KeysOf<DataT> = import('nuxt/dist/app/composables/asyncData').KeysOf<DataT>,
+    PickKeys extends _NuxtKeysOf<DataT> = _NuxtKeysOf<DataT>,
     DefaultT = undefined,
-  >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: import('nuxt/dist/app/composables/fetch').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>): import('nuxt/dist/app/composables/asyncData').AsyncData<import('nuxt/dist/app/composables/asyncData').PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
+  >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: import('nuxt/app').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>): import('nuxt/app').AsyncData<_NuxtPickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
   export function useFetch<
+    ResT = void,
     ErrorT = FetchError,
     Path extends import('#nuxt-better-auth').AuthApiEndpointPath = import('#nuxt-better-auth').AuthApiEndpointPath,
-    Method extends _AuthFetchMethod<Path> = _AuthFetchDefaultMethod<Path>,
-    _ResT = _AuthFetchResult<Path, Method>,
+    const Method extends _AuthFetchMethod = _AuthFetchDefaultMethod<Path>,
+    _ResT = ResT extends void ? _AuthFetchResult<Path, Method> : ResT,
     DataT = _ResT,
-    PickKeys extends import('nuxt/dist/app/composables/asyncData').KeysOf<DataT> = import('nuxt/dist/app/composables/asyncData').KeysOf<DataT>,
+    PickKeys extends _NuxtKeysOf<DataT> = _NuxtKeysOf<DataT>,
     DefaultT = DataT,
-  >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: import('nuxt/dist/app/composables/fetch').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>): import('nuxt/dist/app/composables/asyncData').AsyncData<import('nuxt/dist/app/composables/asyncData').PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
-  export function useFetch(request: string | import('vue').Ref<string> | (() => string), opts?: any): any
+  >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: import('nuxt/app').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>): import('nuxt/app').AsyncData<_NuxtPickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
+${buildNuxtFetchFallback('useFetch')}
 
   export function useLazyFetch<
+    ResT = void,
     ErrorT = FetchError,
     Path extends import('#nuxt-better-auth').AuthApiEndpointPath = import('#nuxt-better-auth').AuthApiEndpointPath,
-    Method extends _AuthFetchMethod<Path> = _AuthFetchDefaultMethod<Path>,
-    _ResT = _AuthFetchResult<Path, Method>,
+    const Method extends _AuthFetchMethod = _AuthFetchDefaultMethod<Path>,
+    _ResT = ResT extends void ? _AuthFetchResult<Path, Method> : ResT,
     DataT = _ResT,
-    PickKeys extends import('nuxt/dist/app/composables/asyncData').KeysOf<DataT> = import('nuxt/dist/app/composables/asyncData').KeysOf<DataT>,
+    PickKeys extends _NuxtKeysOf<DataT> = _NuxtKeysOf<DataT>,
     DefaultT = undefined,
-  >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: Omit<import('nuxt/dist/app/composables/fetch').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>, 'lazy'>): import('nuxt/dist/app/composables/asyncData').AsyncData<import('nuxt/dist/app/composables/asyncData').PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
+  >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: Omit<import('nuxt/app').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>, 'lazy'>): import('nuxt/app').AsyncData<_NuxtPickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
   export function useLazyFetch<
+    ResT = void,
     ErrorT = FetchError,
     Path extends import('#nuxt-better-auth').AuthApiEndpointPath = import('#nuxt-better-auth').AuthApiEndpointPath,
-    Method extends _AuthFetchMethod<Path> = _AuthFetchDefaultMethod<Path>,
-    _ResT = _AuthFetchResult<Path, Method>,
+    const Method extends _AuthFetchMethod = _AuthFetchDefaultMethod<Path>,
+    _ResT = ResT extends void ? _AuthFetchResult<Path, Method> : ResT,
     DataT = _ResT,
-    PickKeys extends import('nuxt/dist/app/composables/asyncData').KeysOf<DataT> = import('nuxt/dist/app/composables/asyncData').KeysOf<DataT>,
+    PickKeys extends _NuxtKeysOf<DataT> = _NuxtKeysOf<DataT>,
     DefaultT = DataT,
-  >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: Omit<import('nuxt/dist/app/composables/fetch').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>, 'lazy'>): import('nuxt/dist/app/composables/asyncData').AsyncData<import('nuxt/dist/app/composables/asyncData').PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
-  export function useLazyFetch(request: string | import('vue').Ref<string> | (() => string), opts?: any): any
+  >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: Omit<import('nuxt/app').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>, 'lazy'>): import('nuxt/app').AsyncData<_NuxtPickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
+${buildNuxtFetchFallback('useLazyFetch')}
 }
 export {}
 `,

--- a/src/module/type-templates.ts
+++ b/src/module/type-templates.ts
@@ -6,7 +6,7 @@ function buildNuxtFetchFallback(name: 'useFetch' | 'useLazyFetch'): string {
   return ['undefined', 'DataT'].map(defaultType => `
   export function ${name}<
     ResT = void,
-    ErrorT = FetchError,
+    ErrorT = _NuxtFetchError,
     ReqT extends NitroFetchRequest = NitroFetchRequest,
     const Method extends _NuxtFetchMethod<ReqT> = ResT extends void ? 'get' extends _NuxtFetchMethod<ReqT> ? 'get' : _NuxtFetchMethod<ReqT> : _NuxtFetchMethod<ReqT>,
     _ResT = ResT extends void ? import('nuxt/app').FetchResult<ReqT, Method> : ResT,
@@ -175,7 +175,9 @@ import type createServerAuth from '${serverConfigPath}'
 import type { BetterAuthOptions } from 'better-auth'
 import type { getEndpoints } from 'better-auth/api'
 import type { AvailableRouterMethod, NitroFetchRequest, Serialize, Simplify } from '${nitroTypesPath}'
-import type { FetchError } from 'ofetch'
+import type { useFetch as _NuxtUseFetch } from '#app/composables/fetch'
+
+type _NuxtFetchError = NonNullable<ReturnType<typeof _NuxtUseFetch<void>>['error']['value']>
 
 type _RawConfig = ReturnType<typeof createServerAuth>
 type _RawPlugins = _RawConfig extends { plugins: infer P } ? P : _RawConfig extends { plugins?: infer P } ? P : []
@@ -262,7 +264,7 @@ declare module '#nuxt-better-auth' {
 declare module 'nuxt/app' {
   export function useFetch<
     ResT = void,
-    ErrorT = FetchError,
+    ErrorT = _NuxtFetchError,
     Path extends import('#nuxt-better-auth').AuthApiEndpointPath = import('#nuxt-better-auth').AuthApiEndpointPath,
     const Method extends _AuthFetchMethod = _AuthFetchDefaultMethod<Path>,
     _ResT = ResT extends void ? _AuthFetchResult<Path, Method> : ResT,
@@ -272,7 +274,7 @@ declare module 'nuxt/app' {
   >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: import('nuxt/app').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>): import('nuxt/app').AsyncData<_NuxtPickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
   export function useFetch<
     ResT = void,
-    ErrorT = FetchError,
+    ErrorT = _NuxtFetchError,
     Path extends import('#nuxt-better-auth').AuthApiEndpointPath = import('#nuxt-better-auth').AuthApiEndpointPath,
     const Method extends _AuthFetchMethod = _AuthFetchDefaultMethod<Path>,
     _ResT = ResT extends void ? _AuthFetchResult<Path, Method> : ResT,
@@ -284,7 +286,7 @@ ${buildNuxtFetchFallback('useFetch')}
 
   export function useLazyFetch<
     ResT = void,
-    ErrorT = FetchError,
+    ErrorT = _NuxtFetchError,
     Path extends import('#nuxt-better-auth').AuthApiEndpointPath = import('#nuxt-better-auth').AuthApiEndpointPath,
     const Method extends _AuthFetchMethod = _AuthFetchDefaultMethod<Path>,
     _ResT = ResT extends void ? _AuthFetchResult<Path, Method> : ResT,
@@ -294,7 +296,7 @@ ${buildNuxtFetchFallback('useFetch')}
   >(request: import('vue').Ref<Path> | Path | (() => Path), opts?: Omit<import('nuxt/app').UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, Path, Method>, 'lazy'>): import('nuxt/app').AsyncData<_NuxtPickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
   export function useLazyFetch<
     ResT = void,
-    ErrorT = FetchError,
+    ErrorT = _NuxtFetchError,
     Path extends import('#nuxt-better-auth').AuthApiEndpointPath = import('#nuxt-better-auth').AuthApiEndpointPath,
     const Method extends _AuthFetchMethod = _AuthFetchDefaultMethod<Path>,
     _ResT = ResT extends void ? _AuthFetchResult<Path, Method> : ResT,

--- a/test/cases/use-fetch-endpoints-type-inference/tsconfig.type-check.json
+++ b/test/cases/use-fetch-endpoints-type-inference/tsconfig.type-check.json
@@ -8,6 +8,7 @@
     "module": "preserve",
     "moduleResolution": "bundler",
     "paths": {
+      "#app/*": ["../../../node_modules/nuxt/dist/app/*"],
       "#auth/client": ["../_base-module/app/auth.config"],
       "#auth/server": ["./server/auth.config"],
       "#imports": ["./imports-shim"]

--- a/test/cases/use-fetch-endpoints-type-inference/typecheck-target.ts
+++ b/test/cases/use-fetch-endpoints-type-inference/typecheck-target.ts
@@ -1,3 +1,4 @@
+import type { useFetch as nativeUseFetch } from '#app/composables/fetch'
 import type { AuthApiEndpointMethod, AuthApiEndpointPath, AuthApiEndpointPatternPath, AuthApiEndpointResponse } from '#nuxt-better-auth'
 import { useFetch, useLazyFetch } from 'nuxt/app'
 import { useAuthRequestFetch } from '../../../src/runtime/app/composables/useAuthRequestFetch'
@@ -86,11 +87,19 @@ void invalidMethodForPostOnly
 void customerStateResponse.missingField
 void assertUseFetchPathInference
 
+type NativeFetchError = NonNullable<ReturnType<typeof nativeUseFetch<void>>['error']['value']>
+type SameType<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false
+type IsAny<T> = 0 extends (1 & T) ? true : false
+
 async function assertNuxtFetchContracts() {
   for (const fetch of [useFetch, useLazyFetch]) {
     const report = await fetch('/api/report')
     report.data.value?.title.toUpperCase()
     report.data.value?.count.toFixed()
+    const nativeError: SameType<NonNullable<typeof report.error.value>, NativeFetchError> = true
+    const errorIsAny: IsAny<NonNullable<typeof report.error.value>> = false
+    void nativeError
+    void errorIsAny
     // @ts-expect-error unrelated route results must retain their response types
     void report.data.value?.missingField
     // @ts-expect-error AsyncData is not an arbitrary object

--- a/test/cases/use-fetch-endpoints-type-inference/typecheck-target.ts
+++ b/test/cases/use-fetch-endpoints-type-inference/typecheck-target.ts
@@ -2,6 +2,12 @@ import type { AuthApiEndpointMethod, AuthApiEndpointPath, AuthApiEndpointPattern
 import { useFetch, useLazyFetch } from 'nuxt/app'
 import { useAuthRequestFetch } from '../../../src/runtime/app/composables/useAuthRequestFetch'
 
+declare module 'nitropack/types' {
+  interface InternalApi {
+    '/api/report': { get: { title: string, count: number } }
+  }
+}
+
 type DynamicPath = Extract<AuthApiEndpointPath, `/api/auth/customer/${string}/state`>
 const dynamicPath: DynamicPath = '/api/auth/customer/123/state'
 
@@ -79,3 +85,49 @@ void invalidMethodForPostOnly
 // @ts-expect-error no unknown key on inferred endpoint response
 void customerStateResponse.missingField
 void assertUseFetchPathInference
+
+async function assertNuxtFetchContracts() {
+  for (const fetch of [useFetch, useLazyFetch]) {
+    const report = await fetch('/api/report')
+    report.data.value?.title.toUpperCase()
+    report.data.value?.count.toFixed()
+    // @ts-expect-error unrelated route results must retain their response types
+    void report.data.value?.missingField
+    // @ts-expect-error AsyncData is not an arbitrary object
+    void report.nonexistent().anything
+    // @ts-expect-error invalid HTTP methods must not match a fallback overload
+    fetch('/api/report', { method: 'NOT_A_METHOD' })
+    // @ts-expect-error Nuxt fetch options must retain their types
+    fetch('/api/report', { immediate: 'yes' })
+    // @ts-expect-error even unknown routes require valid options
+    fetch('/api/unrelated', { immediate: 'yes' })
+
+    // @ts-expect-error auth routes also require valid HTTP methods
+    fetch('/api/auth/customer/state', { method: 'NOT_A_METHOD' })
+    const auth = await fetch('/api/auth/customer/state')
+    auth.data.value?.activeSubscriptions[0]?.toUpperCase()
+    // @ts-expect-error auth responses must not fall back to any
+    void auth.data.value?.missingField
+
+    const explicit = await fetch<{ label: string }>('/api/unrelated')
+    explicit.data.value?.label.toUpperCase()
+    // @ts-expect-error explicit response generics must remain checked
+    void explicit.data.value?.count
+    const explicitAuth = await fetch<{ label: string }>('/api/auth/customer/state')
+    explicitAuth.data.value?.label.toUpperCase()
+    // @ts-expect-error an explicit response generic replaces endpoint inference
+    void explicitAuth.data.value?.activeSubscriptions
+  }
+
+  const transformed = await useFetch('/api/report', { transform: report => report.title })
+  transformed.data.value?.toUpperCase()
+  // @ts-expect-error transform output replaces the original response
+  void transformed.data.value?.count
+  const selected = await useLazyFetch('/api/report', { pick: ['title'] })
+  selected.data.value?.title.toUpperCase()
+  // @ts-expect-error pick removes unselected properties
+  void selected.data.value?.count
+  const withDefault = await useFetch('/api/report', { default: () => ({ title: '', count: 0 }) })
+  withDefault.data.value.title.toUpperCase()
+}
+void assertNuxtFetchContracts


### PR DESCRIPTION
The generated fetch overloads let TypeScript accept invalid options and arbitrary result properties on unrelated routes. Replace the `any` fallbacks with Nuxt's public option and result types while preserving auth endpoint inference, explicit response generics, native Nuxt error types, and the existing exclusion from global Nitro `InternalApi`.

The three invalid calls in the repro compile before this change and are rejected afterward.

**Before:** [CLI reproduction](https://github.com/onmax/repros/tree/repro/better-auth-fetch-types/better-auth-fetch-types) · **After:** [patched control](https://github.com/onmax/repros/tree/repro/better-auth-fetch-types/better-auth-fetch-types-fix)
