### PR TITLE
fix: declare NuxtHub database peers

### DIFF
--- a/docs/content/4.integrations/1.nuxthub.md
+++ b/docs/content/4.integrations/1.nuxthub.md
@@ -27,12 +27,20 @@ Use this guide when you want the shortest path to database-backed auth with sche
 ### Install NuxtHub
 
 ```bash
-pnpm add @nuxthub/core@^0.10.5
+pnpm add @nuxthub/core@^0.10.5 drizzle-orm@^0.45.2
 ```
 
 ::important
 Version 0.10.5 or later is required. Earlier versions cause runtime errors in development mode.
 ::
+
+`drizzle-orm` is required for every NuxtHub database dialect. PostgreSQL and Hyperdrive setups also need the `postgres` driver:
+
+```bash
+pnpm add postgres@^3.4.9
+```
+
+Apps that do not use a NuxtHub database do not need either package.
 
 ### Configure nuxt.config.ts
 

--- a/docs/content/4.integrations/1.nuxthub.md
+++ b/docs/content/4.integrations/1.nuxthub.md
@@ -42,6 +42,8 @@ pnpm add postgres@^3.4.9
 
 Apps that do not use a NuxtHub database do not need either package.
 
+Install the client package for your [NuxtHub database driver](https://hub.nuxt.com/docs/database) too: `@libsql/client` for `libsql`, `mysql2` for MySQL, `@electric-sql/pglite` for PGlite, or `@neondatabase/serverless` for Neon. D1 does not need a separate client package. The module checks the resolved driver during setup and reports missing packages with an install command.
+
 ### Configure nuxt.config.ts
 
 ```ts [nuxt.config.ts]

--- a/package.json
+++ b/package.json
@@ -64,10 +64,18 @@
   },
   "peerDependencies": {
     "@nuxthub/core": ">=0.10.5",
-    "better-auth": ">=1.7.3 <2"
+    "better-auth": ">=1.7.3 <2",
+    "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0",
+    "postgres": "^3.4.9"
   },
   "peerDependenciesMeta": {
     "@nuxthub/core": {
+      "optional": true
+    },
+    "drizzle-orm": {
+      "optional": true
+    },
+    "postgres": {
       "optional": true
     }
   },

--- a/src/module/hub.ts
+++ b/src/module/hub.ts
@@ -1,9 +1,10 @@
 import type { SchemaCasing } from '../runtime/config'
 
 export type DbDialect = 'sqlite' | 'postgresql' | 'mysql'
+export type DbDriver = 'd1' | 'd1-http' | 'postgres-js' | 'neon-http' | 'libsql' | 'mysql2' | 'pglite'
 
 export interface NuxtHubOptions {
-  db?: boolean | DbDialect | { dialect?: DbDialect, casing?: SchemaCasing }
+  db?: boolean | DbDialect | { dialect?: DbDialect, casing?: SchemaCasing, driver?: DbDriver }
   kv?: boolean
 }
 

--- a/src/module/setup.ts
+++ b/src/module/setup.ts
@@ -7,7 +7,7 @@ import type {
   BetterAuthPluginSources,
 } from '../types/hooks'
 import type { AuthConfigDescriptor } from './config-paths'
-import type { NuxtHubOptions } from './hub'
+import type { DbDriver, NuxtHubOptions } from './hub'
 import { createRequire } from 'node:module'
 import { hasNuxtModule } from '@nuxt/kit'
 import { dirname, join } from 'pathe'
@@ -90,12 +90,23 @@ function packageExists(packageName: string, rootDir: string): boolean {
 
 function assertNuxtHubDatabaseDependencies(
   dialect: BetterAuthDatabaseProviderBuildContext['hubDialect'],
+  driver: DbDriver | undefined,
   rootDir: string,
   packageExistsFn: NonNullable<ResolveAuthModuleSetupDependencies['packageExists']>,
 ): void {
   const requiredPackages = dialect === 'postgresql'
     ? ['drizzle-orm', 'postgres']
     : ['drizzle-orm']
+  const driverPackages: Partial<Record<DbDriver, string>> = {
+    'postgres-js': 'postgres',
+    'neon-http': '@neondatabase/serverless',
+    'libsql': '@libsql/client',
+    'mysql2': 'mysql2',
+    'pglite': '@electric-sql/pglite',
+  }
+  const driverPackage = driver && driverPackages[driver]
+  if (driverPackage && !requiredPackages.includes(driverPackage))
+    requiredPackages.push(driverPackage)
   const missingPackages = requiredPackages.filter(packageName => !packageExistsFn(packageName, rootDir))
 
   if (!missingPackages.length)
@@ -231,6 +242,7 @@ export async function resolveAuthModuleSetup(
   if (hasHubDb) {
     assertNuxtHubDatabaseDependencies(
       hubDialect,
+      typeof hub?.db === 'object' ? hub.db.driver : undefined,
       nuxt.options.rootDir,
       dependencies.packageExists ?? packageExists,
     )

--- a/src/module/setup.ts
+++ b/src/module/setup.ts
@@ -240,9 +240,13 @@ export async function resolveAuthModuleSetup(
     throw new Error('[nuxt-better-auth] hub:db not found. Ensure @nuxthub/core is loaded before this module and hub.db is configured.')
   }
   if (hasHubDb) {
+    // NuxtHub publishes driver defaults and hosting overrides in runtimeConfig.
+    const resolvedHub = (nuxt.options.runtimeConfig as { hub?: NuxtHubOptions }).hub
+    const resolvedDriver = typeof resolvedHub?.db === 'object' ? resolvedHub.db.driver : undefined
+    const configuredDriver = typeof hub?.db === 'object' ? hub.db.driver : undefined
     assertNuxtHubDatabaseDependencies(
       hubDialect,
-      typeof hub?.db === 'object' ? hub.db.driver : undefined,
+      resolvedDriver ?? configuredDriver,
       nuxt.options.rootDir,
       dependencies.packageExists ?? packageExists,
     )

--- a/src/module/setup.ts
+++ b/src/module/setup.ts
@@ -8,8 +8,9 @@ import type {
 } from '../types/hooks'
 import type { AuthConfigDescriptor } from './config-paths'
 import type { NuxtHubOptions } from './hub'
+import { createRequire } from 'node:module'
 import { hasNuxtModule } from '@nuxt/kit'
-import { dirname } from 'pathe'
+import { dirname, join } from 'pathe'
 import { resolveDatabaseProvider } from '../database-provider'
 import { resolveAuthConfigDescriptors, resolveAuthPluginSources } from './config-paths'
 import { getHubCasing, getHubDialect } from './hub'
@@ -74,6 +75,35 @@ interface ResolveAuthModuleSetupInput {
 interface ResolveAuthModuleSetupDependencies {
   configExists?: (path: string) => boolean
   hasNuxtModule?: typeof hasNuxtModule
+  packageExists?: (packageName: string, rootDir: string) => boolean
+}
+
+function packageExists(packageName: string, rootDir: string): boolean {
+  try {
+    createRequire(join(rootDir, 'package.json')).resolve(packageName)
+    return true
+  }
+  catch {
+    return false
+  }
+}
+
+function assertNuxtHubDatabaseDependencies(
+  dialect: BetterAuthDatabaseProviderBuildContext['hubDialect'],
+  rootDir: string,
+  packageExistsFn: NonNullable<ResolveAuthModuleSetupDependencies['packageExists']>,
+): void {
+  const requiredPackages = dialect === 'postgresql'
+    ? ['drizzle-orm', 'postgres']
+    : ['drizzle-orm']
+  const missingPackages = requiredPackages.filter(packageName => !packageExistsFn(packageName, rootDir))
+
+  if (!missingPackages.length)
+    return
+
+  throw new Error(
+    `[nuxt-better-auth] NuxtHub ${dialect} support requires ${missingPackages.join(' and ')}. Install ${missingPackages.length === 1 ? 'it' : 'them'} in your Nuxt app, for example with \`pnpm add ${missingPackages.join(' ')}\`.`,
+  )
 }
 
 function assertConfigPresence(configs: ResolvedAuthModuleSetup['configs'], clientOnly: boolean): void {
@@ -197,6 +227,13 @@ export async function resolveAuthModuleSetup(
   const hasHubDb = providerId === 'nuxthub'
   if (hasHubDb && !nuxt.options.alias['hub:db']) {
     throw new Error('[nuxt-better-auth] hub:db not found. Ensure @nuxthub/core is loaded before this module and hub.db is configured.')
+  }
+  if (hasHubDb) {
+    assertNuxtHubDatabaseDependencies(
+      hubDialect,
+      nuxt.options.rootDir,
+      dependencies.packageExists ?? packageExists,
+    )
   }
 
   return {

--- a/test/module-setup.test.ts
+++ b/test/module-setup.test.ts
@@ -175,6 +175,51 @@ describe('resolveAuthModuleSetup', () => {
     expect(packageExists.mock.calls.map(([packageName]) => packageName)).toEqual(['drizzle-orm', 'postgres'])
   })
 
+  it.each([
+    ['sqlite', 'libsql', '@libsql/client'],
+    ['mysql', 'mysql2', 'mysql2'],
+    ['postgresql', 'pglite', '@electric-sql/pglite'],
+    ['postgresql', 'neon-http', '@neondatabase/serverless'],
+    ['postgresql', 'postgres-js', 'postgres'],
+  ])('checks the %s %s driver before completing setup', async (dialect, driver, driverPackage) => {
+    const nuxt = await loadCase('core-auth')
+    nuxt.options.alias['hub:db'] = '/virtual/hub-db'
+    Object.assign(nuxt.options, { hub: { db: { dialect, driver } } })
+    const input = {
+      nuxt,
+      options: createModuleOptions(nuxt),
+      runtimeTypesAugmentPath: '/virtual/runtime-types/augment',
+      consola: createConsolaMock(),
+    }
+
+    await expect(resolveAuthModuleSetup(input, {
+      packageExists: packageName => packageName !== driverPackage,
+    })).rejects.toThrow(`Install it in your Nuxt app, for example with \`pnpm add ${driverPackage}\`.`)
+
+    const installedPackages = new Set(['drizzle-orm', driverPackage])
+    if (dialect === 'postgresql')
+      installedPackages.add('postgres')
+    const setup = await resolveAuthModuleSetup(input, {
+      packageExists: packageName => installedPackages.has(packageName),
+    })
+    expect(setup.database.providerId).toBe('nuxthub')
+  })
+
+  it.each(['d1', 'd1-http'])('does not require a client package for %s', async (driver) => {
+    const nuxt = await loadCase('core-auth')
+    nuxt.options.alias['hub:db'] = '/virtual/hub-db'
+    Object.assign(nuxt.options, { hub: { db: { dialect: 'sqlite', driver } } })
+    const setup = await resolveAuthModuleSetup({
+      nuxt,
+      options: createModuleOptions(nuxt),
+      runtimeTypesAugmentPath: '/virtual/runtime-types/augment',
+      consola: createConsolaMock(),
+    }, {
+      packageExists: packageName => packageName === 'drizzle-orm',
+    })
+    expect(setup.database.providerId).toBe('nuxthub')
+  })
+
   it('supports client-only mode without server setup state', async () => {
     const nuxt = await loadCase('core-auth')
     const packageExists = vi.fn(() => false)

--- a/test/module-setup.test.ts
+++ b/test/module-setup.test.ts
@@ -85,12 +85,15 @@ describe('resolveAuthModuleSetup', () => {
 
   it('captures a non-NuxtHub setup without selecting a database provider', async () => {
     const nuxt = await loadCase('without-nuxthub')
+    const packageExists = vi.fn(() => false)
 
     const setup = await resolveAuthModuleSetup({
       nuxt,
       options: createModuleOptions(nuxt),
       runtimeTypesAugmentPath: '/virtual/runtime-types/augment',
       consola: createConsolaMock(),
+    }, {
+      packageExists,
     })
 
     expect(setup.hub.hasNuxtHub).toBe(false)
@@ -98,16 +101,91 @@ describe('resolveAuthModuleSetup', () => {
     expect(setup.database.providerId).toBe('none')
     expect(setup.database.hasHubDb).toBe(false)
     expect(setup.schemaGeneration).toBeUndefined()
+    expect(packageExists).not.toHaveBeenCalled()
+  })
+
+  it('requires drizzle-orm for a NuxtHub SQLite database', async () => {
+    const nuxt = await loadCase('core-auth')
+    nuxt.options.alias['hub:db'] = '/virtual/hub-db'
+
+    await expect(resolveAuthModuleSetup({
+      nuxt,
+      options: createModuleOptions(nuxt),
+      runtimeTypesAugmentPath: '/virtual/runtime-types/augment',
+      consola: createConsolaMock(),
+    }, {
+      packageExists: () => false,
+    })).rejects.toThrow(
+      '[nuxt-better-auth] NuxtHub sqlite support requires drizzle-orm. Install it in your Nuxt app, for example with `pnpm add drizzle-orm`.',
+    )
+  })
+
+  it('does not require postgres for a NuxtHub SQLite database', async () => {
+    const nuxt = await loadCase('core-auth')
+    const packageExists = vi.fn((packageName: string) => packageName === 'drizzle-orm')
+    nuxt.options.alias['hub:db'] = '/virtual/hub-db'
+
+    const setup = await resolveAuthModuleSetup({
+      nuxt,
+      options: createModuleOptions(nuxt),
+      runtimeTypesAugmentPath: '/virtual/runtime-types/augment',
+      consola: createConsolaMock(),
+    }, {
+      packageExists,
+    })
+
+    expect(setup.database.providerId).toBe('nuxthub')
+    expect(packageExists).toHaveBeenCalledOnce()
+    expect(packageExists).toHaveBeenCalledWith('drizzle-orm', nuxt.options.rootDir)
+  })
+
+  it('requires postgres for a NuxtHub PostgreSQL database', async () => {
+    const nuxt = await loadCase('core-auth')
+    nuxt.options.alias['hub:db'] = '/virtual/hub-db'
+    Object.assign(nuxt.options, { hub: { db: 'postgresql' } })
+
+    await expect(resolveAuthModuleSetup({
+      nuxt,
+      options: createModuleOptions(nuxt),
+      runtimeTypesAugmentPath: '/virtual/runtime-types/augment',
+      consola: createConsolaMock(),
+    }, {
+      packageExists: packageName => packageName === 'drizzle-orm',
+    })).rejects.toThrow(
+      '[nuxt-better-auth] NuxtHub postgresql support requires postgres. Install it in your Nuxt app, for example with `pnpm add postgres`.',
+    )
+  })
+
+  it('accepts a NuxtHub PostgreSQL database when both packages are installed', async () => {
+    const nuxt = await loadCase('core-auth')
+    const packageExists = vi.fn(() => true)
+    nuxt.options.alias['hub:db'] = '/virtual/hub-db'
+    Object.assign(nuxt.options, { hub: { db: 'postgresql' } })
+
+    const setup = await resolveAuthModuleSetup({
+      nuxt,
+      options: createModuleOptions(nuxt),
+      runtimeTypesAugmentPath: '/virtual/runtime-types/augment',
+      consola: createConsolaMock(),
+    }, {
+      packageExists,
+    })
+
+    expect(setup.database.providerId).toBe('nuxthub')
+    expect(packageExists.mock.calls.map(([packageName]) => packageName)).toEqual(['drizzle-orm', 'postgres'])
   })
 
   it('supports client-only mode without server setup state', async () => {
-    const nuxt = await loadCase('without-nuxthub')
+    const nuxt = await loadCase('core-auth')
+    const packageExists = vi.fn(() => false)
 
     const setup = await resolveAuthModuleSetup({
       nuxt,
       options: createModuleOptions(nuxt, { clientOnly: true }),
       runtimeTypesAugmentPath: '/virtual/runtime-types/augment',
       consola: createConsolaMock(),
+    }, {
+      packageExists,
     })
 
     expect(setup.clientOnly).toBe(true)
@@ -116,10 +194,12 @@ describe('resolveAuthModuleSetup', () => {
     expect(setup.prepareTypes).toBeUndefined()
     expect(setup.serverTypes).toBeUndefined()
     expect(setup.schemaGeneration).toBeUndefined()
+    expect(packageExists).not.toHaveBeenCalled()
   })
 
   it('prefers a higher-priority external provider from the provider hook', async () => {
-    const nuxt = await loadCase('without-nuxthub')
+    const nuxt = await loadCase('core-auth')
+    const packageExists = vi.fn(() => false)
     let aliasesDuringProviderSelection: Record<string, string | undefined> | undefined
 
     nuxt.hook('better-auth:database:providers', (providers) => {
@@ -141,10 +221,13 @@ describe('resolveAuthModuleSetup', () => {
       options: createModuleOptions(nuxt),
       runtimeTypesAugmentPath: '/virtual/runtime-types/augment',
       consola: createConsolaMock(),
+    }, {
+      packageExists,
     })
 
     expect(setup.database.providerId).toBe('external')
     expect(setup.database.hasHubDb).toBe(false)
+    expect(packageExists).not.toHaveBeenCalled()
     expect(aliasesDuringProviderSelection).toEqual({
       server: setup.configs.server.path,
       client: setup.configs.client.path,

--- a/test/module-setup.test.ts
+++ b/test/module-setup.test.ts
@@ -205,6 +205,56 @@ describe('resolveAuthModuleSetup', () => {
     expect(setup.database.providerId).toBe('nuxthub')
   })
 
+  it.each([
+    ['sqlite', 'libsql', '@libsql/client'],
+    ['mysql', 'mysql2', 'mysql2'],
+    ['postgresql', 'pglite', '@electric-sql/pglite'],
+    ['postgresql', 'postgres-js', 'postgres'],
+  ])('checks the resolved %s driver when the configured driver is omitted', async (dialect, driver, driverPackage) => {
+    const nuxt = await loadCase('core-auth')
+    nuxt.options.alias['hub:db'] = '/virtual/hub-db'
+    Object.assign(nuxt.options.runtimeConfig, { hub: { db: { dialect, driver } } })
+    const input = {
+      nuxt,
+      options: createModuleOptions(nuxt),
+      runtimeTypesAugmentPath: '/virtual/runtime-types/augment',
+      consola: createConsolaMock(),
+    }
+
+    for (const db of [dialect, { dialect }]) {
+      Object.assign(nuxt.options, { hub: { db } })
+      await expect(resolveAuthModuleSetup(input, {
+        packageExists: packageName => packageName !== driverPackage,
+      })).rejects.toThrow(`Install it in your Nuxt app, for example with \`pnpm add ${driverPackage}\`.`)
+
+      const installedPackages = new Set(['drizzle-orm', driverPackage])
+      if (dialect === 'postgresql')
+        installedPackages.add('postgres')
+      const setup = await resolveAuthModuleSetup(input, {
+        packageExists: packageName => installedPackages.has(packageName),
+      })
+      expect(setup.database.providerId).toBe('nuxthub')
+    }
+  })
+
+  it('checks the resolved driver when NuxtHub overrides the configured driver', async () => {
+    const nuxt = await loadCase('core-auth')
+    nuxt.options.alias['hub:db'] = '/virtual/hub-db'
+    Object.assign(nuxt.options, { hub: { db: { dialect: 'sqlite', driver: 'libsql' } } })
+    Object.assign(nuxt.options.runtimeConfig, { hub: { db: { dialect: 'sqlite', driver: 'd1' } } })
+    const packageExists = vi.fn((packageName: string) => packageName === 'drizzle-orm')
+
+    const setup = await resolveAuthModuleSetup({
+      nuxt,
+      options: createModuleOptions(nuxt),
+      runtimeTypesAugmentPath: '/virtual/runtime-types/augment',
+      consola: createConsolaMock(),
+    }, { packageExists })
+
+    expect(setup.database.providerId).toBe('nuxthub')
+    expect(packageExists.mock.calls.map(([packageName]) => packageName)).toEqual(['drizzle-orm'])
+  })
+
   it.each(['d1', 'd1-http'])('does not require a client package for %s', async (driver) => {
     const nuxt = await loadCase('core-auth')
     nuxt.options.alias['hub:db'] = '/virtual/hub-db'


### PR DESCRIPTION
## Summary

- declare `drizzle-orm` and `postgres` as optional production peers
- resolve them from the consuming app and fail setup with dialect-specific install guidance
- require Drizzle for every selected NuxtHub database and Postgres only for PostgreSQL/Hyperdrive
- skip checks for client-only, non-NuxtHub, and external database providers
- update NuxtHub installation docs and add contract tests

## Why

Published runtime handlers and generated PostgreSQL code import these packages, but both were devDependencies only. Clean pnpm consumers could follow the documented NuxtHub setup and fail module resolution at build/runtime. Optional peers keep non-NuxtHub installs lean while making the real contract explicit.

## Verification

- focused module setup and schema regression tests
- `pnpm typecheck` and `pnpm typecheck:playground`
- module build
- targeted ESLint
- `publint` (only the existing repository URL suggestion)
- `git diff --check`