### PR TITLE
fix: normalize Nitro 3 auth route enforcement

### DIFF
--- a/src/runtime/internal/auth-route-rules.ts
+++ b/src/runtime/internal/auth-route-rules.ts
@@ -1,3 +1,6 @@
+import type { AuthRouteRules } from '../types'
+import { withoutBase } from 'ufo'
+
 const internalRouteRuleAuthPaths = new Set([
   '/_ipx',
   '/_nuxt',
@@ -19,6 +22,18 @@ const internalRouteRuleAuthPrefixes = [
   '/api/_nuxt_icon/',
   '/api/auth/',
 ]
+
+export function normalizeAuthRoutePath(path: string, baseURL = '/'): string {
+  const pathname = path.split(/[?#]/, 1)[0] || '/'
+  return withoutBase(pathname, baseURL) || '/'
+}
+
+export function normalizeAuthRouteRule(rule: unknown): AuthRouteRules['auth'] {
+  if (rule && typeof rule === 'object' && Object.hasOwn(rule, 'options'))
+    return (rule as { options?: AuthRouteRules['auth'] }).options
+
+  return rule as AuthRouteRules['auth']
+}
 
 export function shouldSkipAuthRouteRules(path: string): boolean {
   const pathname = path.split(/[?#]/, 1)[0] || '/'

--- a/src/runtime/server/internal/nitro3.ts
+++ b/src/runtime/server/internal/nitro3.ts
@@ -1,5 +1,6 @@
 import type { H3Event } from 'nitro/h3'
 import type { AuthRouteRules } from '../../types'
+import { normalizeAuthRouteRule } from '../../internal/auth-route-rules'
 import { getRouteRules } from 'nitro/app'
 import {
   defineEventHandler,
@@ -25,8 +26,8 @@ export {
 export type ServerEvent = H3Event
 
 export function getAuthRouteRules(event: ServerEvent): AuthRouteRules {
-  const auth = getRouteRules(event.req.method, getRequestURL(event).pathname).routeRules.auth?.options
-  return { auth: auth as AuthRouteRules['auth'] }
+  const auth = getRouteRules(event.req.method, getRequestURL(event).pathname).routeRules?.auth
+  return { auth: normalizeAuthRouteRule(auth) }
 }
 
 export function createAuthError(status: number, statusText: string): Error {

--- a/src/runtime/server/middleware/route-access.ts
+++ b/src/runtime/server/middleware/route-access.ts
@@ -1,13 +1,16 @@
 import type { AuthMeta, AuthMode, AuthRouteRules } from '../../types'
-import { shouldSkipAuthRouteRules } from '../../internal/auth-route-rules'
+import { normalizeAuthRoutePath, shouldSkipAuthRouteRules } from '../../internal/auth-route-rules'
 import { matchesUser } from '../../utils/match-user'
-import { createAuthError, defineEventHandler, getAuthRouteRules, getRequestURL } from '../internal/nitro-compat'
+import { createAuthError, defineEventHandler, getAuthRouteRules, getRequestURL, useRuntimeConfig } from '../internal/nitro-compat'
 import { getUserSession, requireUserSession } from '../utils/session'
 
 export default defineEventHandler(async (event) => {
-  const path = getRequestURL(event).pathname
+  const path = normalizeAuthRoutePath(
+    getRequestURL(event).pathname,
+    useRuntimeConfig().app?.baseURL,
+  )
 
-  if (!path.startsWith('/api/'))
+  if (path !== '/api' && !path.startsWith('/api/'))
     return
 
   if (shouldSkipAuthRouteRules(path))

--- a/test/auth-route-rules-internal.test.ts
+++ b/test/auth-route-rules-internal.test.ts
@@ -1,5 +1,29 @@
 import { describe, expect, it } from 'vitest'
-import { shouldSkipAuthRouteRules } from '../src/runtime/internal/auth-route-rules'
+import { normalizeAuthRoutePath, normalizeAuthRouteRule, shouldSkipAuthRouteRules } from '../src/runtime/internal/auth-route-rules'
+
+describe('auth route path normalization', () => {
+  it('removes the app base URL from API paths', () => {
+    expect(normalizeAuthRoutePath('/dashboard/api/private?preview=true', '/dashboard/')).toBe('/api/private')
+    expect(normalizeAuthRoutePath('/api/private', '/dashboard/')).toBe('/api/private')
+    expect(normalizeAuthRoutePath('/dashboard', '/dashboard/')).toBe('/')
+  })
+})
+
+describe('nitro auth route rule normalization', () => {
+  it('keeps current direct route rule values', () => {
+    const rule = { only: 'user' as const, user: { role: 'admin' } }
+
+    expect(normalizeAuthRouteRule('user')).toBe('user')
+    expect(normalizeAuthRouteRule(rule)).toBe(rule)
+  })
+
+  it('unwraps route rule values returned by older Nitro 3 builds', () => {
+    expect(normalizeAuthRouteRule({
+      route: '/api/private',
+      options: 'guest',
+    })).toBe('guest')
+  })
+})
 
 describe('internal auth route rule defaults', () => {
   it('skips framework and module internals', () => {

--- a/test/route-access-middleware.test.ts
+++ b/test/route-access-middleware.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const getRouteRules = vi.fn(() => ({}))
 const getUserSession = vi.fn()
 const requireUserSession = vi.fn()
+const useRuntimeConfig = vi.fn(() => ({ app: { baseURL: '/' } }))
 
 vi.mock('h3', async importOriginal => ({
   ...await importOriginal<typeof import('h3')>(),
@@ -13,7 +14,7 @@ vi.mock('h3', async importOriginal => ({
 
 vi.mock('nitropack/runtime', () => ({
   getRouteRules,
-  useRuntimeConfig: vi.fn(),
+  useRuntimeConfig,
 }))
 
 vi.mock('../src/runtime/server/utils/session', () => ({
@@ -32,7 +33,9 @@ describe('route-access middleware', () => {
     getRouteRules.mockReset()
     getUserSession.mockReset()
     requireUserSession.mockReset()
+    useRuntimeConfig.mockReset()
     getRouteRules.mockReturnValue({})
+    useRuntimeConfig.mockReturnValue({ app: { baseURL: '/' } })
   })
 
   it('ignores internal API routes before auth route rules are read', async () => {
@@ -59,5 +62,37 @@ describe('route-access middleware', () => {
     expect(getRouteRules).toHaveBeenCalledTimes(1)
     expect(getRouteRules).toHaveBeenCalledWith(event)
     expect(requireUserSession).toHaveBeenCalledTimes(1)
+  })
+
+  it('protects the exact API root', async () => {
+    getRouteRules.mockReturnValue({ auth: 'user' })
+    requireUserSession.mockResolvedValue({ user: { id: 'user-1' } })
+
+    const middleware = await loadMiddleware()
+    await middleware({ path: '/api' })
+
+    expect(requireUserSession).toHaveBeenCalledTimes(1)
+  })
+
+  it('protects API routes below the app base URL', async () => {
+    useRuntimeConfig.mockReturnValue({ app: { baseURL: '/dashboard/' } })
+    getRouteRules.mockReturnValue({ auth: 'user' })
+    requireUserSession.mockResolvedValue({ user: { id: 'user-1' } })
+
+    const middleware = await loadMiddleware()
+    await middleware({ path: '/dashboard/api/test/me' })
+
+    expect(requireUserSession).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores internal API routes below the app base URL', async () => {
+    useRuntimeConfig.mockReturnValue({ app: { baseURL: '/dashboard/' } })
+    getRouteRules.mockReturnValue({ auth: 'user' })
+
+    const middleware = await loadMiddleware()
+    await middleware({ path: '/dashboard/api/auth/get-session' })
+
+    expect(getRouteRules).not.toHaveBeenCalled()
+    expect(requireUserSession).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

- accept both current direct Nitro 3 auth rule values and older `{ options }` wrappers
- normalize request paths against `app.baseURL` before API matching
- protect the exact `/api` route as well as `/api/**`
- keep internal auth/module API exclusions working below a base URL
- add focused rule-shape and middleware tests

## Why

Current Nitro 3 exposes resolved route-rule values directly, while the compatibility layer only read `.options`; protected routes therefore resolved no auth rule. Nitro 3 also preserves non-root app base paths in global middleware, bypassing the raw `/api/` prefix check.

## Verification

- `pnpm vitest run test/auth-route-rules-internal.test.ts test/route-access-middleware.test.ts` (10 tests)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm prepack`
- `git diff --check`

This is complementary to #462, which makes the middleware discoverable. The changes are independently scoped and may merge in either order; full packed route-rule enforcement requires both.