### PR TITLE
fix: make published server tsconfig self-contained

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,8 @@
   "dependencies": {
     "@nuxt/devtools-kit": "^3.4.1",
     "@nuxt/kit": "^4.5.2",
+    "@types/node": "^24.13.3",
+    "auth": "1.7.3",
     "consola": "^3.4.2",
     "cookie-es": "^3.1.1",
     "defu": "^6.1.7",
@@ -117,7 +119,6 @@
     "@nuxthub/core": "^0.10.8",
     "@pinia/nuxt": "^1.0.2",
     "@types/better-sqlite3": "^9.6.0",
-    "@types/node": "^24.13.3",
     "@vue/test-utils": "^2.4.6",
     "better-auth": "1.7.3",
     "better-call": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
   "dependencies": {
     "@nuxt/devtools-kit": "^3.4.1",
     "@nuxt/kit": "^4.5.2",
-    "auth": "1.7.3",
     "consola": "^3.4.2",
     "cookie-es": "^3.1.1",
     "defu": "^6.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       '@nuxt/kit':
         specifier: ^4.5.2
         version: 4.5.2(magic-string@1.2.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: ^24.13.3
+        version: 24.13.3
+      auth:
+        specifier: 1.7.3
+        version: 1.7.3(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(better-sqlite3@12.11.1)(chokidar@5.0.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@9.6.0)(better-sqlite3@12.11.1)(kysely@0.28.17)(postgres@3.4.9))(giget@3.3.1)(jose@6.2.8)(kysely@0.28.17)(magicast@0.5.4)(nanostores@1.4.2)(supports-color@10.2.2)(vitest@4.1.11(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(happy-dom@20.14.0)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))(vue@3.5.41(typescript@5.9.3))
       consola:
         specifier: ^3.4.2
         version: 3.4.2
@@ -84,9 +90,6 @@ importers:
       '@types/better-sqlite3':
         specifier: ^9.6.0
         version: 9.6.0
-      '@types/node':
-        specifier: ^24.13.3
-        version: 24.13.3
       '@vue/test-utils':
         specifier: ^2.4.6
         version: 2.5.0(@vue/compiler-dom@3.5.41)(@vue/server-renderer@3.5.41)(vue@3.5.41(typescript@5.9.3))
@@ -16596,6 +16599,61 @@ snapshots:
   async-sema@3.1.1: {}
 
   async@3.2.6: {}
+
+  auth@1.7.3(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(better-sqlite3@12.11.1)(chokidar@5.0.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@9.6.0)(better-sqlite3@12.11.1)(kysely@0.28.17)(postgres@3.4.9))(giget@3.3.1)(jose@6.2.8)(kysely@0.28.17)(magicast@0.5.4)(nanostores@1.4.2)(supports-color@10.2.2)(vitest@4.1.11(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(happy-dom@20.14.0)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))(vue@3.5.41(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/preset-react': 7.28.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@better-auth/core': 1.7.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2)
+      '@better-auth/telemetry': 1.7.3(@better-auth/core@1.7.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/utils': 0.4.2
+      '@clack/prompts': 1.7.0
+      '@mrleebo/prisma-ast': 0.16.0
+      better-auth: 1.7.3(@opentelemetry/api@1.9.0)(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@9.6.0)(better-sqlite3@12.11.1)(kysely@0.28.17)(postgres@3.4.9))(vitest@4.1.11(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(happy-dom@20.14.0)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))(vue@3.5.41(typescript@5.9.3))
+      c12: 4.0.0-beta.5(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magicast@0.5.4)
+      chalk: 5.6.2
+      commander: 15.0.0
+      dotenv: 17.4.2
+      get-tsconfig: 4.14.0
+      jiti: 2.7.0
+      open: 11.0.0
+      prettier: 3.8.1
+      prompts: 2.4.2
+      semver: 7.8.5
+      yocto-spinner: 1.2.2
+      zod: 4.5.4
+    transitivePeerDependencies:
+      - '@better-fetch/fetch'
+      - '@cloudflare/workers-types'
+      - '@lynx-js/react'
+      - '@opentelemetry/api'
+      - '@prisma/client'
+      - '@sveltejs/kit'
+      - '@tanstack/react-start'
+      - '@tanstack/solid-start'
+      - better-call
+      - better-sqlite3
+      - chokidar
+      - drizzle-kit
+      - drizzle-orm
+      - giget
+      - jose
+      - kysely
+      - magicast
+      - mongodb
+      - mysql2
+      - nanostores
+      - next
+      - pg
+      - prisma
+      - react
+      - react-dom
+      - solid-js
+      - supports-color
+      - svelte
+      - vitest
+      - vue
 
   auth@1.7.3(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.5.4))(better-sqlite3@12.11.1)(chokidar@5.0.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@9.6.0)(better-sqlite3@12.11.1)(kysely@0.28.17)(postgres@3.4.9))(giget@3.3.1)(jose@6.2.8)(kysely@0.28.17)(magicast@0.5.4)(nanostores@1.4.2)(supports-color@10.2.2)(vitest@4.1.11(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(happy-dom@20.14.0)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))(vue@3.5.41(typescript@5.9.3)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@nuxt/kit':
         specifier: ^4.5.2
         version: 4.5.2(magic-string@1.2.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))
-      auth:
-        specifier: 1.7.3
-        version: 1.7.3(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(better-sqlite3@12.11.1)(chokidar@5.0.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@9.6.0)(better-sqlite3@12.11.1)(kysely@0.28.17)(postgres@3.4.9))(giget@3.3.1)(jose@6.2.8)(kysely@0.28.17)(magicast@0.5.4)(nanostores@1.4.2)(supports-color@10.2.2)(vitest@4.1.11(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(happy-dom@20.14.0)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))(vue@3.5.41(typescript@5.9.3))
       consola:
         specifier: ^3.4.2
         version: 3.4.2
@@ -16599,61 +16596,6 @@ snapshots:
   async-sema@3.1.1: {}
 
   async@3.2.6: {}
-
-  auth@1.7.3(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(better-sqlite3@12.11.1)(chokidar@5.0.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@9.6.0)(better-sqlite3@12.11.1)(kysely@0.28.17)(postgres@3.4.9))(giget@3.3.1)(jose@6.2.8)(kysely@0.28.17)(magicast@0.5.4)(nanostores@1.4.2)(supports-color@10.2.2)(vitest@4.1.11(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(happy-dom@20.14.0)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))(vue@3.5.41(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/preset-react': 7.28.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@better-auth/core': 1.7.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2)
-      '@better-auth/telemetry': 1.7.3(@better-auth/core@1.7.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
-      '@better-auth/utils': 0.4.2
-      '@clack/prompts': 1.7.0
-      '@mrleebo/prisma-ast': 0.16.0
-      better-auth: 1.7.3(@opentelemetry/api@1.9.0)(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@9.6.0)(better-sqlite3@12.11.1)(kysely@0.28.17)(postgres@3.4.9))(vitest@4.1.11(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(happy-dom@20.14.0)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))(vue@3.5.41(typescript@5.9.3))
-      c12: 4.0.0-beta.5(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magicast@0.5.4)
-      chalk: 5.6.2
-      commander: 15.0.0
-      dotenv: 17.4.2
-      get-tsconfig: 4.14.0
-      jiti: 2.7.0
-      open: 11.0.0
-      prettier: 3.8.1
-      prompts: 2.4.2
-      semver: 7.8.5
-      yocto-spinner: 1.2.2
-      zod: 4.5.4
-    transitivePeerDependencies:
-      - '@better-fetch/fetch'
-      - '@cloudflare/workers-types'
-      - '@lynx-js/react'
-      - '@opentelemetry/api'
-      - '@prisma/client'
-      - '@sveltejs/kit'
-      - '@tanstack/react-start'
-      - '@tanstack/solid-start'
-      - better-call
-      - better-sqlite3
-      - chokidar
-      - drizzle-kit
-      - drizzle-orm
-      - giget
-      - jose
-      - kysely
-      - magicast
-      - mongodb
-      - mysql2
-      - nanostores
-      - next
-      - pg
-      - prisma
-      - react
-      - react-dom
-      - solid-js
-      - supports-color
-      - svelte
-      - vitest
-      - vue
 
   auth@1.7.3(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.5.4))(better-sqlite3@12.11.1)(chokidar@5.0.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@9.6.0)(better-sqlite3@12.11.1)(kysely@0.28.17)(postgres@3.4.9))(giget@3.3.1)(jose@6.2.8)(kysely@0.28.17)(magicast@0.5.4)(nanostores@1.4.2)(supports-color@10.2.2)(vitest@4.1.11(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(happy-dom@20.14.0)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))(vue@3.5.41(typescript@5.9.3)):
     dependencies:

--- a/src/runtime/server/tsconfig.json
+++ b/src/runtime/server/tsconfig.json
@@ -1,7 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "#better-auth/nitro-compat": ["./internal/nitro2"],
       "#nuxt-better-auth": ["../types/augment"]

--- a/src/runtime/server/tsconfig.json
+++ b/src/runtime/server/tsconfig.json
@@ -3,16 +3,16 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "paths": {
+      "#better-auth/nitro-compat": ["./internal/nitro2"],
+      "#nuxt-better-auth": ["../types/augment"]
+    },
     "types": ["node"],
     "strict": true,
     "esModuleInterop": true,
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
-    "skipLibCheck": true,
-    "paths": {
-      "#better-auth/nitro-compat": ["./internal/nitro2"],
-      "#nuxt-better-auth": ["../types/augment"]
-    }
+    "skipLibCheck": true
   },
   "include": ["./**/*.ts", "./**/*.d.ts"],
   "exclude": ["node_modules"]

