### PR TITLE
fix(types): align root package declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/types.d.mts",
+      "types": "./dist/module.d.mts",
       "import": "./dist/module.mjs"
     },
     "./composables": {
@@ -29,7 +29,7 @@
   "typesVersions": {
     "*": {
       ".": [
-        "./dist/types.d.mts"
+        "./dist/module.d.mts"
       ],
       "composables": [
         "./dist/runtime/composables.d.ts"

--- a/src/module.ts
+++ b/src/module.ts
@@ -259,4 +259,5 @@ export default defineNuxtModule<BetterAuthModuleOptions>({
 })
 
 export { defineClientAuth, defineServerAuth } from './runtime/config'
-export type { AppSession, Auth, AuthActionError, AuthMeta, AuthMode, AuthRouteRules, AuthSession, AuthSocialProviderId, AuthUser, InferSession, InferUser, RequireSessionOptions, ServerAuthContext, UserMatch } from './runtime/types'
+export type ModuleOptions = Partial<BetterAuthModuleOptions>
+export type { AppSession, Auth, AuthActionError, AuthMeta, AuthMode, AuthRouteRules, AuthSession, AuthSocialProviderId, AuthUser, ClientAuthSession, InferSession, InferUser, RequireSessionOptions, ServerAuthContext, UserMatch } from './runtime/types'

--- a/test/cases/composables-subpath-import/root-typecheck-target.ts
+++ b/test/cases/composables-subpath-import/root-typecheck-target.ts
@@ -1,0 +1,12 @@
+import type { ClientAuthSession, ModuleOptions } from '@nuxtjs/better-auth'
+import { defineClientAuth, defineServerAuth } from '@nuxtjs/better-auth'
+
+declare const session: ClientAuthSession
+const options: ModuleOptions = { clientOnly: true }
+
+void (session.id satisfies string)
+// @ts-expect-error Session tokens are server-only.
+void session.token
+void options
+void defineClientAuth({})
+void defineServerAuth({})

--- a/test/cases/composables-subpath-import/tsconfig.type-check.json
+++ b/test/cases/composables-subpath-import/tsconfig.type-check.json
@@ -9,6 +9,7 @@
     "./.nuxt/types/nuxt-better-auth-infer.d.ts",
     "./.nuxt/types/nuxt-better-auth-social-providers.d.ts",
     "./.nuxt/types/nuxt-better-auth-endpoints.d.ts",
+    "./root-typecheck-target.ts",
     "./typecheck-target.ts"
   ]
 }


### PR DESCRIPTION
Points the root package type condition at the declarations that actually describe its runtime exports, restores the standard ModuleOptions alias, and exports the documented ClientAuthSession type. The packaged consumer contract imports both root helper values and verifies client sessions exclude tokens.\n\nVerification: module build, packaged consumer typecheck, and focused ESLint.