### PR TITLE
docs: require an explicit auth URL on Cloudflare Workers

### DIFF
--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -12,7 +12,7 @@ Install @nuxtjs/better-auth in my Nuxt app.
 - Read the raw installation documentation first: https://better-auth.nuxt.dev/raw/getting-started/installation.md
 - Run `npx nuxi module add @nuxtjs/better-auth`
 - Set `NUXT_BETTER_AUTH_SECRET` or `BETTER_AUTH_SECRETS` in `.env` (at least 32 chars per current secret, high entropy)
-- Optionally set `NUXT_PUBLIC_SITE_URL` for non-auto-detected platforms
+- Set `NUXT_PUBLIC_SITE_URL` for Cloudflare Workers, custom domains, and production hosts without a supported platform URL variable
 - Create `server/auth.config.ts` using `defineServerAuth` from `@nuxtjs/better-auth/config`
 - Create `app/auth.config.ts` using `defineClientAuth` from `@nuxtjs/better-auth/config`
 - The module auto-injects `secret` and `baseURL` — do not configure them manually
@@ -73,13 +73,15 @@ For non-destructive rotation, use Better Auth's versioned environment variable i
 BETTER_AUTH_SECRETS=2:current-secret-must-be-at-least-32-characters,1:previous-secret-must-be-at-least-32-characters
 ```
 
-2. **Base URL** (Optional)
+2. **Base URL**
 
-The module auto-detects the URL on :brand-badge{name="vercel"}, :brand-badge{name="cloudflare"}, and :brand-badge{name="netlify"}. Set manually for other platforms.
+Set `NUXT_PUBLIC_SITE_URL` for :brand-badge{name="cloudflare"} Workers, custom domains, and production hosts without a supported platform URL variable. For platform domains, the module can use `VERCEL_URL` (Vercel), `CF_PAGES_URL` (Cloudflare Pages), or `URL` (Netlify) when available at runtime.
 
 ```txt [.env]
 NUXT_PUBLIC_SITE_URL=https://your-domain.com
 ```
+
+Cloudflare Workers does not supply `CF_PAGES_URL`. Configure `NUXT_PUBLIC_SITE_URL` in the Worker's runtime variables, including for `workers.dev` deployments. Without an explicit or supported platform URL, production auth initialization fails.
 
 ### Create configuration files
 

--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -15,7 +15,7 @@ Configure @nuxtjs/better-auth module options and server auth.
 - The function syntax receives `ctx` with `runtimeConfig` and `db` (NuxtHub)
 - The module auto-injects `secret` and `baseURL` — do not set them in defineServerAuth
 - Production base URL: runtimeConfig > platform env vars. Request URL inference is development-only.
-- Set `NUXT_PUBLIC_SITE_URL` for custom domains or deterministic OAuth callbacks
+- Set `NUXT_PUBLIC_SITE_URL` for Cloudflare Workers, custom domains, and production hosts without a supported platform URL variable
 ```
 
 ::
