### PR TITLE
fix: avoid unnecessary post-auth waits

### DIFF
--- a/src/runtime/app/composables/runWithSessionRefresh.ts
+++ b/src/runtime/app/composables/runWithSessionRefresh.ts
@@ -7,10 +7,11 @@ export async function runWithSessionRefresh<TResult>(runner: () => Promise<TResu
     throw new TypeError('runWithSessionRefresh(runner) requires an async function')
 
   const auth = useUserSession()
+  const wasLoggedIn = auth.loggedIn.value
   const result = await runner()
 
   if (!isAuthActionErrorResult(result))
-    await refreshSessionAfterAuthAction(auth.fetchSession, auth.loggedIn, auth.waitForSession)
+    await refreshSessionAfterAuthAction(auth.fetchSession, auth.loggedIn, auth.waitForSession, true, wasLoggedIn)
 
   return result
 }

--- a/src/runtime/app/composables/useUserSession.ts
+++ b/src/runtime/app/composables/useUserSession.ts
@@ -43,6 +43,12 @@ function createServerOnlyActionNamespace(path: string) {
 const _signInServerOnly = createServerOnlyActionNamespace('signIn')
 const _signUpServerOnly = createServerOnlyActionNamespace('signUp')
 
+function shouldWaitForSignUpSession(context: unknown): boolean {
+  if (!isRecord(context) || !isRecord(context.data))
+    return true
+  return context.data.token !== null
+}
+
 export function useUserSession(): UseUserSessionReturn {
   const runtimeFlags = getAuthRuntimeFlags()
   const runtimeConfig = useRuntimeConfig()
@@ -278,9 +284,10 @@ export function useAuthActionNamespaces() {
           isRedirectOAuthSignIn
             ? {
                 shouldSkipSessionSync: (data: unknown) => !isRecord(data) || data.disableRedirect !== true,
+                shouldWaitForSession: () => true,
                 transformData: (data: unknown) => withFallbackSocialCallbackURL(data, requestURL),
               }
-            : {},
+            : { shouldWaitForSession: () => true },
         )
       })
     : _signInServerOnly as SignIn
@@ -291,7 +298,11 @@ export function useAuthActionNamespaces() {
         const method = targetRecord[prop]
         if (typeof method !== 'function')
           return method
-        return wrapAuthMethod((...args: unknown[]) => (targetRecord[prop] as (...a: unknown[]) => Promise<unknown>)(...args), wrapDeps)
+        return wrapAuthMethod(
+          (...args: unknown[]) => (targetRecord[prop] as (...a: unknown[]) => Promise<unknown>)(...args),
+          wrapDeps,
+          { shouldWaitForSession: shouldWaitForSignUpSession },
+        )
       })
     : _signUpServerOnly as SignUp
 

--- a/src/runtime/app/internal/wrap-auth-method.ts
+++ b/src/runtime/app/internal/wrap-auth-method.ts
@@ -6,9 +6,11 @@ export async function refreshSessionAfterAuthAction(
   fetchSession: (options?: { force?: boolean }) => Promise<void>,
   loggedIn: ComputedRef<boolean>,
   waitForSession: () => Promise<void>,
+  shouldWaitForSession = true,
+  wasLoggedIn = loggedIn.value,
 ) {
   await fetchSession({ force: true })
-  if (!loggedIn.value)
+  if (shouldWaitForSession && !wasLoggedIn && !loggedIn.value)
     await waitForSession()
   await nextTick()
 }
@@ -18,9 +20,11 @@ export function wrapOnSuccess(
   loggedIn: ComputedRef<boolean>,
   waitForSession: () => Promise<void>,
   cb: (ctx: unknown) => void | Promise<void>,
+  shouldWaitForSession: (ctx: unknown) => boolean,
+  wasLoggedIn: boolean,
 ) {
   return async (ctx: unknown) => {
-    await refreshSessionAfterAuthAction(fetchSession, loggedIn, waitForSession)
+    await refreshSessionAfterAuthAction(fetchSession, loggedIn, waitForSession, shouldWaitForSession(ctx), wasLoggedIn)
     await cb(ctx)
   }
 }
