### PR TITLE
ci: move Pullfrog reviews to GitHub-hosted runners

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -15,7 +15,7 @@ permissions: {}
 
 jobs:
   pullfrog:
-    runs-on: pullfrog-better-auth
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
@@ -31,6 +31,16 @@ jobs:
           node-version: 24
       - name: Setup Corepack
         run: npm install --global corepack@0.36.0
+      - name: Configure proxy access
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CLIPROXY_CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CLIPROXY_CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          test -n "$CF_ACCESS_CLIENT_ID" || { echo 'Missing CLIPROXY_CF_ACCESS_CLIENT_ID'; exit 1; }
+          test -n "$CF_ACCESS_CLIENT_SECRET" || { echo 'Missing CLIPROXY_CF_ACCESS_CLIENT_SECRET'; exit 1; }
+          cat > "$RUNNER_TEMP/pullfrog-opencode.json" <<'JSON'
+          {"provider":{"openai-compatible":{"options":{"headers":{"CF-Access-Client-Id":"{env:CF_ACCESS_CLIENT_ID}","CF-Access-Client-Secret":"{env:CF_ACCESS_CLIENT_SECRET}"}}}}}
+          JSON
       - name: Run agent
         uses: pullfrog/pullfrog@v0
         with:
@@ -38,8 +48,11 @@ jobs:
           model: openai-compatible/byok
           effort: high
         env:
-          OPENAI_COMPATIBLE_BASE_URL: http://cliproxy.internal:8317/v1
+          OPENAI_COMPATIBLE_BASE_URL: https://ai.onmax.me/v1
           OPENAI_COMPATIBLE_API_KEY: ${{ secrets.OPENAI_COMPATIBLE_API_KEY }}
           OPENAI_COMPATIBLE_MODEL: gpt-5.6-luna(high)
           OPENAI_COMPATIBLE_CONTEXT: '1050000'
           OPENAI_COMPATIBLE_MAX_OUTPUT: '128000'
+          OPENCODE_CONFIG: ${{ runner.temp }}/pullfrog-opencode.json
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CLIPROXY_CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CLIPROXY_CF_ACCESS_CLIENT_SECRET }}


### PR DESCRIPTION
Pullfrog reviews share server-local runners, leaving new reviews queued behind earlier jobs. Run them on GitHub-hosted `ubuntu-latest` runners and connect to the existing public CLIProxy endpoint through Cloudflare Access. Preserve the Luna model, high reasoning, checkout credential isolation, and review inputs.

The workflow creates the OpenCode proxy-header configuration and fails early when either Cloudflare Access secret is missing. Both secrets are now configured with a dedicated token permitted by the existing API access policy.

Validation: required `ci` and `pkg` checks passed; actionlint, YAML parsing, generated JSON, missing-credential failure, and diff checks passed. A GitHub-hosted execution completed the model-and-shell smoke test successfully: https://github.com/nuxt-modules/better-auth/actions/runs/34228821007.

Existing jobs queued against the old workflow need to drain or be replaced before both local runner services are retired.