@@ -189,7 +189,7 @@ export default defineServerAuth((ctx) => ({
 The module automatically injects the singular `secret` and `baseURL`. Use Better Auth's `secrets` option only when you need versioned rotation.
 - **Secret**: Priority: `nuxt.config.ts` runtimeConfig > `NUXT_BETTER_AUTH_SECRET` > `BETTER_AUTH_SECRET`
 - **Versioned secrets**: Set `secrets` in `defineServerAuth` or use `BETTER_AUTH_SECRETS`. When present, the singular secret is a legacy decryption fallback.
-- **Base URL**: The module auto-detects the base URL on :brand-badge{name="vercel"}, :brand-badge{name="cloudflare"}, and :brand-badge{name="netlify"}. For other platforms, set `NUXT_PUBLIC_SITE_URL`
+- **Base URL**: The module can use `VERCEL_URL` (Vercel), `CF_PAGES_URL` (Cloudflare Pages), or `URL` (Netlify) at runtime. Set `NUXT_PUBLIC_SITE_URL` for Cloudflare Workers, custom domains, and hosts without one of these variables
 ::
 
 ### Context Options
@@ -238,10 +238,12 @@ The module resolves `siteUrl` using this priority:
 |----------|--------|-----------|
 | 1 | `runtimeConfig.public.siteUrl` | Explicit config (always wins) |
 | 2 | Request URL, then Nitro development environment | Development only |
-| 3 | `VERCEL_URL`, `CF_PAGES_URL`, `URL` | Platform env vars (:brand-badge{name="vercel"}, :brand-badge{name="cloudflare"}, :brand-badge{name="netlify"}) |
+| 3 | `VERCEL_URL`, `CF_PAGES_URL`, `URL` | Runtime platform env vars (Vercel, Cloudflare Pages, Netlify) |
 | 4 | `http://localhost:3000` | Development only |
 
 In production, request headers and listener settings such as `HOST` and `NITRO_HOST` never select the auth base URL. Set a public URL explicitly or use a platform environment variable. Without either, auth initialization fails with a configuration error.
+
+Cloudflare Workers does not supply `CF_PAGES_URL`. Set `NUXT_PUBLIC_SITE_URL` in the Worker's runtime variables, including when using a `workers.dev` domain.
 
 Continue passing `event` to `serverAuth(event)` for request-scoped database access and the optional `ctx.requestOrigin` context.
 
@@ -275,7 +277,7 @@ Configure secrets using environment variables (see [Installation](/getting-start
 
 ```ini [.env]
 NUXT_BETTER_AUTH_SECRET="your-super-secret-key"
-NUXT_PUBLIC_SITE_URL="https://your-domain.com" # Optional on Vercel/Cloudflare/Netlify
+NUXT_PUBLIC_SITE_URL="https://your-domain.com" # Required on Workers, custom domains, and hosts without a platform URL
 ```
 
 ::tip

--- a/docs/content/3.guides/6.migrate-from-nuxt-auth-utils.md
+++ b/docs/content/3.guides/6.migrate-from-nuxt-auth-utils.md
@@ -310,7 +310,7 @@ See **Schema Generation** to set up database tables.
 Ensure a singular or versioned auth secret is configured and the database is available.
 
 ### OAuth redirect errors
-Auto-detected on :brand-badge{name="vercel"}, :brand-badge{name="cloudflare"}, and :brand-badge{name="netlify"}. For other platforms, set `NUXT_PUBLIC_SITE_URL`.
+Set `NUXT_PUBLIC_SITE_URL` for Cloudflare Workers, custom domains, and hosts without a supported platform URL variable. For platform domains, the module can use `VERCEL_URL` (Vercel), `CF_PAGES_URL` (Cloudflare Pages), or `URL` (Netlify) when available at runtime. Cloudflare Workers does not supply `CF_PAGES_URL`.
 
 ### Type errors on user fields
 Run type augmentation - see [Type Augmentation](/getting-started/type-augmentation).

--- a/docs/content/3.guides/9.production-deployment.md
+++ b/docs/content/3.guides/9.production-deployment.md
@@ -16,7 +16,7 @@ NUXT_BETTER_AUTH_SECRET="your-32-character-secret-here-minimum"
 # Alternative for non-destructive rotation
 # BETTER_AUTH_SECRETS="2:current-secret-must-be-at-least-32-characters,1:previous-secret-must-be-at-least-32-characters"
 
-# Optional: Auto-detected on Vercel/Cloudflare/Netlify
+# Required on Workers, custom domains, and hosts without a platform URL
 NUXT_PUBLIC_SITE_URL="https://your-app.com"
 
 # OAuth provider credentials (if using)
@@ -37,7 +37,7 @@ Singular secrets must be at least 32 characters. Shorter `NUXT_BETTER_AUTH_SECRE
 ### Before Deploying
 
 - [ ] `NUXT_BETTER_AUTH_SECRET`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_SECRETS`, or `defineServerAuth({ secrets })` is configured
-- [ ] `NUXT_PUBLIC_SITE_URL` set (or using :brand-badge{name="vercel"}, :brand-badge{name="cloudflare"}, or :brand-badge{name="netlify"} auto-detection)
+- [ ] `NUXT_PUBLIC_SITE_URL` is set at runtime. For platform domains, `VERCEL_URL` (Vercel), `CF_PAGES_URL` (Cloudflare Pages), or `URL` (Netlify) can supply the URL instead. Cloudflare Workers needs an explicit URL, including on `workers.dev`.
 - [ ] `trustedOrigins` includes every active frontend origin (primary domain and preview domain, if used)
 - [ ] OAuth redirect URIs configured for production domain
 - [ ] `NODE_ENV=production` is set (disables devtools)
@@ -113,7 +113,7 @@ The deployed server runtime could not resolve an auth secret. Set `NUXT_BETTER_A
 
 ### "siteUrl required in production"
 
-The module auto-detects URLs on :brand-badge{name="vercel"}, :brand-badge{name="cloudflare"}, and :brand-badge{name="netlify"}. For other platforms, set `NUXT_PUBLIC_SITE_URL` to your production domain.
+Set `NUXT_PUBLIC_SITE_URL` to your production domain for Cloudflare Workers, custom domains, and hosts without a supported platform URL variable. For platform domains, the module can use `VERCEL_URL` (Vercel), `CF_PAGES_URL` (Cloudflare Pages), or `URL` (Netlify) when available at runtime. Cloudflare Workers does not supply `CF_PAGES_URL`; configure the URL in the Worker's runtime variables.
 
 ### OAuth Redirects Fail
 


### PR DESCRIPTION
The setup guides describe the auth URL as optional on Cloudflare, but Workers does not provide `CF_PAGES_URL`. Since production auth no longer infers its origin from request headers, following that guidance can make auth initialization fail.

Update installation, configuration, migration, and deployment guidance to require `NUXT_PUBLIC_SITE_URL` in Worker runtime variables, including for `workers.dev`. Distinguish Cloudflare Pages and list the supported runtime URL variables for platform domains.

Validation: checked against the runtime origin resolver and its production configuration tests; `git diff --check` passed. CI validates the docs build.
