### PR TITLE
fix: register route access middleware

### DIFF
--- a/src/module/hooks.ts
+++ b/src/module/hooks.ts
@@ -1,7 +1,7 @@
 import type { Nuxt, NuxtPage } from '@nuxt/schema'
 import type { AuthRouteRules } from '../runtime/types'
 import { existsSync, statSync } from 'node:fs'
-import { addComponentsDir, addImports, addPlugin, addServerHandler, addServerImports, addServerScanDir, extendPages, updateTemplates } from '@nuxt/kit'
+import { addComponentsDir, addImports, addPlugin, addServerHandler, addServerImports, extendPages, updateTemplates } from '@nuxt/kit'
 import { defu } from 'defu'
 import { isAbsolute, join } from 'pathe'
 import { createRouter, toRouteMatcher } from 'radix3'
@@ -44,7 +44,7 @@ export function registerServerRuntime(input: RegisterServerRuntimeInput): void {
       ...['getRequestSession', 'getUserSession', 'setRequestSession', 'refreshSessionCookieCache', 'setSessionCookie', 'createSession', 'requireUserSession']
         .map(name => ({ name, from: resolve('./runtime/server/utils/session') })),
     ])
-    addServerScanDir(resolve('./runtime/server/middleware'))
+    addServerHandler({ middleware: true, handler: resolve('./runtime/server/middleware/route-access') })
     addServerHandler({ route: '/api/auth/**', handler: resolve('./runtime/server/api/auth/[...all]') })
   }
 

--- a/test/cases/core-auth/nuxt.config.ts
+++ b/test/cases/core-auth/nuxt.config.ts
@@ -9,6 +9,7 @@ export default defineNuxtConfig({
   },
 
   routeRules: {
+    '/api/test/route-rule-only': { auth: 'user' },
     '/protected': { auth: 'user' },
     '/admin': { auth: { user: { role: 'admin' } } },
     '/login': { auth: 'guest' },

--- a/test/cases/core-auth/server/api/test/route-rule-only.get.ts
+++ b/test/cases/core-auth/server/api/test/route-rule-only.get.ts
@@ -1,0 +1,1 @@
+export default defineEventHandler(() => ({ exposed: true }))

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -75,6 +75,11 @@ describe('nuxt-better-auth module', async () => {
   })
 
   describe('aPI protection', () => {
+    it('enforces auth route rules before app API handlers run', async () => {
+      const response = await fetch(url('/api/test/route-rule-only'))
+      expect(response.status).toBe(401)
+    })
+
     it('returns 401 on protected API without auth', async () => {
       const response = await fetch(url('/api/test/me'))
       expect(response.status).toBe(401)
@@ -100,6 +105,10 @@ describe('nuxt-better-auth module', async () => {
       expect(meRes.status).toBe(200)
       const data = await meRes.json()
       expect(data.email).toBe(testUser.email)
+
+      const routeRuleRes = await fetch(url('/api/test/route-rule-only'), { headers: { cookie: cookies } })
+      expect(routeRuleRes.status).toBe(200)
+      await expect(routeRuleRes.json()).resolves.toEqual({ exposed: true })
     })
 
     it('preserves Date fields in the SSR plugin and explicit session refresh', async () => {


### PR DESCRIPTION
## Summary

- register the Better Auth route-access middleware explicitly with Nuxt Kit
- add an API route protected only by `routeRules.auth`
- verify unauthenticated requests receive 401 and authenticated requests still succeed

## Why

`addServerScanDir` expects a server-root-shaped directory and scans its `middleware/` child. The module passed the middleware directory itself, so Nitro discovered no route-access middleware and documented API route rules did not run.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm vitest run test/module.test.ts test/route-access-middleware.test.ts --project unit --project integration` (18 tests)