--- a/src/runtime/server/tsconfig.json
+++ b/src/runtime/server/tsconfig.json
@@ -1,5 +1,14 @@
 {
   "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
     "paths": {
       "#better-auth/nitro-compat": ["./internal/nitro2"],
       "#nuxt-better-auth": ["../types/augment"]

--- a/src/schema-generator.ts
+++ b/src/schema-generator.ts
@@ -1,5 +1,5 @@
 import type { BetterAuthOptions } from 'better-auth'
-import type { generateDrizzleSchema as GenerateDrizzleSchema } from 'better-auth/api'
+import type { generateDrizzleSchema as GenerateDrizzleSchema } from 'auth/api'
 import { existsSync } from 'node:fs'
 import { consola } from 'consola'
 import { Diagnostic, formatDiagnostic } from 'nostics'
@@ -24,7 +24,7 @@ function dialectToProvider(dialect: Dialect): Provider {
 }
 
 export async function generateDrizzleSchema(authOptions: BetterAuthOptions, dialect: Dialect, schemaOptions?: SchemaOptions): Promise<string> {
-  const { generateDrizzleSchema } = await import('better-auth/api')
+  const { generateDrizzleSchema } = await import('auth/api')
   const provider = dialectToProvider(dialect)
 
   const options: BetterAuthOptions = {

--- a/src/schema-generator.ts
+++ b/src/schema-generator.ts
@@ -1,5 +1,5 @@
 import type { BetterAuthOptions } from 'better-auth'
-import type { generateDrizzleSchema as GenerateDrizzleSchema } from 'auth/api'
+import type { generateDrizzleSchema as GenerateDrizzleSchema } from 'better-auth/api'
 import { existsSync } from 'node:fs'
 import { consola } from 'consola'
 import { Diagnostic, formatDiagnostic } from 'nostics'
@@ -24,7 +24,7 @@ function dialectToProvider(dialect: Dialect): Provider {
 }
 
 export async function generateDrizzleSchema(authOptions: BetterAuthOptions, dialect: Dialect, schemaOptions?: SchemaOptions): Promise<string> {
-  const { generateDrizzleSchema } = await import('auth/api')
+  const { generateDrizzleSchema } = await import('better-auth/api')
   const provider = dialectToProvider(dialect)
 
   const options: BetterAuthOptions = {

--- a/test/runtime-server-tsconfig.test.ts
+++ b/test/runtime-server-tsconfig.test.ts
@@ -6,6 +6,10 @@ describe('published runtime server tsconfig', () => {
   it('does not reference files omitted from the npm package or deprecated options', async () => {
     const config = JSON.parse(await readFile(resolve('src/runtime/server/tsconfig.json'), 'utf8'))
 
+    const manifest = JSON.parse(await readFile(resolve('package.json'), 'utf8'))
+    for (const type of config.compilerOptions.types)
+      expect(manifest.dependencies).toHaveProperty(`@types/${type}`)
+
     expect(config).not.toHaveProperty('extends')
     expect(config.compilerOptions).not.toHaveProperty('baseUrl')
     expect(config.compilerOptions).toMatchObject({

--- a/test/runtime-server-tsconfig.test.ts
+++ b/test/runtime-server-tsconfig.test.ts
@@ -8,5 +8,14 @@ describe('published runtime server tsconfig', () => {
 
     expect(config).not.toHaveProperty('extends')
     expect(config.compilerOptions).not.toHaveProperty('baseUrl')
+    expect(config.compilerOptions).toMatchObject({
+      target: 'ESNext',
+      module: 'ESNext',
+      moduleResolution: 'bundler',
+      types: ['node'],
+      strict: true,
+      esModuleInterop: true,
+      skipLibCheck: true,
+    })
   })
 })

--- a/test/runtime-server-tsconfig.test.ts
+++ b/test/runtime-server-tsconfig.test.ts
@@ -1,0 +1,12 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'pathe'
+import { describe, expect, it } from 'vitest'
+
+describe('published runtime server tsconfig', () => {
+  it('does not reference files omitted from the npm package or deprecated options', async () => {
+    const config = JSON.parse(await readFile(resolve('src/runtime/server/tsconfig.json'), 'utf8'))
+
+    expect(config).not.toHaveProperty('extends')
+    expect(config.compilerOptions).not.toHaveProperty('baseUrl')
+  })
+})


### PR DESCRIPTION
## Problem
`@nuxtjs/better-auth@0.3.1` publishes `dist/runtime/server/tsconfig.json`, which extends `../../../tsconfig.json`. The npm package only contains `dist/**`, so TypeScript resolves that path to a missing package-root `tsconfig.json` and VS Code reports TS5083. The same file sets deprecated `baseUrl`.

## Fix
Remove the unavailable `extends` reference and deprecated `baseUrl` from the runtime server config. The relative `paths` mappings and include/exclude entries remain unchanged.

Add a regression test that prevents either setting from returning.

## Validation
- `pnpm vitest run test/runtime-server-tsconfig.test.ts`
- `pnpm typecheck:runtime-server`
- `pnpm prepack`
- inspected generated `dist/runtime/server/tsconfig.json` after packing; it is self-contained and contains no `extends` or `baseUrl`.

Issue: #499