@@ -35,10 +39,12 @@ export function wrapAuthMethod<T extends (...args: unknown[]) => Promise<unknown
   },
   wrapOptions: {
     shouldSkipSessionSync?: (data: unknown, options: unknown) => boolean
+    shouldWaitForSession?: (ctx: unknown) => boolean
     transformData?: (data: unknown, options: unknown) => unknown
   } = {},
 ): T {
   return (async (...args: unknown[]) => {
+    const wasLoggedIn = deps.loggedIn.value
     const originalData = args[0]
     const options = args[1]
     const data = wrapOptions.transformData?.(originalData, options) ?? originalData
@@ -52,13 +58,14 @@ export function wrapAuthMethod<T extends (...args: unknown[]) => Promise<unknown
     const fetchOptions = isRecord(dataRecord?.fetchOptions) ? dataRecord.fetchOptions : undefined
     const nestedOnSuccess = fetchOptions?.onSuccess
     const topLevelOnSuccess = optionsRecord?.onSuccess
+    const shouldWaitForSession = wrapOptions.shouldWaitForSession ?? (() => false)
 
     const fallbackOnSuccess = deps.resolvePostAuthSuccessRedirect()
     const wrappedFallbackOnSuccess = fallbackOnSuccess && wrapOnSuccess(deps.fetchSession, deps.loggedIn, deps.waitForSession, async () => {
       if (!deps.loggedIn.value)
         return
       await fallbackOnSuccess()
-    })
+    }, shouldWaitForSession, wasLoggedIn)
 
     // Passkey pattern: onSuccess in data.fetchOptions
     if (typeof nestedOnSuccess === 'function') {
@@ -66,7 +73,7 @@ export function wrapAuthMethod<T extends (...args: unknown[]) => Promise<unknown
         ...dataRecord,
         fetchOptions: {
           ...fetchOptions,
-          onSuccess: wrapOnSuccess(deps.fetchSession, deps.loggedIn, deps.waitForSession, nestedOnSuccess as OnSuccess),
+          onSuccess: wrapOnSuccess(deps.fetchSession, deps.loggedIn, deps.waitForSession, nestedOnSuccess as OnSuccess, shouldWaitForSession, wasLoggedIn),
         },
       }
       return method(nextData as unknown as Parameters<T>[0], options as unknown as Parameters<T>[1])
@@ -75,7 +82,7 @@ export function wrapAuthMethod<T extends (...args: unknown[]) => Promise<unknown
     if (typeof topLevelOnSuccess === 'function') {
       const nextOptions = {
         ...optionsRecord,
-        onSuccess: wrapOnSuccess(deps.fetchSession, deps.loggedIn, deps.waitForSession, topLevelOnSuccess as OnSuccess),
+        onSuccess: wrapOnSuccess(deps.fetchSession, deps.loggedIn, deps.waitForSession, topLevelOnSuccess as OnSuccess, shouldWaitForSession, wasLoggedIn),
       }
       return method(data as unknown as Parameters<T>[0], nextOptions as unknown as Parameters<T>[1])
     }

--- a/test/run-with-session-refresh.test.ts
+++ b/test/run-with-session-refresh.test.ts
@@ -56,6 +56,19 @@ describe('runWithSessionRefresh', () => {
     expect(mocks.nextTick).toHaveBeenCalledOnce()
   })
 
+  it('does not wait when a custom action destroys the existing session', async () => {
+    const runWithSessionRefresh = await loadRunWithSessionRefresh()
+
+    await runWithSessionRefresh(async () => {
+      mocks.loggedIn.value = false
+      return { ok: true }
+    })
+
+    expect(mocks.fetchSession).toHaveBeenCalledWith({ force: true })
+    expect(mocks.waitForSession).not.toHaveBeenCalled()
+    expect(mocks.nextTick).toHaveBeenCalledOnce()
+  })
+
   it('does not refresh after rejected actions', async () => {
     const runWithSessionRefresh = await loadRunWithSessionRefresh()
     const error = new Error('boom')

--- a/test/use-user-session.test.ts
+++ b/test/use-user-session.test.ts
@@ -778,7 +778,7 @@ describe('useUserSession hydration bootstrap', () => {
     runtimeConfig.public.auth.redirects = { authenticated: '/app' }
     mockClient.getSession.mockResolvedValueOnce({ data: null })
     mockClient.signUp.email.mockImplementation(async (_data, opts) => {
-      await opts?.onSuccess?.('ctx')
+      await opts?.onSuccess?.({ data: { token: null, user: { id: 'user-1' } } })
     })
 
     const { useAuthActionNamespaces } = await loadAuthComposables()
@@ -787,7 +787,91 @@ describe('useUserSession hydration bootstrap', () => {
     await auth.signUp.email({ email: 'user@example.com', password: 'password', name: 'User' })
 
     expect(navigateTo).not.toHaveBeenCalled()
-  }, 10000)
+  })
+
+  it('does not wait five seconds when email-verification sign-up creates no session', async () => {
+    vi.useFakeTimers()
+    let settledBeforeTimeout = false
+    let timerCountBeforeCleanup = 0
+    const onSuccess = vi.fn()
+
+    try {
+      mockClient.getSession.mockResolvedValueOnce({ data: null })
+      mockClient.signUp.email.mockImplementation(async (_data, opts) => {
+        await opts?.onSuccess?.({ data: { token: null, user: { id: 'user-1' } } })
+      })
+
+      const { useAuthActionNamespaces } = await loadAuthComposables()
+      const auth = useAuthActionNamespaces()
+      let settled = false
+      const pending = auth.signUp.email(
+        { email: 'user@example.com', password: 'password', name: 'User' },
+        { onSuccess },
+      ).then(() => {
+        settled = true
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+      settledBeforeTimeout = settled
+      timerCountBeforeCleanup = vi.getTimerCount()
+      await vi.runAllTimersAsync()
+      await pending
+    }
+    finally {
+      vi.useRealTimers()
+    }
+
+    expect(settledBeforeTimeout).toBe(true)
+    expect(timerCountBeforeCleanup).toBe(0)
+    expect(onSuccess).toHaveBeenCalledOnce()
+  })
+
+  it('still waits for a session-creating sign-up before running onSuccess', async () => {
+    vi.useFakeTimers()
+    let callbackBeforeSession = false
+    let settledAfterSession = false
+
+    try {
+      mockClient.getSession.mockResolvedValueOnce({ data: null })
+      mockClient.signUp.email.mockImplementation(async (_data, opts) => {
+        await opts?.onSuccess?.({ data: { token: 'session-token', user: { id: 'user-1' } } })
+      })
+      const onSuccess = vi.fn()
+
+      const { useAuthActionNamespaces } = await loadAuthComposables()
+      const auth = useAuthActionNamespaces()
+      let settled = false
+      const pending = auth.signUp.email(
+        { email: 'user@example.com', password: 'password', name: 'User' },
+        { onSuccess },
+      ).then(() => {
+        settled = true
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+      callbackBeforeSession = onSuccess.mock.calls.length > 0
+      sessionAtom.value = {
+        data: {
+          session: { id: 'session-1' },
+          user: { id: 'user-1' },
+        },
+        isPending: false,
+        isRefetching: false,
+        error: null,
+      }
+      await flushPromises()
+      await vi.advanceTimersByTimeAsync(0)
+      settledAfterSession = settled
+      await vi.runAllTimersAsync()
+      await pending
+    }
+    finally {
+      vi.useRealTimers()
+    }
+
+    expect(callbackBeforeSession).toBe(false)
+    expect(settledAfterSession).toBe(true)
+  })
 
   it('signUp uses auth.redirects.authenticated when no callback is provided', async () => {
     runtimeConfig.public.auth.redirects = { authenticated: '/app' }

--- a/test/wrap-auth-method.test.ts
+++ b/test/wrap-auth-method.test.ts
@@ -1,4 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
+import { computed, ref } from 'vue'
+import { wrapAuthMethod } from '../src/runtime/app/internal/wrap-auth-method'
+
+vi.mock('#imports', async () => {
+  const { nextTick } = await import('vue')
+  return { nextTick }
+})
 
 /**
  * Better Auth callback patterns:
@@ -53,6 +60,51 @@ function createWrapper(
 }
 
 describe('wrapAuthMethod', () => {
+  it('does not wait after a successful action destroys an existing session', async () => {
+    vi.useFakeTimers()
+    let settledBeforeTimeout = false
+    let timerCountBeforeCleanup = 0
+    const loggedIn = ref(true)
+    const waitForSession = vi.fn(() => new Promise<void>((resolve) => {
+      setTimeout(resolve, 5000)
+    }))
+    const onSuccess = vi.fn()
+
+    try {
+      const wrapped = wrapAuthMethod(
+        vi.fn(async (_data, options) => {
+          loggedIn.value = false
+          await options?.onSuccess?.({ data: { success: true } })
+        }),
+        {
+          fetchSession: vi.fn(async () => {}),
+          loggedIn: computed(() => loggedIn.value),
+          waitForSession,
+          resolvePostAuthSuccessRedirect: () => undefined,
+        },
+        { shouldWaitForSession: () => true },
+      )
+
+      let settled = false
+      const pending = wrapped({}, { onSuccess }).then(() => {
+        settled = true
+      })
+      await vi.advanceTimersByTimeAsync(0)
+      settledBeforeTimeout = settled
+      timerCountBeforeCleanup = vi.getTimerCount()
+      await vi.runAllTimersAsync()
+      await pending
+    }
+    finally {
+      vi.useRealTimers()
+    }
+
+    expect(settledBeforeTimeout).toBe(true)
+    expect(timerCountBeforeCleanup).toBe(0)
+    expect(waitForSession).not.toHaveBeenCalled()
+    expect(onSuccess).toHaveBeenCalledOnce()
+  })
+
   it('standard: signIn.email(data, { onSuccess })', async () => {
     const wait = vi.fn()
     const onSuccess = vi.fn()


### PR DESCRIPTION
## Summary

- wait for a newly created session only when the action can establish one
- skip the five-second wait when an existing session is destroyed
- recognize Better Auth email-verification sign-ups that return `token: null`
- retain session synchronization for sign-in and session-creating sign-up

## Verification

- `pnpm vitest run test/run-with-session-refresh.test.ts test/use-user-session.test.ts test/wrap-auth-method.test.ts --project unit` (80 tests)
- full unit suite during branch preparation (283 passed, 18 skipped)