### PR TITLE
docs: correct auth security and migration guidance

### DIFF
--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -65,13 +65,13 @@ You can define auth route rules in either `routeRules` or `nitro.routeRules`. Th
   ::field{name="serverConfig" type="string"}
     Default: `'server/auth.config'`
 
-    Path to the server auth config file, relative to the project root.
+    Path to the server auth config file. Relative paths resolve from the Nuxt layer that declares this option. Paths declared by the app resolve from the project root.
   ::
 
   ::field{name="clientConfig" type="string"}
     Default: `'app/auth.config'`
 
-    Path to the client auth config file, relative to the project root.
+    Path to the client auth config file. Relative paths resolve from the Nuxt layer that declares this option. Paths declared by the app resolve from the project root.
   ::
 
   ::field{name="redirects" type="{ login?: string, guest?: string, authenticated?: string, logout?: string }"}

--- a/docs/content/2.core-concepts/3.route-protection.md
+++ b/docs/content/2.core-concepts/3.route-protection.md
@@ -202,12 +202,33 @@ When preserving the original URL for post-login redirects, validate it to preven
 const route = useRoute()
 const signInEmail = useSignIn('email')
 
-function getSafeRedirect() {
-  const redirect = route.query.redirect as string
-  if (!redirect || !redirect.startsWith('/') || redirect.startsWith('//')) {
-    return '/'
+function isSafeLocalRedirect(value: unknown): value is string {
+  if (
+    typeof value !== 'string'
+    || !value.startsWith('/')
+    || value.startsWith('//')
+    || value.includes('\\')
+    || /[\u0000-\u001F\u007F]/.test(value)
+    || /%2f|%5c/i.test(value)
+  ) {
+    return false
   }
-  return redirect
+
+  try {
+    const parsed = new URL(value, 'https://app.invalid')
+    return parsed.origin === 'https://app.invalid'
+      && !parsed.pathname.startsWith('//')
+  }
+  catch {
+    return false
+  }
+}
+
+function getSafeRedirect(): string {
+  const redirect = route.query.redirect
+  return isSafeLocalRedirect(redirect)
+    ? redirect
+    : '/'
 }
 
 async function login(email: string, password: string) {
@@ -249,15 +270,15 @@ export default defineWebSocketHandler({
 
 ## CSRF Protection
 
-Better Auth includes CSRF protection by default. Always use the auth client methods instead of raw `fetch`:
+Better Auth checks request origins for state-changing auth requests. This protection applies whether you use an auth client method or raw `fetch`.
+
+Prefer the module composables and Better Auth client methods because they provide the expected request shape, typed responses, and error handling:
 
 ```ts
-// ✓ Correct: uses auth client
 await useSignIn('email').execute({ email, password })
-
-// ✗ Incorrect: bypasses CSRF protection
-await fetch('/api/auth/sign-in/email', { method: 'POST', body: JSON.stringify({ email, password }) })
 ```
+
+If you call an auth endpoint with `fetch`, follow Better Auth's endpoint contract and include credentials for cross-origin cookie requests. Do not disable origin checks to make a cross-origin request work. Add the frontend origin to `trustedOrigins` on the auth server instead.
 
 :read-more{to="/core-concepts/security-caveats" title="Security Caveats"}
 

--- a/docs/content/2.core-concepts/3.route-protection.md
+++ b/docs/content/2.core-concepts/3.route-protection.md
@@ -218,9 +218,11 @@ function isSafeLocalRedirect(value: unknown): value is string {
   try {
     // Decode only for validation so encoded traversal cannot become an authority.
     const decoded = decodeURIComponent(value)
+    const decodedURL = new URL(decoded, 'https://app.invalid')
     if (
       decoded.startsWith('//')
-      || decoded.includes('\\')
+      || decodedURL.origin !== 'https://app.invalid'
+      || decodedURL.pathname.startsWith('//')
       || /(?:^|\/)(?:\.{2})(?:\/|$)/.test(decoded)
     ) {
       return false

--- a/docs/content/2.core-concepts/3.route-protection.md
+++ b/docs/content/2.core-concepts/3.route-protection.md
@@ -209,7 +209,6 @@ function isSafeLocalRedirect(value: unknown): value is string {
     || value.startsWith('//')
     || value.includes('\\')
     || /[\u0000-\u001F\u007F]/.test(value)
-    || /%2f|%5c/i.test(value)
   ) {
     return false
   }

--- a/docs/content/2.core-concepts/3.route-protection.md
+++ b/docs/content/2.core-concepts/3.route-protection.md
@@ -208,6 +208,7 @@ function isSafeLocalRedirect(value: unknown): value is string {
     || !value.startsWith('/')
     || value.startsWith('//')
     || /^\/(?:%2f|%5c)/i.test(value)
+    || /(?:^|\/)(?:%2e){2}(?:%2f|%5c)/i.test(value)
     || value.includes('\\')
     || /[\u0000-\u001F\u007F]/.test(value)
   ) {

--- a/docs/content/2.core-concepts/3.route-protection.md
+++ b/docs/content/2.core-concepts/3.route-protection.md
@@ -208,7 +208,6 @@ function isSafeLocalRedirect(value: unknown): value is string {
     || !value.startsWith('/')
     || value.startsWith('//')
     || value.includes('\\')
-    || /%(?:2f|5c)/i.test(value)
     || /[\u0000-\u001F\u007F]/.test(value)
   ) {
     return false
@@ -240,7 +239,7 @@ async function login(email: string, password: string) {
 ```
 
 ::warning
-Always validate redirect URLs. Accepting arbitrary URLs allows attackers to redirect users to malicious sites after login.
+Always validate redirect URLs. Accepting arbitrary URLs allows attackers to redirect users to malicious sites after login. Pass the validated value unchanged to `navigateTo`; do not decode it again after validation. Encoded separators can be valid route data, such as `/files/a%2Fb`, and do not change the parsed URL's origin.
 ::
 
 ## Advanced API Patterns

--- a/docs/content/2.core-concepts/3.route-protection.md
+++ b/docs/content/2.core-concepts/3.route-protection.md
@@ -216,6 +216,16 @@ function isSafeLocalRedirect(value: unknown): value is string {
   }
 
   try {
+    // Decode only for validation so encoded traversal cannot become an authority.
+    const decoded = decodeURIComponent(value)
+    if (
+      decoded.startsWith('//')
+      || decoded.includes('\\')
+      || /(?:^|\/)(?:\.{2})(?:\/|$)/.test(decoded)
+    ) {
+      return false
+    }
+
     const parsed = new URL(value, 'https://app.invalid')
     return parsed.origin === 'https://app.invalid'
       && !parsed.pathname.startsWith('//')

--- a/docs/content/2.core-concepts/3.route-protection.md
+++ b/docs/content/2.core-concepts/3.route-protection.md
@@ -207,8 +207,6 @@ function isSafeLocalRedirect(value: unknown): value is string {
     typeof value !== 'string'
     || !value.startsWith('/')
     || value.startsWith('//')
-    || /^\/(?:%2f|%5c)/i.test(value)
-    || /(?:^|\/)(?:%2e){2}(?:%2f|%5c)/i.test(value)
     || value.includes('\\')
     || /[\u0000-\u001F\u007F]/.test(value)
   ) {
@@ -216,20 +214,17 @@ function isSafeLocalRedirect(value: unknown): value is string {
   }
 
   try {
-    // Decode only for validation so encoded traversal cannot become an authority.
-    const decoded = decodeURIComponent(value)
-    const decodedURL = new URL(decoded, 'https://app.invalid')
-    if (
-      decoded.startsWith('//')
-      || decodedURL.origin !== 'https://app.invalid'
-      || /(?:^|\/)(?:\.{2})(?:\/|$)/.test(decoded)
-    ) {
+    const origin = 'https://app.invalid'
+    const parsed = new URL(value, origin)
+    if (parsed.origin !== origin || parsed.pathname.startsWith('//')) {
       return false
     }
 
-    const parsed = new URL(value, 'https://app.invalid')
-    return parsed.origin === 'https://app.invalid'
-      && !parsed.pathname.startsWith('//')
+    // Normalize encoded path separators only for validation.
+    const normalizedPath = parsed.pathname.replace(/%(?:2f|5c)/gi, '/')
+    const normalized = new URL(normalizedPath, origin)
+    return normalized.origin === origin
+      && !normalized.pathname.startsWith('//')
   }
   catch {
     return false

--- a/docs/content/2.core-concepts/3.route-protection.md
+++ b/docs/content/2.core-concepts/3.route-protection.md
@@ -222,7 +222,6 @@ function isSafeLocalRedirect(value: unknown): value is string {
     if (
       decoded.startsWith('//')
       || decodedURL.origin !== 'https://app.invalid'
-      || decodedURL.pathname.startsWith('//')
       || /(?:^|\/)(?:\.{2})(?:\/|$)/.test(decoded)
     ) {
       return false

--- a/docs/content/2.core-concepts/3.route-protection.md
+++ b/docs/content/2.core-concepts/3.route-protection.md
@@ -208,6 +208,7 @@ function isSafeLocalRedirect(value: unknown): value is string {
     || !value.startsWith('/')
     || value.startsWith('//')
     || value.includes('\\')
+    || /%(?:2f|5c)/i.test(value)
     || /[\u0000-\u001F\u007F]/.test(value)
   ) {
     return false

--- a/docs/content/2.core-concepts/3.route-protection.md
+++ b/docs/content/2.core-concepts/3.route-protection.md
@@ -207,6 +207,7 @@ function isSafeLocalRedirect(value: unknown): value is string {
     typeof value !== 'string'
     || !value.startsWith('/')
     || value.startsWith('//')
+    || /^\/(?:%2f|%5c)/i.test(value)
     || value.includes('\\')
     || /[\u0000-\u001F\u007F]/.test(value)
   ) {

--- a/docs/content/3.guides/5.external-auth-backend.md
+++ b/docs/content/3.guides/5.external-auth-backend.md
@@ -29,14 +29,21 @@ export default defineNuxtConfig({
 
 ### 2. Point the Client to the External Server
 
-`defineClientAuth` is wrapped by the module at runtime, so `baseURL` here is **overridden**.
-To target an external auth server, set the site URL:
+Set the site URL to your external auth server:
 
 ```ini [.env]
 NUXT_PUBLIC_SITE_URL="https://auth.example.com"
 ```
 
-This value becomes the Better Auth client base URL in client-only mode.
+This value becomes the default Better Auth client base URL in client-only mode. You can instead set `baseURL` in the client config. An explicit client config value takes precedence over the site URL:
+
+```ts [app/auth.config.ts]
+import { defineClientAuth } from '@nuxtjs/better-auth/config'
+
+export default defineClientAuth({
+  baseURL: 'https://auth.example.com',
+})
+```
 
 ### 3. Configure Route Redirect Targets (Optional)
 
@@ -76,7 +83,7 @@ In client-only mode, all auth requests go directly to your external server. Ensu
 ::
 
 ::note
-In client-only mode, `NUXT_PUBLIC_SITE_URL` is used as the auth client base URL.
+In client-only mode, `NUXT_PUBLIC_SITE_URL` is used as the auth client base URL unless `defineClientAuth` provides an explicit `baseURL`.
 Use `routeRules.auth.redirectTo` (or page meta `auth.redirectTo`) to control frontend navigation paths.
 ::
 

--- a/docs/content/3.guides/6.migrate-from-nuxt-auth-utils.md
+++ b/docs/content/3.guides/6.migrate-from-nuxt-auth-utils.md
@@ -237,52 +237,32 @@ const { user } = await requireUserSession(event, {
 ### Password Hashing Migration
 
 ::important
-nuxt-auth-utils uses **scrypt** for password hashing. Better Auth also uses **scrypt** by default (unless you configured a custom password hasher). If you used defaults in both systems, existing password hashes should continue to work.
+nuxt-auth-utils and Better Auth both use scrypt by default, but their hashes are not compatible. nuxt-auth-utils stores an Adonis-style PHC string such as `$scrypt$...`. Better Auth uses a different `salt:key` encoding and different default scrypt parameters. Better Auth cannot verify an unchanged nuxt-auth-utils hash.
 ::
 
-#### Step 0: Validate Hash Compatibility (Recommended)
+#### Step 0: Test the Migration
 
-Before doing any migration work, validate that a known test user's password hash verifies correctly in a staging environment.
+Before the cutover, generate a password hash with the nuxt-auth-utils version used by your app. Assert that your migration path accepts the password, then assert that Better Auth can authenticate the account after its password is reset or re-hashed.
 
-If you used the **default** nuxt-auth-utils hashing settings, you can usually keep existing hashes without any migration.
-
-If you customized hashing in nuxt-auth-utils or Better Auth, treat this as a migration and use one of the options below.
+Do not remove the old verifier, auth secret, or rollback data until this test passes in staging. If you customized either password hasher, test hashes created with your exact production settings.
 
 #### Option 1: Require Password Resets
 
-The simplest approach: require all users to reset their passwords during migration.
+The simplest approach is to require all users to reset their passwords during migration.
 
-1. Set all user passwords to `null` in your database
-2. Direct users to password reset flow on first login
-3. New passwords will use Argon2id
+1. Do not import a legacy hash as a usable Better Auth credential
+2. Direct users through a verified password-reset flow
+3. Let Better Auth hash the new password with the hasher configured in `emailAndPassword.password` (scrypt by default)
 
 #### Option 2: Support Both Hash Formats (Custom Hashing)
 
-Implement a custom password verifier that tries both formats:
+Configure both `emailAndPassword.password.hash` and `emailAndPassword.password.verify`. The verifier must recognize the stored format and support both legacy nuxt-auth-utils hashes and new Better Auth hashes. Use Better Auth's `hashPassword` and `verifyPassword` exports from `better-auth/crypto` for its current format, and keep a tested implementation for the exact legacy format you used.
 
-```ts [server/auth.config.ts]
-import { scrypt, timingSafeEqual } from 'node:crypto'
-import { defineServerAuth } from '@nuxtjs/better-auth/config'
-
-async function verifyLegacyHash(password: string, hash: string): Promise<boolean> {
-  // Implement scrypt verification for legacy hashes
-  // Return true if password matches legacy hash
-}
-
-export default defineServerAuth({
-  // Custom verification logic
-})
-```
+A custom `verify` function replaces Better Auth's default verifier for every password check. Supporting only the legacy format will lock out users after they set a new password.
 
 #### Option 3: Gradual Migration (Custom Hashing)
 
-Verify with scrypt first, then re-hash with Argon2id on successful login:
-
-```ts
-// On successful legacy verification:
-const newHash = await hashPassword(password) // Argon2id
-await updateUserPassword(userId, newHash)
-```
+After the dual-format verifier accepts a legacy hash, replace that stored hash with a value from your configured Better Auth `hash` function. Better Auth does not automatically re-hash legacy values, so implement and test this database update as part of your migration flow. Keep password resets available as a fallback.
 
 ### WebAuthn Migration
 

--- a/docs/content/3.guides/7.two-factor-auth.md
+++ b/docs/content/3.guides/7.two-factor-auth.md
@@ -162,21 +162,9 @@ Display backup codes to users during 2FA setup. Each code can only be used once.
 
 ### Admin Recovery
 
-For users who lose their device and backup codes, implement an admin recovery flow:
+Better Auth's admin plugin does not provide an API for disabling another user's two-factor authentication. The `twoFactor.disable` method applies to the current user and requires their password.
 
-```ts [server/api/admin/reset-2fa.ts]
-export default defineEventHandler(async (event) => {
-  await requireUserSession(event, { user: { role: 'admin' } })
-
-  const { userId } = await readBody(event)
-  const auth = serverAuth(event)
-
-  // Reset 2FA for user (requires admin plugin)
-  await auth.api.admin.disableTwoFactor({ userId })
-
-  return { success: true }
-})
-```
+Use backup codes or a verified account-recovery process for users who lose every second factor. If your application adds an admin-assisted reset, implement it as an application-owned security flow with administrator re-authentication, an audit log, user notification, and session revocation. Do not call `auth.api.admin.disableTwoFactor`; that method does not exist.
 
 ::callout{icon="i-lucide-link" to="https://better-auth.com/docs/plugins/2fa"}
 See the Better Auth 2FA docs for provider options and OTP flows.

--- a/docs/public/.well-known/skills/nuxt-better-auth/references/client-only.md
+++ b/docs/public/.well-known/skills/nuxt-better-auth/references/client-only.md
@@ -17,6 +17,14 @@ export default defineNuxtConfig({
 NUXT_PUBLIC_SITE_URL=https://auth.example.com
 ```
 
+The site URL is the default auth client base URL. An explicit client config value takes precedence:
+
+```ts
+export default defineClientAuth({
+  baseURL: 'https://auth.example.com',
+})
+```
+
 ## What changes
 
 - no local `/api/auth/**` handlers


### PR DESCRIPTION
## Summary

- correct nuxt-auth-utils password migration: both defaults use scrypt, but their formats and parameters are incompatible
- remove a nonexistent admin two-factor API example
- document explicit client `baseURL` precedence and layer-relative config paths
- explain that Better Auth origin checks also apply to raw fetch requests
- harden the safe local-redirect example

## Why

These examples could cause failed password migrations, calls to an API Better Auth does not expose, and incorrect security assumptions.

## Verification

- `pnpm vitest run test/public-skill.test.ts test/client-auth-config.test.ts test/config-paths.test.ts` (13 tests)
- `pnpm build:docs`
- focused redirect validator exercise (9 cases)
- `git diff --check`