### PR TITLE
test: exercise runtime auth origin resolution

### DIFF
--- a/test/get-base-url.test.ts
+++ b/test/get-base-url.test.ts
@@ -1,430 +1,228 @@
-import { withoutProtocol } from 'ufo'
-import { describe, expect, it, vi } from 'vitest'
+import type { BetterAuthOptions } from 'better-auth'
+import type { H3Event } from 'h3'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-function normalizeLoopbackOrigin(origin: string, isDev: boolean): string {
-  if (!isDev)
-    return origin
+const runtimeConfig = {
+  public: { siteUrl: '' as unknown },
+  auth: {},
+  betterAuthSecret: 'test-secret-for-testing-only-32chars',
+}
+const createServerAuthMock = vi.fn()
 
-  const parsed = new URL(origin)
-  if (parsed.hostname === '127.0.0.1' || parsed.hostname === '::1' || parsed.hostname === '[::1]') {
-    parsed.hostname = 'localhost'
-    return parsed.origin
-  }
+vi.mock('#auth/database', () => ({ createDatabase: () => undefined, db: {} }))
+vi.mock('#auth/server', () => ({ default: createServerAuthMock }))
+vi.mock('better-auth', () => ({
+  betterAuth: (options: BetterAuthOptions) => ({ options }),
+  env: process.env,
+}))
+vi.mock('../src/runtime/server/internal/nitro-compat', async () => {
+  const { getRequestHost, getRequestProtocol } = await import('h3')
+  return { getRequestHost, getRequestProtocol, useRuntimeConfig: () => runtimeConfig }
+})
 
-  return origin
+function createEvent(host = 'request.example.com', forwardedHost?: string): H3Event {
+  return {
+    context: {},
+    node: {
+      req: {
+        headers: {
+          host,
+          ...(forwardedHost ? { 'x-forwarded-host': forwardedHost, 'x-forwarded-proto': 'https' } : {}),
+        },
+        socket: {},
+      },
+    },
+  } as unknown as H3Event
 }
 
-function validateURL(url: string, isDev: boolean): string {
-  try {
-    return normalizeLoopbackOrigin(new URL(url).origin, isDev)
-  }
-  catch {
-    throw new Error(`Invalid siteUrl: "${url}". Must be a valid URL.`)
-  }
+async function authOptions(event?: H3Event) {
+  const { serverAuth } = await import('../src/runtime/server/utils/auth')
+  return serverAuth(event).options
 }
 
-interface GetNitroOriginOptions {
-  isDev: boolean
-  isPrerender: boolean
-  env: Partial<Record<string, string>>
-  requestHost?: string
-  requestProtocol?: string
+async function trustedOrigins(request?: Request) {
+  const options = await authOptions()
+  expect(options.trustedOrigins).toBeTypeOf('function')
+  if (typeof options.trustedOrigins !== 'function')
+    throw new TypeError('Expected development trustedOrigins callback')
+  return options.trustedOrigins(request)
 }
 
-function resolveConfiguredSiteUrl(config: { public: { siteUrl?: unknown } }, isDev: boolean): string | undefined {
-  if (typeof config.public.siteUrl !== 'string' || !config.public.siteUrl)
-    return undefined
-
-  return validateURL(config.public.siteUrl, isDev)
-}
-
-function resolveEventOrigin(options: GetNitroOriginOptions): string | undefined {
-  if (!options.requestHost || !options.requestProtocol)
-    return undefined
-
-  try {
-    return validateURL(`${options.requestProtocol}://${options.requestHost}`, options.isDev)
+beforeEach(() => {
+  vi.resetModules()
+  vi.resetAllMocks()
+  runtimeConfig.public.siteUrl = ''
+  createServerAuthMock.mockReturnValue({})
+  for (const name of [
+    'BETTER_AUTH_SECRET',
+    'BETTER_AUTH_SECRETS',
+    'VERCEL_URL',
+    'CF_PAGES_URL',
+    'URL',
+    'HOST',
+    'PORT',
+    'NITRO_HOST',
+    'NITRO_PORT',
+    'NITRO_SSL_CERT',
+    'NITRO_SSL_KEY',
+    '__NUXT_DEV__',
+    'NUXT_VITE_NODE_OPTIONS',
+  ]) {
+    vi.stubEnv(name, '')
   }
-  catch {
-    return undefined
-  }
-}
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
 
-function getNitroOrigin(options: GetNitroOriginOptions): string | undefined {
-  const { isDev, isPrerender, env } = options
-  const cert = env.NITRO_SSL_CERT
-  const key = env.NITRO_SSL_KEY
-  let host: string | undefined = env.NITRO_HOST || env.HOST
-  let port: string | undefined
-  if (isDev)
-    port = env.NITRO_PORT || env.PORT || '3000'
-  let protocol = (cert && key) || !isDev ? 'https' : 'http'
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+})
 
-  try {
-    if ((isDev || isPrerender) && env.__NUXT_DEV__) {
-      const origin = JSON.parse(env.__NUXT_DEV__).proxy.url
-      host = withoutProtocol(origin)
-      protocol = origin.includes('https') ? 'https' : 'http'
-    }
-    else if ((isDev || isPrerender) && env.NUXT_VITE_NODE_OPTIONS) {
-      const origin = JSON.parse(env.NUXT_VITE_NODE_OPTIONS).baseURL.replace('/__nuxt_vite_node__', '')
-      host = withoutProtocol(origin)
-      protocol = origin.includes('https') ? 'https' : 'http'
-    }
-  }
-  catch {
-    // JSON parse failed, continue with env fallbacks
-  }
-
-  if (!host)
-    return undefined
-
-  if (host.startsWith('[') && host.includes(']:')) {
-    const lastBracketColon = host.lastIndexOf(']:')
-    const extractedPort = host.slice(lastBracketColon + 2)
-    host = host.slice(0, lastBracketColon + 1)
-    if (extractedPort)
-      port = extractedPort
-  }
-  else if (host.includes(':') && !host.startsWith('[')) {
-    const hostParts = host.split(':')
-    port = hostParts.pop()
-    host = hostParts.join(':')
-  }
-
-  const portSuffix = port ? `:${port}` : ''
-  return `${protocol}://${host}${portSuffix}`
-}
-
-function resolveEnvironmentOrigin(options: GetNitroOriginOptions): string | undefined {
-  const nitroOrigin = getNitroOrigin(options)
-  if (nitroOrigin)
-    return validateURL(nitroOrigin, options.isDev)
-
-  if (options.env.VERCEL_URL)
-    return validateURL(`https://${options.env.VERCEL_URL}`, options.isDev)
-  if (options.env.CF_PAGES_URL)
-    return validateURL(`https://${options.env.CF_PAGES_URL}`, options.isDev)
-  if (options.env.URL)
-    return validateURL(options.env.URL.startsWith('http') ? options.env.URL : `https://${options.env.URL}`, options.isDev)
-
-  return undefined
-}
-
-function resolveDevFallback(options: GetNitroOriginOptions): string | undefined {
-  if (options.isDev)
-    return 'http://localhost:3000'
-
-  return undefined
-}
-
-function getBaseURL(config: { public: { siteUrl?: unknown } }, options: GetNitroOriginOptions): string {
-  const configuredSiteUrl = resolveConfiguredSiteUrl(config, options.isDev)
-  if (configuredSiteUrl)
-    return configuredSiteUrl
-
-  const eventOrigin = resolveEventOrigin(options)
-  if (eventOrigin)
-    return eventOrigin
-
-  const environmentOrigin = resolveEnvironmentOrigin(options)
-  if (environmentOrigin)
-    return environmentOrigin
-
-  const devFallback = resolveDevFallback(options)
-  if (devFallback)
-    return devFallback
-
-  throw new Error('siteUrl required. Set NUXT_PUBLIC_SITE_URL.')
-}
-
-type TrustedOrigins
-  = | string[]
-    | ((request?: Request) => (string | undefined | null)[] | Promise<(string | undefined | null)[]>)
-    | undefined
-
-function dedupeOrigins(origins: readonly string[]): string[] {
-  return [...new Set(origins)]
-}
-
-function getDevTrustedOrigins(options: GetNitroOriginOptions): string[] {
-  const fallbackOrigin = 'http://localhost:3000'
-  const nitroOrigin = getNitroOrigin(options)
-  if (!nitroOrigin)
-    return [fallbackOrigin]
-
-  try {
-    const parsed = new URL(nitroOrigin)
-    const protocol = parsed.protocol === 'https:' ? 'https' : 'http'
-    const port = parsed.port || '3000'
-    const localhostOrigin = `${protocol}://localhost:${port}`
-    return dedupeOrigins([localhostOrigin, parsed.origin])
-  }
-  catch {
-    return [fallbackOrigin]
-  }
-}
-
-function getRequestOrigin(request?: Request): string | undefined {
-  if (!request)
-    return undefined
-
-  try {
-    return new URL(request.url).origin
-  }
-  catch {
-    return undefined
-  }
-}
-
-function withDevTrustedOrigins(
-  trustedOrigins: TrustedOrigins,
-  options: GetNitroOriginOptions,
-): TrustedOrigins {
-  if (!options.isDev)
-    return trustedOrigins
-
-  const devOrigins = getDevTrustedOrigins(options)
-  const mergeOrigins = (origins: readonly (string | null | undefined)[], request?: Request): string[] => {
-    const validOrigins = origins.filter((origin): origin is string => typeof origin === 'string')
-    const requestOrigin = getRequestOrigin(request)
-    return dedupeOrigins(requestOrigin ? [...validOrigins, ...devOrigins, requestOrigin] : [...validOrigins, ...devOrigins])
-  }
-
-  if (typeof trustedOrigins === 'function') {
-    return async (request?: Request) => {
-      const resolvedOrigins = await trustedOrigins(request)
-      return mergeOrigins(resolvedOrigins, request)
-    }
-  }
-
-  if (Array.isArray(trustedOrigins)) {
-    const baseOrigins = mergeOrigins(trustedOrigins)
-    return async (request?: Request) => {
-      return mergeOrigins(baseOrigins, request)
-    }
-  }
-
-  return async (request?: Request) => {
-    return mergeOrigins([], request)
-  }
-}
-
-describe('getBaseURL', () => {
-  it('explicit config takes priority', () => {
-    expect(getBaseURL({ public: { siteUrl: 'https://explicit.com' } }, { isDev: false, isPrerender: false, env: {}, requestHost: 'request.com', requestProtocol: 'https' })).toBe('https://explicit.com')
+describe('serverAuth origin configuration', () => {
+  it('prefers explicit configuration over the request and platform environment', async () => {
+    runtimeConfig.public.siteUrl = 'https://explicit.example.com/path'
+    vi.stubEnv('VERCEL_URL', 'deployment.vercel.app')
+    const options = await authOptions(createEvent('request.example.com', 'untrusted.example.com'))
+    expect(options.baseURL).toBe('https://explicit.example.com')
   })
 
-  it('requestHost used when no explicit config', () => {
-    expect(getBaseURL({ public: {} }, { isDev: false, isPrerender: false, env: {}, requestHost: 'myapp.com', requestProtocol: 'https' })).toBe('https://myapp.com')
+  it('rejects an invalid configured URL instead of falling back', async () => {
+    runtimeConfig.public.siteUrl = 'not-a-url'
+    vi.stubEnv('VERCEL_URL', 'deployment.vercel.app')
+    await expect(authOptions(createEvent())).rejects.toThrow('Invalid siteUrl')
   })
 
-  it('requestHost takes priority over dev proxy env when siteUrl is unset', () => {
-    const nuxtDev = JSON.stringify({ proxy: { url: 'http://localhost:3000' } })
-    expect(getBaseURL({ public: {} }, { isDev: true, isPrerender: false, env: { __NUXT_DEV__: nuxtDev }, requestHost: 'lan-host.local:3000', requestProtocol: 'http' })).toBe('http://lan-host.local:3000')
+  it.each([
+    ['VERCEL_URL', 'deployment.vercel.app', 'https://deployment.vercel.app'],
+    ['CF_PAGES_URL', 'https://deployment.pages.dev', 'https://deployment.pages.dev'],
+    ['URL', 'https://deployment.netlify.app', 'https://deployment.netlify.app'],
+  ])('uses %s when configuration and a dev request are absent', async (name, value, expected) => {
+    vi.stubEnv(name, value)
+    expect((await authOptions()).baseURL).toBe(expected)
   })
 
-  it('requestHost takes priority over platform env vars when siteUrl is unset', () => {
-    expect(getBaseURL({ public: {} }, { isDev: false, isPrerender: false, env: { VERCEL_URL: 'my-app.vercel.app' }, requestHost: 'request.com', requestProtocol: 'https' })).toBe('https://request.com')
-  })
-
-  it('uses NITRO_HOST/PORT in dev mode', () => {
-    expect(getBaseURL({ public: {} }, { isDev: true, isPrerender: false, env: { NITRO_HOST: 'localhost', NITRO_PORT: '3000' } })).toBe('http://localhost:3000')
-  })
-
-  it('dev mode defaults to port 3000', () => {
-    expect(getBaseURL({ public: {} }, { isDev: true, isPrerender: false, env: { HOST: 'localhost' } })).toBe('http://localhost:3000')
-  })
-
-  it('uses https with SSL certs', () => {
-    expect(getBaseURL({ public: {} }, { isDev: true, isPrerender: false, env: { HOST: 'localhost', NITRO_SSL_CERT: 'cert', NITRO_SSL_KEY: 'key' } })).toBe('https://localhost:3000')
-  })
-
-  it('parses __NUXT_DEV__ in dev mode', () => {
-    const nuxtDev = JSON.stringify({ proxy: { url: 'http://localhost:3000' } })
-    expect(getBaseURL({ public: {} }, { isDev: true, isPrerender: false, env: { __NUXT_DEV__: nuxtDev } })).toBe('http://localhost:3000')
-  })
-
-  it('handles malformed __NUXT_DEV__ gracefully', () => {
-    expect(getBaseURL({ public: {} }, { isDev: true, isPrerender: false, env: { __NUXT_DEV__: 'not-json', HOST: 'localhost' } })).toBe('http://localhost:3000')
-  })
-
-  it('falls back to VERCEL_URL when no host detected', () => {
-    expect(getBaseURL({ public: {} }, { isDev: false, isPrerender: false, env: { VERCEL_URL: 'my-app.vercel.app' } })).toBe('https://my-app.vercel.app')
-  })
-
-  it('falls back to CF_PAGES_URL when no host detected', () => {
-    expect(getBaseURL({ public: {} }, { isDev: false, isPrerender: false, env: { CF_PAGES_URL: 'my-app.pages.dev' } })).toBe('https://my-app.pages.dev')
-  })
-
-  it('falls back to URL env var', () => {
-    expect(getBaseURL({ public: {} }, { isDev: false, isPrerender: false, env: { URL: 'https://my-app.netlify.app' } })).toBe('https://my-app.netlify.app')
-  })
-
-  it('dev fallback to localhost when no host', () => {
-    expect(getBaseURL({ public: {} }, { isDev: true, isPrerender: false, env: {} })).toBe('http://localhost:3000')
-  })
-
-  it('throws in production without config', () => {
-    expect(() => getBaseURL({ public: {} }, { isDev: false, isPrerender: false, env: {} })).toThrow('siteUrl required')
-  })
-
-  it('ignores non-string siteUrl', () => {
-    expect(getBaseURL({ public: { siteUrl: 123 } }, { isDev: true, isPrerender: false, env: { HOST: 'localhost' } })).toBe('http://localhost:3000')
-  })
-
-  it('throws on invalid URL format', () => {
-    expect(() => getBaseURL({ public: { siteUrl: 'not-a-url' } }, { isDev: false, isPrerender: false, env: {} })).toThrow('Invalid siteUrl')
-  })
-
-  it('handles IPv6 addresses', () => {
-    expect(getBaseURL({ public: {} }, { isDev: false, isPrerender: false, env: {}, requestHost: '[::1]:3000', requestProtocol: 'http' })).toBe('http://[::1]:3000')
-  })
-
-  it('normalizes 127.0.0.1 to localhost in dev', () => {
-    expect(getBaseURL({ public: {} }, { isDev: true, isPrerender: false, env: {}, requestHost: '127.0.0.1:3000', requestProtocol: 'http' })).toBe('http://localhost:3000')
-  })
-
-  it('normalizes ::1 to localhost in dev', () => {
-    expect(getBaseURL({ public: {} }, { isDev: true, isPrerender: false, env: {}, requestHost: '[::1]:3000', requestProtocol: 'http' })).toBe('http://localhost:3000')
-  })
-
-  it('normalizes explicit loopback siteUrl in dev', () => {
-    expect(getBaseURL({ public: { siteUrl: 'http://127.0.0.1:3000' } }, { isDev: true, isPrerender: false, env: {} })).toBe('http://localhost:3000')
-  })
-
-  it('does not normalize loopback hosts in production', () => {
-    expect(getBaseURL({ public: {} }, { isDev: false, isPrerender: false, env: {}, requestHost: '127.0.0.1:3000', requestProtocol: 'http' })).toBe('http://127.0.0.1:3000')
-  })
-
-  it('does not alter non-loopback hosts in dev', () => {
-    expect(getBaseURL({ public: {} }, { isDev: true, isPrerender: false, env: {}, requestHost: 'myapp.local:3000', requestProtocol: 'http' })).toBe('http://myapp.local:3000')
+  it('ignores a non-string siteUrl', async () => {
+    runtimeConfig.public.siteUrl = 123
+    vi.stubEnv('VERCEL_URL', 'deployment.vercel.app')
+    expect((await authOptions()).baseURL).toBe('https://deployment.vercel.app')
   })
 })
 
-describe('withDevTrustedOrigins', () => {
-  it('adds detected localhost origin with detected port', async () => {
-    const trustedOrigins = withDevTrustedOrigins(undefined, {
-      isDev: true,
-      isPrerender: false,
-      env: {
-        __NUXT_DEV__: JSON.stringify({ proxy: { url: 'http://127.0.0.1:4123' } }),
-      },
-    })
-
-    expect(typeof trustedOrigins).toBe('function')
-    if (typeof trustedOrigins !== 'function')
-      throw new Error('trustedOrigins should be a function')
-    const resolvedOrigins = await trustedOrigins()
-    expect(resolvedOrigins).toEqual(['http://localhost:4123', 'http://127.0.0.1:4123'])
+describe.runIf(!import.meta.dev)('serverAuth production origins', () => {
+  it.each([undefined, 'untrusted.example.com'])('rejects request inference with forwarded host %s', async (forwardedHost) => {
+    await expect(authOptions(createEvent('request.example.com', forwardedHost))).rejects.toThrow('siteUrl required in production')
   })
 
-  it('preserves and deduplicates configured trustedOrigins arrays', async () => {
-    const trustedOrigins = withDevTrustedOrigins(['https://foo.workers.dev', 'http://localhost:3001'], {
-      isDev: true,
-      isPrerender: false,
-      env: {
-        NITRO_HOST: 'localhost',
-        NITRO_PORT: '3001',
-      },
-    })
-
-    expect(typeof trustedOrigins).toBe('function')
-    if (typeof trustedOrigins !== 'function')
-      throw new Error('trustedOrigins should be a function')
-    const resolvedOrigins = await trustedOrigins()
-    expect(resolvedOrigins).toEqual(['https://foo.workers.dev', 'http://localhost:3001'])
+  it('rejects listener and dev proxy addresses as production configuration', async () => {
+    vi.stubEnv('HOST', '0.0.0.0')
+    vi.stubEnv('NITRO_HOST', '127.0.0.1')
+    vi.stubEnv('__NUXT_DEV__', JSON.stringify({ proxy: { url: 'http://localhost:4000' } }))
+    await expect(authOptions()).rejects.toThrow('siteUrl required in production')
   })
 
-  it('wraps trustedOrigins functions and appends dev origins', async () => {
-    const trustedOriginsFn = vi.fn(async () => ['https://foo.workers.dev', undefined, null, 'http://localhost:3002'])
-    const trustedOrigins = withDevTrustedOrigins(trustedOriginsFn, {
-      isDev: true,
-      isPrerender: false,
-      env: {
-        NITRO_HOST: '192.168.1.50',
-        NITRO_PORT: '3002',
-      },
-    })
-
-    expect(typeof trustedOrigins).toBe('function')
-    if (typeof trustedOrigins !== 'function')
-      throw new Error('trustedOrigins should be a function')
-    const resolvedOrigins = await trustedOrigins()
-
-    expect(trustedOriginsFn).toHaveBeenCalledTimes(1)
-    expect(resolvedOrigins).toEqual(['https://foo.workers.dev', 'http://localhost:3002', 'http://192.168.1.50:3002'])
+  it.each([
+    ['VERCEL_URL', 'deployment.vercel.app', 'https://deployment.vercel.app'],
+    ['CF_PAGES_URL', 'https://deployment.pages.dev', 'https://deployment.pages.dev'],
+    ['URL', 'https://deployment.netlify.app', 'https://deployment.netlify.app'],
+  ])('preserves %s across requests with different forwarded hosts', async (name, value, expected) => {
+    vi.stubEnv(name, value)
+    const first = await authOptions(createEvent('request.example.com', 'first.example.com'))
+    const second = await authOptions(createEvent('request.example.com', 'second.example.com'))
+    expect(first.baseURL).toBe(expected)
+    expect(second.baseURL).toBe(expected)
   })
 
-  it('adds request origin for --host style access', async () => {
-    const trustedOrigins = withDevTrustedOrigins(undefined, {
-      isDev: true,
-      isPrerender: false,
-      env: {
-        NITRO_HOST: '0.0.0.0',
-        NITRO_PORT: '3000',
-      },
-    })
-
-    expect(typeof trustedOrigins).toBe('function')
-    if (typeof trustedOrigins !== 'function')
-      throw new Error('trustedOrigins should be a function')
-    const request = new Request('http://192.168.1.20:3000/api/auth/sign-in')
-    const resolvedOrigins = await trustedOrigins(request)
-
-    expect(resolvedOrigins).toContain('http://localhost:3000')
-    expect(resolvedOrigins).toContain('http://192.168.1.20:3000')
+  it('does not normalize an explicitly configured loopback URL', async () => {
+    runtimeConfig.public.siteUrl = 'http://127.0.0.1:3000'
+    expect((await authOptions()).baseURL).toBe('http://127.0.0.1:3000')
   })
 
-  it('does not augment in production mode', () => {
-    const trustedOrigins = withDevTrustedOrigins(undefined, {
-      isDev: false,
-      isPrerender: false,
-      env: {
-        NITRO_HOST: 'localhost',
-        NITRO_PORT: '3000',
-      },
-    })
+  it.each([undefined, ['https://trusted.example.com'], async () => ['https://trusted.example.com']])('does not augment production trusted origins: %s', async (origins) => {
+    runtimeConfig.public.siteUrl = 'https://explicit.example.com'
+    createServerAuthMock.mockReturnValue({ trustedOrigins: origins })
+    expect((await authOptions(createEvent())).trustedOrigins).toBe(origins)
+  })
+})
 
-    expect(trustedOrigins).toBeUndefined()
+describe.runIf(Boolean(import.meta.dev))('serverAuth development origins', () => {
+  it('prefers the current request over platform and dev proxy URLs', async () => {
+    vi.stubEnv('VERCEL_URL', 'deployment.vercel.app')
+    vi.stubEnv('__NUXT_DEV__', JSON.stringify({ proxy: { url: 'http://localhost:4000' } }))
+    expect((await authOptions(createEvent('lan-host.local:3000'))).baseURL).toBe('http://lan-host.local:3000')
   })
 
-  it('augments even when siteUrl is inferred', async () => {
-    const trustedOrigins = withDevTrustedOrigins(['https://foo.workers.dev'], {
-      isDev: true,
-      isPrerender: false,
-      env: {
-        NITRO_HOST: 'localhost',
-        NITRO_PORT: '3000',
-      },
-    })
-
-    expect(typeof trustedOrigins).toBe('function')
-    if (typeof trustedOrigins !== 'function')
-      throw new Error('trustedOrigins should be a function')
-
-    const resolvedOrigins = await trustedOrigins()
-    expect(resolvedOrigins).toEqual(['https://foo.workers.dev', 'http://localhost:3000'])
+  it('supports forwarded hosts and protocols for development proxies', async () => {
+    expect((await authOptions(createEvent('localhost:3000', 'dev.example.com'))).baseURL).toBe('https://dev.example.com')
   })
 
-  it('adds loopback request origins regardless of alias order', async () => {
-    const trustedOrigins = withDevTrustedOrigins(undefined, {
-      isDev: true,
-      isPrerender: false,
-      env: {
-        NITRO_HOST: 'localhost',
-        NITRO_PORT: '3000',
-      },
-    })
+  it('resolves separate development requests independently', async () => {
+    expect((await authOptions(createEvent('first.local:3000'))).baseURL).toBe('http://first.local:3000')
+    expect((await authOptions(createEvent('second.local:3000'))).baseURL).toBe('http://second.local:3000')
+  })
 
-    expect(typeof trustedOrigins).toBe('function')
-    if (typeof trustedOrigins !== 'function')
-      throw new Error('trustedOrigins should be a function')
+  it.each(['127.0.0.1:3000', '[::1]:3000'])('normalizes loopback request %s', async (host) => {
+    expect((await authOptions(createEvent(host))).baseURL).toBe('http://localhost:3000')
+  })
 
-    const localhostRequestOrigins = await trustedOrigins(new Request('http://localhost:3000/api/auth/sign-in'))
-    const loopbackRequestOrigins = await trustedOrigins(new Request('http://127.0.0.1:3000/api/auth/sign-in'))
+  it('normalizes an explicit loopback URL', async () => {
+    runtimeConfig.public.siteUrl = 'http://127.0.0.1:3000'
+    expect((await authOptions()).baseURL).toBe('http://localhost:3000')
+  })
 
-    expect(localhostRequestOrigins).toEqual(['http://localhost:3000'])
-    expect(loopbackRequestOrigins).toEqual(['http://localhost:3000', 'http://127.0.0.1:3000'])
+  it.each([
+    [{ NITRO_HOST: 'localhost', NITRO_PORT: '4000' }, 'http://localhost:4000'],
+    [{ HOST: 'localhost' }, 'http://localhost:3000'],
+    [{ HOST: 'localhost', NITRO_SSL_CERT: 'cert', NITRO_SSL_KEY: 'key' }, 'https://localhost:3000'],
+    [{ __NUXT_DEV__: JSON.stringify({ proxy: { url: 'http://localhost:4001' } }) }, 'http://localhost:4001'],
+    [{ NUXT_VITE_NODE_OPTIONS: JSON.stringify({ baseURL: 'http://localhost:4002/__nuxt_vite_node__' }) }, 'http://localhost:4002'],
+    [{ __NUXT_DEV__: 'invalid-json', HOST: 'localhost' }, 'http://localhost:3000'],
+    [{}, 'http://localhost:3000'],
+  ])('resolves development environment %j', async (env, expected) => {
+    for (const [name, value] of Object.entries(env))
+      vi.stubEnv(name, value)
+    expect((await authOptions()).baseURL).toBe(expected)
+  })
+
+  it('adds the detected localhost and loopback origins', async () => {
+    vi.stubEnv('__NUXT_DEV__', JSON.stringify({ proxy: { url: 'http://127.0.0.1:4123' } }))
+    expect(await trustedOrigins()).toEqual(['http://localhost:4123', 'http://127.0.0.1:4123'])
+  })
+
+  it('preserves and deduplicates configured trusted origins', async () => {
+    runtimeConfig.public.siteUrl = 'https://explicit.example.com'
+    vi.stubEnv('NITRO_HOST', 'localhost')
+    vi.stubEnv('NITRO_PORT', '3001')
+    createServerAuthMock.mockReturnValue({ trustedOrigins: ['https://explicit.example.com', 'http://localhost:3001'] })
+    expect(await trustedOrigins()).toEqual(['https://explicit.example.com', 'http://localhost:3001'])
+  })
+
+  it('passes the request to async trusted origins and appends dev origins', async () => {
+    vi.stubEnv('NITRO_HOST', '192.168.1.50')
+    vi.stubEnv('NITRO_PORT', '3002')
+    const origins = vi.fn(async () => ['https://trusted.example.com', undefined, null, 'http://localhost:3002'])
+    createServerAuthMock.mockReturnValue({ trustedOrigins: origins })
+    const request = new Request('http://192.168.1.20:3002/api/auth/sign-in')
+    expect(await trustedOrigins(request)).toEqual([
+      'https://trusted.example.com',
+      'http://localhost:3002',
+      'http://192.168.1.50:3002',
+      'http://192.168.1.20:3002',
+    ])
+    expect(origins).toHaveBeenCalledExactlyOnceWith(request)
+  })
+
+  it('augments trusted origins when siteUrl is inferred', async () => {
+    createServerAuthMock.mockReturnValue({ trustedOrigins: ['https://trusted.example.com'] })
+    expect(await trustedOrigins()).toEqual(['https://trusted.example.com', 'http://localhost:3000'])
+  })
+
+  it('uses each callback request origin without retaining the previous origin', async () => {
+    const options = await authOptions()
+    if (typeof options.trustedOrigins !== 'function')
+      throw new TypeError('Expected development trustedOrigins callback')
+    const loopback = new Request('http://127.0.0.1:3000/api/auth/sign-in')
+    const localhost = new Request('http://localhost:3000/api/auth/sign-in')
+    expect(await options.trustedOrigins(loopback)).toEqual(['http://localhost:3000', 'http://127.0.0.1:3000'])
+    expect(await options.trustedOrigins(localhost)).toEqual(['http://localhost:3000'])
   })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -47,6 +47,10 @@ export default defineConfig({
     globalSetup: ['./test/setup/build-package.ts'],
     projects: [
       {
+        define: {
+          'import.meta.dev': 'false',
+          'import.meta.prerender': 'false',
+        },
         resolve: {
           alias: nitroCompatibilityAlias,
         },
@@ -54,6 +58,20 @@ export default defineConfig({
           name: 'unit',
           include: ['test/**/*.test.ts'],
           exclude: [...configDefaults.exclude, ...typeTests, ...integrationTests],
+        },
+      },
+      {
+        // Exercise the same auth implementation with Nuxt's development flags.
+        define: {
+          'import.meta.dev': 'true',
+          'import.meta.prerender': 'false',
+        },
+        resolve: {
+          alias: nitroCompatibilityAlias,
+        },
+        test: {
+          name: 'unit-dev',
+          include: ['test/get-base-url.test.ts'],
         },
       },
       {


### PR DESCRIPTION
The origin tests copied resolver logic and still expected request headers to determine the production URL, even though the runtime now rejects that behavior. Replace those copies with tests that call `serverAuth()` and use H3's real header helpers.

Run the tests with development and production build flags to cover explicit and platform URLs, rejection of production request inference, development proxies, loopback normalization, and trusted-origin callbacks. Production code and public APIs are unchanged.

Validation:
- All 303 unit tests passed across the `unit` and `unit-dev` projects.
- Repository lint and `git diff --check` passed.
- Temporarily restoring production request-origin inference caused five new tests to fail. Restored the correct implementation before the passing run.
